### PR TITLE
fix: missing styles for some reports components

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf/exporter/converter/PdfConverter.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf/exporter/converter/PdfConverter.java
@@ -168,7 +168,7 @@ public class PdfConverter {
         String content = placeholderProcessor.replacePlaceholders(documentData, exportParams, css);
         String processed = velocityEvaluator.evaluateVelocityExpressions(documentData, content);
 
-        return (exportParams.getDocumentType() == DocumentType.WIKI) ? appendWikiCss(processed) : processed;
+        return (exportParams.getDocumentType() != DocumentType.DOCUMENT) ? appendWikiCss(processed) : processed;
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Refs: #35

### Proposed changes

When exporting some reports/rich pages with standard components (e.g. plan progress) to PDF, these components are missing/displayed incorrectly

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
