### PR TITLE
fix: fix CSS

### DIFF
--- a/src/main/resources/default/dle-pdf-export.css
+++ b/src/main/resources/default/dle-pdf-export.css
@@ -347,10 +347,10 @@ ul.toc li > a.page-number::after {
     table {
         border-collapse: collapse;
         max-width: 100% !important;
-        float: none !importatnt; /* Fixes content inside of table breaking bug */
+        float: none !important; /* Fixes content inside of table breaking bug */
     }
 
-    tr { /* Fixes breaking of work item custom field tables */
+    table.polarion-dle-workitem-fields-end-table tr { /* Fixes breaking of work item custom field tables */
         page-break-inside: avoid;
         break-inside: avoid;
     }


### PR DESCRIPTION
Refs: #145

### Description

Fix to previous modification of CSS which added `page-break-inside: avoid` to all table rows. Fix was to narrow that declaration just to tables which contain work items definitions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
