### PR TITLE
fix: Possibility for global admin to hide webhook functionality at all via polarion.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ com.siemens.polarion.rest.enabled=true
 com.siemens.polarion.rest.cors.allowedOrigins=http://localhost:8888,https://anotherdomain.com
 ```
 
+### Enabling Webhooks
+
+By default, webhooks functionality is not enabled in PDF Exporter. If you want to make it available the following line should be added in `polarion.properties`:
+```properties
+ch.sbb.polarion.extension.pdf-exporter.webhooks.enabled=true
+```
+
 ### Debug option
 
 This extension makes intensive HTML processing to extend similar standard Polarion functionality. There is a possibility to log

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1149,6 +1149,27 @@
           "Extension Information"
         ]
       }
+    },
+    "/api/webhooks/status": {
+      "get": {
+        "operationId": "getWebhooksStatus",
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhooksStatus"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "summary": "Returns boolean value telling if webhooks are enabled or not",
+        "tags": [
+          "Utility resources"
+        ]
+      }
     }
   },
   "components": {
@@ -1673,6 +1694,14 @@
           },
           "supportEmail": {
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "WebhooksStatus": {
+        "properties": {
+          "enabled": {
+            "type": "boolean"
           }
         },
         "type": "object"

--- a/src/main/java/ch/sbb/polarion/extension/pdf/exporter/PdfExporterFormExtension.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf/exporter/PdfExporterFormExtension.java
@@ -5,6 +5,7 @@ import ch.sbb.polarion.extension.generic.settings.NamedSettingsRegistry;
 import ch.sbb.polarion.extension.generic.settings.SettingId;
 import ch.sbb.polarion.extension.generic.settings.SettingName;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
+import ch.sbb.polarion.extension.pdf.exporter.properties.PdfExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.pdf.exporter.rest.model.conversion.DocumentType;
 import ch.sbb.polarion.extension.pdf.exporter.rest.model.settings.localization.Language;
 import ch.sbb.polarion.extension.pdf.exporter.rest.model.settings.stylepackage.StylePackageModel;
@@ -154,8 +155,9 @@ public class PdfExporterFormExtension implements IFormExtension {
         Collection<SettingName> webhooksNames = getSettingNames(WebhooksSettings.FEATURE_NAME, scope);
         boolean noHooks = StringUtils.isEmpty(stylePackage.getWebhooks());
         String webhooksOptions = generateSelectOptions(webhooksNames, noHooks ? NamedSettings.DEFAULT_NAME : stylePackage.getWebhooks());
+        form = form.replace("{WEBHOOKS_DISPLAY}", PdfExporterExtensionConfiguration.getInstance().areWebhooksEnabled() ? "" : "hidden");
         form = form.replace("{WEBHOOKS_OPTIONS}", webhooksOptions);
-        form = form.replace("{WEBHOOKS_DISPLAY}", noHooks ? "none" : "inline-block");
+        form = form.replace("{WEBHOOKS_SELECTOR_DISPLAY}", noHooks ? "none" : "inline-block");
         return form.replace("{WEBHOOKS_SELECTED}", noHooks ? "" : "checked");
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf/exporter/converter/PdfConverter.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf/exporter/converter/PdfConverter.java
@@ -147,7 +147,8 @@ public class PdfConverter {
     }
 
     private @NotNull String applyWebhooks(@NotNull ExportParams exportParams, @NotNull String htmlContent) {
-        if (exportParams.getWebhooks() == null) {
+        // Skip webhooks processing among other if this functionality is not enabled by system administrator
+        if (!PdfExporterExtensionConfiguration.getInstance().areWebhooksEnabled() || exportParams.getWebhooks() == null) {
             return htmlContent;
         }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf/exporter/model/WebhooksStatus.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf/exporter/model/WebhooksStatus.java
@@ -1,0 +1,14 @@
+package ch.sbb.polarion.extension.pdf.exporter.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WebhooksStatus {
+    private Boolean enabled;
+}

--- a/src/main/java/ch/sbb/polarion/extension/pdf/exporter/properties/PdfExporterExtensionConfiguration.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf/exporter/properties/PdfExporterExtensionConfiguration.java
@@ -13,6 +13,7 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
     public static final String WEASYPRINT_SERVICE_DEFAULT = "http://localhost:9080";
     public static final String WEASYPRINT_PDF_VARIANT = "weasyprint.pdf.variant";
     public static final String INTERNALIZE_EXTERNAL_CSS = "internalizeExternalCss";
+    public static final String WEBHOOKS_ENABLED = "webhooks.enabled";
 
     public String getWeasyprintService() {
         return SystemValueReader.getInstance().readString(getPropertyPrefix() + WEASYPRINT_SERVICE, WEASYPRINT_SERVICE_DEFAULT);
@@ -26,12 +27,17 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
         return SystemValueReader.getInstance().readBoolean(getPropertyPrefix() + INTERNALIZE_EXTERNAL_CSS, false);
     }
 
+    public Boolean areWebhooksEnabled() {
+        return SystemValueReader.getInstance().readBoolean(getPropertyPrefix() + WEBHOOKS_ENABLED, false);
+    }
+
     @Override
     public @NotNull List<String> getSupportedProperties() {
         List<String> supportedProperties = new ArrayList<>(super.getSupportedProperties());
         supportedProperties.add(WEASYPRINT_SERVICE);
         supportedProperties.add(WEASYPRINT_PDF_VARIANT);
         supportedProperties.add(INTERNALIZE_EXTERNAL_CSS);
+        supportedProperties.add(WEBHOOKS_ENABLED);
         return supportedProperties;
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf/exporter/rest/controller/UtilityResourcesApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf/exporter/rest/controller/UtilityResourcesApiController.java
@@ -2,6 +2,7 @@ package ch.sbb.polarion.extension.pdf.exporter.rest.controller;
 
 import ch.sbb.polarion.extension.generic.rest.filter.Secured;
 import ch.sbb.polarion.extension.generic.service.PolarionService;
+import ch.sbb.polarion.extension.pdf.exporter.model.WebhooksStatus;
 import ch.sbb.polarion.extension.pdf.exporter.rest.model.conversion.DocumentType;
 
 import javax.ws.rs.Path;
@@ -31,5 +32,10 @@ public class UtilityResourcesApiController extends UtilityResourcesInternalContr
     @Override
     public String getFileName(String locationPath, String revision, DocumentType documentType, String scope) {
         return polarionService.callPrivileged(() -> super.getFileName(locationPath, revision, documentType, scope));
+    }
+
+    @Override
+    public WebhooksStatus getWebhooksStatus() {
+        return polarionService.callPrivileged(super::getWebhooksStatus);
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf/exporter/rest/controller/UtilityResourcesInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf/exporter/rest/controller/UtilityResourcesInternalController.java
@@ -1,5 +1,7 @@
 package ch.sbb.polarion.extension.pdf.exporter.rest.controller;
 
+import ch.sbb.polarion.extension.pdf.exporter.model.WebhooksStatus;
+import ch.sbb.polarion.extension.pdf.exporter.properties.PdfExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.pdf.exporter.rest.model.conversion.DocumentType;
 import ch.sbb.polarion.extension.pdf.exporter.service.PdfExporterPolarionService;
 import ch.sbb.polarion.extension.pdf.exporter.util.DocumentFileNameHelper;
@@ -80,5 +82,14 @@ public class UtilityResourcesInternalController {
     @Operation(summary = "Gets a filename, prepared with velocity and placeholders")
     public String getFileName(@QueryParam("locationPath") String locationPath, @QueryParam("revision") String revision, @QueryParam("documentType") DocumentType documentType, @QueryParam("scope") String scope) {
         return new DocumentFileNameHelper(pdfExporterPolarionService).getDocumentFileName(locationPath, revision, documentType, scope);
+    }
+
+    @GET
+    @Path("/webhooks/status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Tag(name = "Utility resources")
+    @Operation(summary = "Gets webhooks status - if they are enabled or not")
+    public WebhooksStatus getWebhooksStatus() {
+        return WebhooksStatus.builder().enabled(PdfExporterExtensionConfiguration.getInstance().areWebhooksEnabled()).build();
     }
 }

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
 <%! String bundleTimestamp = ch.sbb.polarion.extension.generic.util.VersionUtils.getVersion().getBundleBuildTimestampDigitsOnly(); %>
+<%! Boolean webhooksEnabled = ch.sbb.polarion.extension.pdf.exporter.properties.PdfExporterExtensionConfiguration.getInstance().areWebhooksEnabled(); %>
 
 <head>
     <title>PDF Exporter: Style Packages</title>
@@ -102,7 +103,7 @@
             </div>
         </div>
 
-        <div class="flex-container" style="border-top: 1px solid #ccc; margin-top: 20px; padding-top: 15px;">
+        <div class="flex-container" style="border-top: 1px solid #ccc; margin-top: 20px; padding-top: 15px; display: <%= webhooksEnabled ? "flex" : "none" %>;">
             <div class="flex-column">
                 <div class="input-group">
                     <label for='webhooks-checkbox' style="width: 120px;">

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/webhooks.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/webhooks.jsp
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 
 <%! String bundleTimestamp = ch.sbb.polarion.extension.generic.util.VersionUtils.getVersion().getBundleBuildTimestampDigitsOnly(); %>
+<%! Boolean webhooksEnabled = ch.sbb.polarion.extension.pdf.exporter.properties.PdfExporterExtensionConfiguration.getInstance().areWebhooksEnabled(); %>
 
 <head>
     <title>PDF Exporter: Webhooks</title>
@@ -51,44 +52,52 @@
 </head>
 
 <body>
-<div class="standard-admin-page">
-    <h1>PDF Exporter: Webhooks</h1>
+<div style="display: <%= webhooksEnabled ? "flex" : "none" %>; flex: 1; flex-direction: column">
+    <div class="standard-admin-page">
+        <h1>PDF Exporter: Webhooks</h1>
 
-    <jsp:include page='/common/jsp/notifications.jsp' />
+        <jsp:include page='/common/jsp/notifications.jsp' />
 
-    <jsp:include page='/common/jsp/configurations.jsp' />
+        <jsp:include page='/common/jsp/configurations.jsp' />
 
-    <h2 class="align-left">List of webhooks</h2>
-    <table id="webhooks-table"><!-- Filled by JS --></table>
-    <button class="toolbar-button webhook-button" onclick="WebHooks.addHook()" title="Add a webhook" style="margin-top: 10px; margin-left: 3px;"><img src='/polarion/ria/images/control/tablePlus.png' alt="Plus"></button>
+        <h2 class="align-left">List of webhooks <%= ch.sbb.polarion.extension.pdf.exporter.properties.PdfExporterExtensionConfiguration.getInstance().areWebhooksEnabled() %></h2>
+        <table id="webhooks-table"><!-- Filled by JS --></table>
+        <button class="toolbar-button webhook-button" onclick="WebHooks.addHook()" title="Add a webhook" style="margin-top: 10px; margin-left: 3px;">
+            <img src='/polarion/ria/images/control/tablePlus.png' alt="Plus">
+        </button>
 
-    <input id="scope" type="hidden" value="<%= request.getParameter("scope")%>"/>
-    <input id="bundle-timestamp" type="hidden" value="<%= ch.sbb.polarion.extension.generic.util.VersionUtils.getVersion().getBundleBuildTimestamp() %>"/>
-</div>
-
-<jsp:include page='/common/jsp/buttons.jsp'>
-    <jsp:param name="saveFunction" value="WebHooks.saveHooks()"/>
-    <jsp:param name="cancelFunction" value="SbbCommon.cancelEdit()"/>
-    <jsp:param name="defaultFunction" value="WebHooks.revertToDefault()"/>
-</jsp:include>
-
-<div class="standard-admin-page help">
-    <h2 class="align-left">Quick Help</h2>
-
-    <div>
-        <p>On this page you can add, edit or remove a webhook applied to selected configuration.</p>
-
-        <h3>What is a webhook</h3>
-        <p>
-            A webhook is a REST endpoint accepting initial HTML as a string (POST request), making some modification to this HTML and returning resulting HTML as a string back in body of response.
-            A webhook endpoint can locate anywhere, either within Polarion itself or outside of it.
-        </p>
-        <h3>Webhooks processing</h3>
-        <p>
-            Webhooks to run they should be selected in appropriate style package, or during PDF exporting. They are invoked in an order they entered on this page.
-            If certain webhook fails with an error, it's just skipped, remaining webhooks will still be invoked.
-        </p>
+        <input id="scope" type="hidden" value="<%= request.getParameter("scope")%>"/>
+        <input id="bundle-timestamp" type="hidden" value="<%= ch.sbb.polarion.extension.generic.util.VersionUtils.getVersion().getBundleBuildTimestamp() %>"/>
     </div>
+
+    <jsp:include page='/common/jsp/buttons.jsp'>
+        <jsp:param name="saveFunction" value="WebHooks.saveHooks()"/>
+        <jsp:param name="cancelFunction" value="SbbCommon.cancelEdit()"/>
+        <jsp:param name="defaultFunction" value="WebHooks.revertToDefault()"/>
+    </jsp:include>
+
+    <div class="standard-admin-page help">
+        <h2 class="align-left">Quick Help</h2>
+
+        <div>
+            <p>On this page you can add, edit or remove a webhook applied to selected configuration.</p>
+
+            <h3>What is a webhook</h3>
+            <p>
+                A webhook is a REST endpoint accepting initial HTML as a string (POST request), making some modification to this HTML and returning resulting HTML as a string back in body of response.
+                A webhook endpoint can locate anywhere, either within Polarion itself or outside of it.
+            </p>
+            <h3>Webhooks processing</h3>
+            <p>
+                Webhooks to run they should be selected in appropriate style package, or during PDF exporting. They are invoked in an order they entered on this page.
+                If certain webhook fails with an error, it's just skipped, remaining webhooks will still be invoked.
+            </p>
+        </div>
+    </div>
+</div>
+<div style="display: <%= webhooksEnabled ? "none" : "block" %>">
+    <h1>PDF Exporter: Webhooks</h1>
+    <p style="font-style: italic; color: palevioletred;">Webhooks are not enabled. Please contact system administrator if this functionality should be available.</p>
 </div>
 
 <script type="text/javascript" src="../ui/generic/js/common.js?bundle=<%= bundleTimestamp %>"></script>

--- a/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
+++ b/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
@@ -194,6 +194,10 @@
     column-gap: 5px;
 }
 
+.property-wrapper.hidden {
+    display: none;
+}
+
 .property-wrapper label {
     margin-top: 2px;
     margin-bottom: 3px;

--- a/src/main/resources/webapp/pdf-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/pdf-exporter/html/popupForm.html
@@ -45,7 +45,7 @@
             </div>
         </div>
 
-        <div class="flex-container" style='border-top: 1px solid #eee; margin-top: 15px; padding-top: 5px;'>
+        <div class="flex-container" id="webhooks-container" style='border-top: 1px solid #eee; margin-top: 15px; padding-top: 5px;'>
             <div class="flex-column">
                 <div class='property-wrapper'>
                     <label for='popup-webhooks-checkbox' class="fixed-width w-1">

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -41,12 +41,12 @@
             {LOCALIZATION_OPTIONS}
         </select>
     </div>
-    <div class='property-wrapper' style='border-top: 1px solid #eee; padding-top: 10px;'>
+    <div class='property-wrapper {WEBHOOKS_DISPLAY}' style='border-top: 1px solid #eee; padding-top: 10px;'>
         <label for='webhooks-selector'>
             <input id='webhooks-checkbox' onchange='document.getElementById("webhooks-selector").style.display = this.checked ? "inline-block" : "none"' type='checkbox' {WEBHOOKS_SELECTED}/>
             Webhooks:
         </label>
-        <select id='webhooks-selector' style="display: {WEBHOOKS_DISPLAY}">
+        <select id='webhooks-selector' style="display: {WEBHOOKS_SELECTOR_DISPLAY}">
             {WEBHOOKS_OPTIONS}
         </select>
     </div>

--- a/src/main/resources/webapp/pdf-exporter/js/pdf-exporter.js
+++ b/src/main/resources/webapp/pdf-exporter/js/pdf-exporter.js
@@ -131,7 +131,8 @@ const PdfExporter = {
             this.loadLinkRoles(this.exportContext),
             this.loadProjectName(this.exportContext),
             this.loadDocumentLanguage(this.exportContext),
-            this.loadFileName(this.exportContext)
+            this.loadFileName(this.exportContext),
+            this.adjustWebhooksVisibility()
         ]).then(() => {
             return this.loadSettingNames({
                 setting: "style-package",
@@ -231,6 +232,19 @@ const PdfExporter = {
             }).then(({responseText}) => {
                 document.getElementById("popup-filename").value = responseText;
                 document.getElementById("popup-filename").dataset.default = responseText;
+                resolve()
+            }).catch((error) => reject(error));
+        });
+    },
+
+    adjustWebhooksVisibility: function () {
+        return new Promise((resolve, reject) => {
+            this.callAsync({
+                method: "GET",
+                url: `/polarion/pdf-exporter/rest/internal/webhooks/status`,
+                responseType: "json",
+            }).then(({response}) => {
+                document.getElementById("webhooks-container").style.display = response.enabled ? "flex" : "none";
                 resolve()
             }).catch((error) => reject(error));
         });


### PR DESCRIPTION
Possibility for global admin to hide webhook functionality at all via polarion.properties

Refs: #91

### Proposed changes

N/A

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
