### PR TITLE
fix: Prevent setting matching query for default style packages on server side level

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettings.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettings.java
@@ -56,7 +56,8 @@ public class StylePackageSettings extends GenericNamedSettings<StylePackageModel
         }
     }
 
-    private void validateMatchingQuery(StylePackageModel model) {
+    @VisibleForTesting
+    void validateMatchingQuery(StylePackageModel model) {
         if (DEFAULT_NAME.equals(model.getName()) && !StringUtils.isEmpty(model.getMatchingQuery())) {
             throw new IllegalArgumentException("Matching query cannot be specified for a default style package");
         }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettings.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettings.java
@@ -5,6 +5,7 @@ import ch.sbb.polarion.extension.generic.settings.SettingsService;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.Orientation;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.PaperSize;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.StylePackageModel;
+import com.polarion.core.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -23,6 +24,7 @@ public class StylePackageSettings extends GenericNamedSettings<StylePackageModel
     @Override
     public void beforeSave(@NotNull StylePackageModel what) {
         adjustAndValidateWeight(what);
+        validateMatchingQuery(what);
     }
 
     @Override
@@ -54,4 +56,9 @@ public class StylePackageSettings extends GenericNamedSettings<StylePackageModel
         }
     }
 
+    private void validateMatchingQuery(StylePackageModel model) {
+        if (DEFAULT_NAME.equals(model.getName()) && !StringUtils.isEmpty(model.getMatchingQuery())) {
+            throw new IllegalArgumentException("Matching query cannot be specified for a default style package");
+        }
+    }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettingsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettingsTest.java
@@ -16,8 +16,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static ch.sbb.polarion.extension.generic.settings.NamedSettings.DEFAULT_NAME;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -205,6 +205,24 @@ class StylePackageSettingsTest {
                 stylePackageSettings.adjustAndValidateWeight(model);
             });
             assertEquals("Weight must be between 0 and 100 and have only one digit after the decimal point", exception.getMessage());
+        }
+    }
+
+    @Test
+    void testValidateMatchingQuery() {
+        try (MockedStatic<ScopeUtils> mockScopeUtils = mockStatic(ScopeUtils.class)) {
+            SettingsService mockedSettingsService = mock(SettingsService.class);
+            mockScopeUtils.when(() -> ScopeUtils.getFileContent(any())).thenCallRealMethod();
+
+            StylePackageSettings stylePackageSettings = new StylePackageSettings(mockedSettingsService);
+            StylePackageModel model = new StylePackageModel();
+
+            model.setMatchingQuery("query");
+            assertDoesNotThrow(() -> stylePackageSettings.validateMatchingQuery(model));
+
+            model.setName(DEFAULT_NAME);
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> stylePackageSettings.validateMatchingQuery(model));
+            assertEquals("Matching query cannot be specified for a default style package", exception.getMessage());
         }
     }
 


### PR DESCRIPTION
### Proposed changes

Prevent setting matching query for default style packages on server side level

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
