### PR TITLE
fix: test run attachments downloaded despite the checkbox 'Download a…

### DIFF
--- a/src/main/resources/webapp/pdf-exporter/js/pdf-exporter.js
+++ b/src/main/resources/webapp/pdf-exporter/js/pdf-exporter.js
@@ -471,7 +471,7 @@ const PdfExporter = {
             return;
         }
 
-        if (this.exportContext.getDocumentType() === ExportParams.DocumentType.TEST_RUN) {
+        if (this.exportContext.getDocumentType() === ExportParams.DocumentType.TEST_RUN && document.getElementById("popup-download-attachments").checked) {
             const testRunId = new URLSearchParams(this.exportContext.getUrlQueryParameters()).get("id")
             ExportCommon.downloadTestRunAttachments(exportParams.projectId, testRunId, exportParams.revision, exportParams.attachmentsFilter);
         }


### PR DESCRIPTION
…ttachments' is unchecked

Refs: #337

### Proposed changes

Attachments shouldn't be downloaded when the checkbox 'Download attachments' is unchecked

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
