### PR TITLE
docs: add link to weasyprint-service in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ ch.sbb.polarion.extension.pdf-exporter.weasyprint.pdf.variant=pdf/a-2b
 
 #### WeasyPrint as Service in Docker
 
-This extension supports using WeasyPrint running as a REST Service in Docker container. This feature can be switched on with help of following properties in file `<POLARION_HOME>/etc/polarion.properties`:
+This extension supports the use of WeasyPrint as a REST service within a Docker container, as implemented [here](https://github.com/SchweizerischeBundesbahnen/weasyprint-service). To activate this feature, adjust the following properties in the `<POLARION_HOME>/etc/polarion.properties` file:
+
 
 ```properties
 ch.sbb.polarion.extension.pdf-exporter.weasyprint.connector=service


### PR DESCRIPTION
### Proposed changes

A link to weasyprint-service is missing in the documentation. This fixes it.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
