### PR TITLE
fix: table of content indentation fix

### DIFF
--- a/src/main/resources/default/dle-pdf-export.css
+++ b/src/main/resources/default/dle-pdf-export.css
@@ -97,7 +97,7 @@ ul.toc, ul.toc ul {
 }
 
 ul.toc ul {
-    padding-inline-start: .6em;
+    padding-left: .6em;
     margin-top: .2em;
     margin-bottom: .2em;
 }


### PR DESCRIPTION
Refs: #354

### Proposed changes

We have to replace `padding-inline-start` usage with `padding-left`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
