### PR TITLE
fix: Make it possible to alternate content of header/footer for even/odd pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,51 @@ In case if both of them specified 'existing_wi_id' has higher priority.
    (Style package, Stylesheets) there's no `Quick Help` section as their content is self-evident.
 4. To change configuration of PDF Exporter extension just edit corresponding section and press `Save` button.
 
+### CSS for booklet layout
+
+If you export PDF to be printed as a booklet, then you may need to alternate blocks in header/footer depending on the fact if it's even or odd page.
+This can be achieved (since version 8.1.0) by CSS modification. Let us give you an example. Find following definition in standard CSS of the extension:
+
+```
+@page :left {
+    @top-left {
+        content: element(top-left);
+    }
+    @top-right {
+        content: element(top-right);
+    }
+    @bottom-left {
+        content: element(bottom-left);
+    }
+    @bottom-right {
+        content: element(bottom-right);
+    }
+}
+```
+
+...and replace it by this code:
+
+```
+@page :left {
+    @top-left {
+        content: element(top-right);
+    }
+    @top-right {
+        content: element(top-left);
+    }
+    @bottom-left {
+        content: element(bottom-right);
+    }
+    @bottom-right {
+        content: element(bottom-left);
+    }
+}
+```
+
+As a result blocks in header and footer which in normal case are displayed at right side of the header/footer will be displayed at left side and vice versa.
+This is only an example to illustrate an idea, if your use case is different feel free to modify this code according to your requirements.
+
+
 ## Usage
 
 1. Open a document in Polarion.

--- a/src/main/resources/default/dle-pdf-export.css
+++ b/src/main/resources/default/dle-pdf-export.css
@@ -140,29 +140,41 @@ ul.toc li > a.page-number::after {
 @page {
     margin: 120px 60px 90px 80px;
     border-bottom: 1px solid #aaa;
-    @top-left {
-        content: element(top-left);
-        display: none;
-    }
     @top-center {
         content: element(top-center);
-        width: 100%;
-    }
-    @top-right {
-        content: element(top-right);
-        display: none;
-    }
-    @bottom-left {
-        content: element(bottom-left);
-        display: none;
     }
     @bottom-center {
         content: element(bottom-center);
-        width: 100%;
+    }
+}
+
+@page :left {
+    @top-left {
+        content: element(top-left);
+    }
+    @top-right {
+        content: element(top-right);
+    }
+    @bottom-left {
+        content: element(bottom-left);
     }
     @bottom-right {
         content: element(bottom-right);
-        display: none;
+    }
+}
+
+@page :right {
+    @top-left {
+        content: element(top-left);
+    }
+    @top-right {
+        content: element(top-right);
+    }
+    @bottom-left {
+        content: element(bottom-left);
+    }
+    @bottom-right {
+        content: element(bottom-right);
     }
 }
 
@@ -306,30 +318,30 @@ ul.toc li > a.page-number::after {
     }
 
     .header, .footer {
-        display: inline-block;
+        display: block;
     }
 
-    .header.top-left {
+    .header .top-left {
         position: running(top-left);
     }
 
-    .header.top-center {
+    .header .top-center {
         position: running(top-center);
     }
 
-    .header.top-right {
+    .header .top-right {
         position: running(top-right);
     }
 
-    .footer.bottom-left {
+    .footer .bottom-left {
         position: running(bottom-left);
     }
 
-    .footer.bottom-center {
+    .footer .bottom-center {
         position: running(bottom-center);
     }
 
-    .footer.bottom-right {
+    .footer .bottom-right {
         position: running(bottom-right);
     }
 
@@ -868,21 +880,12 @@ li span {
     line-height: 1em !important;
 }
 
-.header-footer-wrapper {
-    display: flex;
-}
-
-.header-footer-left {
-    flex: 1;
-}
-
 .header-footer-center {
-    max-width: 30%;
+    /*max-width: 30%;*/
     text-align: center;
 }
 
 .header-footer-right {
-    flex: 1;
     text-align: right;
 }
 

--- a/src/main/resources/webapp/pdf-exporter/html/headerAndFooter.html
+++ b/src/main/resources/webapp/pdf-exporter/html/headerAndFooter.html
@@ -1,22 +1,22 @@
-<div class='header top-center header-footer-wrapper'>
-    <div class='header-footer-left'>
+<div class='header'>
+    <div class='top-left'>
         %s
     </div>
-    <div class='header-footer-center'>
+    <div class='top-center'>
         %s
     </div>
-    <div class='header-footer-right'>
+    <div class='top-right'>
         %s
     </div>
 </div>
-<div class='footer bottom-center header-footer-wrapper'>
-    <div class='header-footer-left'>
+<div class='footer'>
+    <div class='bottom-left'>
         %s
     </div>
-    <div class='header-footer-center'>
+    <div class='bottom-center'>
         %s
     </div>
-    <div class='header-footer-right'>
+    <div class='bottom-right'>
         %s
     </div>
 </div>

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterTest.java
@@ -195,25 +195,25 @@ class PdfConverterTest {
 
         // Assert
         assertThat(TestStringUtils.removeNonsensicalSymbols(headerFooterContent)).isEqualTo(TestStringUtils.removeNonsensicalSymbols("""
-                <div class='header top-center header-footer-wrapper'>
-                    <div class='header-footer-left'>
+                <div class='header'>
+                    <div class='top-left'>
                         -xheader-left-
                     </div>
-                    <div class='header-footer-center'>
+                    <div class='top-center'>
                         -xheader-center-
                     </div>
-                    <div class='header-footer-right'>
+                    <div class='top-right'>
                         -xheader-right-
                     </div>
                 </div>
-                <div class='footer bottom-center header-footer-wrapper'>
-                    <div class='header-footer-left'>
+                <div class='footer'>
+                    <div class='bottom-left'>
                         -xfooter-left-
                     </div>
-                    <div class='header-footer-center'>
+                    <div class='bottom-center'>
                         -xfooter-center-
                     </div>
-                    <div class='header-footer-right'>
+                    <div class='bottom-right'>
                         -xfooter-right-
                     </div>
                 </div>""".indent(0).trim()));


### PR DESCRIPTION
Make it possible to alternate content of header/footer for even/odd pages

Fixes #339

### Proposed changes

If exported PDF to be printed as a booklet, then you may need to alternate blocks in header/footer depending on the fact if it's even or odd page. At the moment it's not possible to do this. Content and CSS of prepared HTML should be modified to make it possible.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
