### PR TITLE
fix: style package weights don't work for bulk export widget

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1027,37 +1027,28 @@
       }
     },
     "/api/settings/style-package/suitable-names": {
-      "get": {
+      "post": {
         "operationId": "getSuitableStylePackageNames",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "projectId",
-            "schema": {
-              "type": "string"
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/DocIdentifier"
+                },
+                "type": "array"
+              }
             }
           },
-          {
-            "in": "query",
-            "name": "spaceId",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "documentName",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+          "description": "List of document identifiers",
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Successfully retrieved the list of style package names"
           }
         },
-        "summary": "Get list of style packages suitable for a document",
+        "summary": "Get list of style packages suitable for the specified list of documents (sorted by weight)",
         "tags": [
           "Settings"
         ]
@@ -1606,6 +1597,24 @@
               "CANCELLED"
             ],
             "example": "IN_PROGRESS",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DocIdentifier": {
+        "description": "Unique document identifier data",
+        "properties": {
+          "documentName": {
+            "description": "Document name",
+            "type": "string"
+          },
+          "projectId": {
+            "description": "Project ID",
+            "type": "string"
+          },
+          "spaceId": {
+            "description": "Space ID",
             "type": "string"
           }
         },

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/PdfExporterFormExtension.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/PdfExporterFormExtension.java
@@ -9,6 +9,7 @@ import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionCon
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.DocumentType;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.ExportParams;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.localization.Language;
+import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.DocIdentifier;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.StylePackageModel;
 import ch.sbb.polarion.extension.pdf_exporter.service.PdfExporterPolarionService;
 import ch.sbb.polarion.extension.pdf_exporter.service.PolarionBaselineExecutor;
@@ -173,7 +174,7 @@ public class PdfExporterFormExtension implements IFormExtension {
         } else {
             documentName = locationPath;
         }
-        return polarionService.getSuitableStylePackages(module.getProject().getId(), spaceId, documentName);
+        return polarionService.getSuitableStylePackages(List.of(new DocIdentifier(module.getProject().getId(), spaceId, documentName)));
     }
 
     private Collection<SettingName> getSettingNames(@NotNull String featureName, @NotNull String scope) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/SettingsApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/SettingsApiController.java
@@ -3,6 +3,7 @@ package ch.sbb.polarion.extension.pdf_exporter.rest.controller;
 import ch.sbb.polarion.extension.generic.rest.filter.Secured;
 import ch.sbb.polarion.extension.generic.service.PolarionService;
 import ch.sbb.polarion.extension.generic.settings.SettingName;
+import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.DocIdentifier;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.StylePackageWeightInfo;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 
@@ -44,8 +45,8 @@ public class SettingsApiController extends SettingsInternalController {
     }
 
     @Override
-    public Collection<SettingName> getSuitableStylePackageNames(String projectId, String spaceId, String documentName) {
-        return polarionService.callPrivileged(() -> super.getSuitableStylePackageNames(projectId, spaceId, documentName));
+    public Collection<SettingName> getSuitableStylePackageNames(List<DocIdentifier> docIdentifiers) {
+        return polarionService.callPrivileged(() -> super.getSuitableStylePackageNames(docIdentifiers));
     }
 
     @Override

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/SettingsInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/SettingsInternalController.java
@@ -4,6 +4,7 @@ import ch.sbb.polarion.extension.generic.settings.SettingId;
 import ch.sbb.polarion.extension.generic.settings.SettingName;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.coverpage.CoverPageModel;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.localization.LocalizationModel;
+import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.DocIdentifier;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.StylePackageWeightInfo;
 import ch.sbb.polarion.extension.pdf_exporter.service.PdfExporterPolarionService;
 import ch.sbb.polarion.extension.pdf_exporter.settings.CoverPageSettings;
@@ -143,20 +144,27 @@ public class SettingsInternalController {
         new CoverPageSettings().deleteCoverPageImages(coverPageName, scope);
     }
 
-    @GET
+    @POST
     @Path("/settings/style-package/suitable-names")
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = "Settings")
-    @Operation(summary = "Get list of style packages suitable for a document",
+    @Operation(summary = "Get list of style packages suitable for the specified list of documents (sorted by weight)",
+            requestBody = @RequestBody(description = "List of document identifiers",
+                    required = true,
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = DocIdentifier.class)),
+                            mediaType = MediaType.APPLICATION_JSON
+                    )
+            ),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successfully retrieved the list of style package names")
             }
     )
-    public Collection<SettingName> getSuitableStylePackageNames(@QueryParam("projectId") String projectId, @QueryParam("spaceId") String spaceId, @QueryParam("documentName") String documentName) {
-        if (spaceId == null || documentName == null) {
-            throw new BadRequestException("Parameters 'spaceId' and 'documentName' are required'");
+    public Collection<SettingName> getSuitableStylePackageNames(List<DocIdentifier> docIdentifiers) {
+        if (docIdentifiers.isEmpty()) {
+            throw new BadRequestException("At least one document identifier required");
         }
-        return pdfExporterPolarionService.getSuitableStylePackages(projectId, spaceId, documentName);
+        return pdfExporterPolarionService.getSuitableStylePackages(docIdentifiers);
     }
 
     @GET

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/settings/stylepackage/DocIdentifier.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/settings/stylepackage/DocIdentifier.java
@@ -1,0 +1,37 @@
+package ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@EqualsAndHashCode(callSuper = false)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Unique document identifier data")
+public class DocIdentifier {
+
+    @Schema(
+            description = "Project ID"
+    )
+    private @NotNull String projectId;
+
+    @Schema(
+            description = "Space ID"
+    )
+    private @NotNull String spaceId;
+
+    @Schema(
+            description = "Document name"
+    )
+    private @NotNull String documentName;
+}

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
@@ -1,6 +1,7 @@
 package ch.sbb.polarion.extension.pdf_exporter.widgets;
 
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.DocumentType;
+import com.polarion.alm.projects.internal.model.Project;
 import com.polarion.alm.server.api.model.rp.widget.AbstractWidgetRenderer;
 import com.polarion.alm.server.api.model.rp.widget.BottomQueryLinksBuilder;
 import com.polarion.alm.shared.api.model.ModelObject;
@@ -164,6 +165,7 @@ public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
             checkbox.attributes()
                     .byName("type", "checkbox")
                     .byName("data-type", item.getOldApi().getPrototype().getName())
+                    .byName("data-project", getProject(item))
                     .byName("data-space", getSpace(item))
                     .byName("data-id", getValue(item, "id"))
                     .className("export-item");
@@ -191,6 +193,10 @@ public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
         } else {
             return "";
         }
+    }
+
+    private String getProject(@NotNull ModelObject item) {
+        return item.getOldApi().getValue("project") instanceof Project project ? project.getId() : "";
     }
 
     private String getValue(@NotNull ModelObject item, @NotNull String fieldName) {

--- a/src/main/resources/webapp/pdf-exporter/js/bulk-pdf-exporter.js
+++ b/src/main/resources/webapp/pdf-exporter/js/bulk-pdf-exporter.js
@@ -65,6 +65,7 @@ const BulkPdfExporter = {
                 const div = document.createElement("div");
                 div.className = "export-item paused";
                 div.dataset["type"] = selectedCheckbox.dataset["type"];
+                div.dataset["project"] = selectedCheckbox.dataset["project"];
                 div.dataset["space"] = selectedCheckbox.dataset["space"];
                 div.dataset["id"] = selectedCheckbox.dataset["id"];
 
@@ -211,6 +212,7 @@ const BulkPdfExporter = {
             currentItem.classList.add("in-progress");
 
             const documentType = this.getDocumentType(currentItem.dataset["type"]);
+            this.exportParams["projectId"] = `${currentItem.dataset["project"]}`;
             this.exportParams["documentType"] = documentType;
             const documentId = currentItem.dataset["id"];
             if (documentType === ExportParams.DocumentType.TEST_RUN) {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionServiceTest.java
@@ -7,6 +7,7 @@ import ch.sbb.polarion.extension.generic.util.PObjectListStub;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.attachments.TestRunAttachment;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.collections.DocumentCollectionEntry;
+import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.DocIdentifier;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.StylePackageModel;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.StylePackageWeightInfo;
 import ch.sbb.polarion.extension.pdf_exporter.settings.StylePackageSettings;
@@ -161,7 +162,7 @@ class PdfExporterPolarionServiceTest {
         when(stylePackageSettings.read(eq("project/someProjectId/"), eq(SettingId.fromName("name4")), isNull())).thenReturn(mockModel4);
         when(stylePackageSettings.read(eq("project/someProjectId/"), eq(SettingId.fromName("name5")), isNull())).thenReturn(mockModel5);
 
-        Collection<SettingName> result = service.getSuitableStylePackages(projectId, spaceId, documentName);
+        Collection<SettingName> result = service.getSuitableStylePackages(List.of(new DocIdentifier(projectId, spaceId, documentName)));
 
         assertNotNull(result);
         assertEquals(5, result.size());


### PR DESCRIPTION
Refs: #317

### Proposed changes

When using the Bulk-PDF-Export-Widget, the Style Package Weights shall have an influence on the order.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
