### PR TITLE
docs: use Headings instead of Headers

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -6,7 +6,7 @@
     * [Header and footer](#header-and-footer)
     * [Localization](#localization)
     * [Webhooks](#webhooks)
-    * [Headers color](#headers-color)
+    * [Headings color](#headings-color)
     * [Paper size](#paper-size)
     * [Orientation](#orientation)
     * [Fit images and tables to page width](#fit-images-and-tables-to-page-width)
@@ -67,14 +67,14 @@ In this section, you can choose a specific webhook for custom HTML processing be
 
 ![Webhooks](docs/user_guide/img/webhooks.png)
 
-### Headers color
-By default, dark blue color (Polarion's default) is used for headers, but you can change this by selecting any other color:
+### Headings color
+By default, dark blue color (Polarion's default) is used for headings, but you can change this by selecting any other color:
 
-![Headers color](docs/user_guide/img/headers_color.png)
+![Headings color](docs/user_guide/img/headers_color.png)
 
-As a result, the headers of the generated PDF will be of the selected color:
+As a result, the headings of the generated PDF will be of selected color:
 
-![Headers color result](docs/user_guide/img/headers_color_result.png)
+![Headings color result](docs/user_guide/img/headers_color_result.png)
 
 ### Paper size
 This option specifies the paper size of the generated PDF document. Default is "A4".

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
@@ -162,7 +162,7 @@
         <div class="flex-container" style="border-top: 1px solid #ccc; margin-top: 20px; padding-top: 15px;">
             <div class="flex-column">
                 <div class='input-group'>
-                    <label for='headers-color'>Headers color:</label>
+                    <label for='headers-color'>Headings color:</label>
                     <input id='headers-color' type='color' value='#004d73' style="width: 30px"/>
                 </div>
             </div>

--- a/src/main/resources/webapp/pdf-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/pdf-exporter/html/popupForm.html
@@ -60,7 +60,7 @@
         <div class="flex-container" style='border-top: 1px solid #eee; margin-top: 15px; padding-top: 5px;'>
             <div class="flex-column">
                 <div class='property-wrapper'>
-                    <label for='popup-headers-color' class="fixed-width w-1">Headers color:</label>
+                    <label for='popup-headers-color' class="fixed-width w-1">Headings color:</label>
                     <input id='popup-headers-color' type='color'/>
                 </div>
             </div>

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -55,7 +55,7 @@
             </select>
         </div>
         <div class='property-wrapper' style='border-top: 1px solid #eee; padding-top: 10px;'>
-            <label for='headers-color'>Headers color:</label>
+            <label for='headers-color'>Headings color:</label>
             <input id='headers-color' type='color' value='{HEADERS_COLOR_VALUE}'/>
         </div>
         <div class='property-wrapper'>


### PR DESCRIPTION
### Proposed changes

In the User Interface, Headings are meant for the Headings Work Items whereas headers are more related to the page header (and footer). This PR would like to increase the consistency.

Fixes https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.pdf-exporter/issues/436

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [X] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
