### PR TITLE
fix: fields data ignored on new style package creation

### DIFF
--- a/src/main/resources/webapp/pdf-exporter-admin/pages/cover-page.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/cover-page.jsp
@@ -91,7 +91,7 @@
     <jsp:param name="defaultFunction" value="revertToDefault()"/>
 </jsp:include>
 
-<div class="standard-admin-page" id="templates-pane" style="display: none">
+<div class="standard-admin-page hide-on-edit-configuration" id="templates-pane" style="display: none">
     <h2 class="align-left">Predefined Templates</h2>
     <div>
         <p>In addition to a default template, there are more predefined ones which you can persist. Please select one from the dropdown below and click 'Persist' button.</p>


### PR DESCRIPTION
Refs: #247

### Proposed changes

Hide configuration-unrelated component on cover settings page on configuration creation or name change. Uses new feature introduced in generic v.7.4.1+

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
