### PR TITLE
fix: fit images and tables to page for Test Runs

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -556,7 +556,7 @@ public class HtmlProcessor {
             // This regexp searches for <td> or <th> elements of regular tables which width in styles specified in pixels ("px").
             // <td> or <th> element till "width:" in styles matched into first unnamed group and width value - into second unnamed group.
             // Then we replace matched content by first group content plus "auto" instead of value in pixels.
-            html = RegexMatcher.get("(<t[dh].+?width:.*?)(\\d+px)")
+            html = RegexMatcher.get("(<t[dh][^>]+?width:.*?)(\\d+px)")
                     .replace(html, regexEngine -> regexEngine.group(1) + "auto");
         }
 

--- a/src/main/resources/webapp/pdf-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/pdf-exporter/html/popupForm.html
@@ -92,7 +92,7 @@
 
         <div class="flex-container">
             <div class="flex-column">
-                <div class='property-wrapper only-live-doc'>
+                <div class='property-wrapper'>
                     <label for='popup-fit-to-page'>
                         <input id='popup-fit-to-page' type='checkbox'/>
                         Fit images and tables to page

--- a/src/main/resources/webapp/pdf-exporter/js/pdf-exporter.js
+++ b/src/main/resources/webapp/pdf-exporter/js/pdf-exporter.js
@@ -508,6 +508,7 @@ const PdfExporter = {
 
     buildExportParams: function (selectedChapters, numberedListStyles, selectedRoles, fileName) {
         const live_doc = this.exportContext.getDocumentType() === ExportParams.DocumentType.LIVE_DOC;
+        const test_run = this.exportContext.getDocumentType() === ExportParams.DocumentType.TEST_RUN;
         return new ExportParams.Builder(this.exportContext.getDocumentType())
             .setProjectId(this.exportContext.getProjectId())
             .setLocationPath(this.exportContext.getLocationPath())
@@ -520,7 +521,7 @@ const PdfExporter = {
             .setHeadersColor(document.getElementById("popup-headers-color").value)
             .setPaperSize(document.getElementById("popup-paper-size-selector").value)
             .setOrientation(document.getElementById("popup-orientation-selector").value)
-            .setFitToPage(live_doc && document.getElementById('popup-fit-to-page').checked)
+            .setFitToPage((live_doc || test_run) && document.getElementById('popup-fit-to-page').checked)
             .setEnableCommentsRendering(live_doc && document.getElementById('popup-enable-comments-rendering').checked)
             .setWatermark(document.getElementById("popup-watermark").checked)
             .setMarkReferencedWorkitems(live_doc && document.getElementById("popup-mark-referenced-workitems").checked)


### PR DESCRIPTION
Refs: #293

### Proposed changes

We have to enable "Fit images and tables to page" feature for Test Runs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
