### PR TITLE
fix: misaligned TOC numbers fix

### DIFF
--- a/src/main/resources/default/dle-pdf-export.css
+++ b/src/main/resources/default/dle-pdf-export.css
@@ -105,9 +105,14 @@ ul.toc ul {
 
 ul.toc li {
     border-bottom: 1px dotted black;
+    display: table;
+    width: 100%;
+    position: relative;
 }
 
 ul.toc li > a {
+    display: table-cell;
+    padding-right: 5em;
     text-decoration: none;
     color: inherit;
 }
@@ -121,12 +126,11 @@ ul.toc li a .number {
     margin-right: .4em;
 }
 
-ul.toc li a .text {
-    margin-right: 10em;
-}
-
 ul.toc li > a.page-number {
-    float: right;
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    padding-right: 0;
 }
 
 ul.toc li > a.page-number::after {


### PR DESCRIPTION
### Proposed changes

TOC numbers are misaligned in some cases. We have to change CSS to behave independently of headings width.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
