### PR TITLE
feat: unused configuration property removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,6 @@ The converting HTML can contain some external CSS links referencing Polarion Ser
 <link rel="stylesheet" href="/polarion/diff-tool-app/ui/app/_next/static/css/3c374f9daffd361a.css" data-precedence="next">
 ```
 
-In case the Polarion Server is not reachable from the WeasyPrint Service, such links cannot be successfully resolved during the WeasyPrint PDF transformation. The solution is to replace external CSS <link> elements with internal CSS <style> tags containing the CSS content embedded into the HTML document. By default, CSS link internalization is disabled. To enable internalization of CSS links, it is necessary to activate the following property in file `polarion.properties`:
-
-```properties
-ch.sbb.polarion.extension.pdf-exporter.internalizeExternalCss=true
-```
-
 ## Extension configuration
 
 1. On the top of the project's navigation pane click ⚙ (Actions) ➙ 🔧 Administration. Project's administration page will be opened.

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfiguration.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfiguration.java
@@ -15,7 +15,6 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
     public static final String WEASYPRINT_SERVICE = "weasyprint.service";
     public static final String WEASYPRINT_SERVICE_DEFAULT = "http://localhost:9080";
     public static final String WEASYPRINT_PDF_VARIANT = "weasyprint.pdf.variant";
-    public static final String INTERNALIZE_EXTERNAL_CSS = "internalizeExternalCss";
     public static final String WEBHOOKS_ENABLED = "webhooks.enabled";
 
     public String getWeasyprintService() {
@@ -24,10 +23,6 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
 
     public String getWeasyprintPdfVariant() {
         return SystemValueReader.getInstance().readString(getPropertyPrefix() + WEASYPRINT_PDF_VARIANT, null);
-    }
-
-    public Boolean getInternalizeExternalCss() {
-        return SystemValueReader.getInstance().readBoolean(getPropertyPrefix() + INTERNALIZE_EXTERNAL_CSS, false);
     }
 
     @NotNull
@@ -40,7 +35,6 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
         List<String> supportedProperties = new ArrayList<>(super.getSupportedProperties());
         supportedProperties.add(WEASYPRINT_SERVICE);
         supportedProperties.add(WEASYPRINT_PDF_VARIANT);
-        supportedProperties.add(INTERNALIZE_EXTERNAL_CSS);
         supportedProperties.add(WEBHOOKS_ENABLED);
         return supportedProperties;
     }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/HtmlLinksHelper.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/HtmlLinksHelper.java
@@ -1,7 +1,6 @@
 package ch.sbb.polarion.extension.pdf_exporter.util.html;
 
 import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
-import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.pdf_exporter.util.FileResourceProvider;
 
 import java.util.LinkedHashMap;
@@ -38,11 +37,6 @@ public class HtmlLinksHelper {
     }
 
     public String internalizeLinks(String htmlContent) {
-        boolean linksInternalizationEnabled = PdfExporterExtensionConfiguration.getInstance().getInternalizeExternalCss();
-        if (!linksInternalizationEnabled) {
-            return htmlContent;
-        }
-
         return RegexMatcher.get(LINK_REGEX, RegexMatcher.CASE_INSENSITIVE).replace(htmlContent, regexEngine -> {
             String linkTag = regexEngine.group(0);
             Map<String, String> attributesMap = parseLinkTagAttributes(linkTag);

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -76,7 +76,7 @@ class MediaUtilsTest {
         assertNull(MediaUtils.guessMimeType("unknownExtensionNonsenseContent.unk", Bytes.toArray(List.of(0, 0, 0, 0, 0))));
 
         assertTrue(InMemoryAppender.anyMessageContains("Cannot get mime type for the resource: unknownExtensionEmptyContent.unk"));
-        assertTrue(InMemoryAppender.anyMessageContains("Cannot get mime type for the resource: unknownExtensionEmptyContent.unk"));
+        assertTrue(InMemoryAppender.anyMessageContains("Cannot get mime type for the resource: unknownExtensionNonsenseContent.unk"));
     }
 
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/html/HtmlLinksHelperTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/html/HtmlLinksHelperTest.java
@@ -34,7 +34,6 @@ class HtmlLinksHelperTest {
     void setup() {
         extensionConfigurationMockedStatic = mockStatic(PdfExporterExtensionConfiguration.class);
         extensionConfigurationMockedStatic.when(PdfExporterExtensionConfiguration::getInstance).thenReturn(pdfExporterExtensionConfiguration);
-        when(pdfExporterExtensionConfiguration.getInternalizeExternalCss()).thenReturn(true);
         htmlLinksHelper = new HtmlLinksHelper(Set.of(linkInternalizer1, linkInternalizer2));
     }
 
@@ -64,15 +63,5 @@ class HtmlLinksHelperTest {
         ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
         verify(linkInternalizer1).inline(captor.capture());
         assertThat(captor.getValue()).containsExactly(Map.entry("attr1", "value1"), Map.entry("attr2", "value2")); // also it must lowercase attributes
-    }
-
-    @Test
-    void shouldReturnUnchangedHtmlWhenPropertyNotSet() {
-        when(pdfExporterExtensionConfiguration.getInternalizeExternalCss()).thenReturn(false);
-        String resultHtml = htmlLinksHelper.internalizeLinks("""
-                    <html lang='en'><head><link attr1="value1" attr2="value2">some content</head>""");
-        assertThat(resultHtml).isEqualTo("""
-                <html lang='en'><head><link attr1="value1" attr2="value2">some content</head>""");
-        verify(linkInternalizer1, times(0)).inline(anyMap());
     }
 }


### PR DESCRIPTION
Refs: SchweizerischeBundesbahnen/weasyprint-service#61

### Proposed changes

We have to remove obsolete property "internalizeExternalCss".

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
