### PR TITLE
fix: make pageParameters available in velocity context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,13 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <!-- Required for mocking HtmlFragmentParser -->
+        <dependency>
+            <groupId>com.polarion.thirdparty</groupId>
+            <artifactId>nu.xom_1.3.7.osgi</artifactId>
+            <version>${polarion.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/velocity/VelocityEvaluator.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/velocity/VelocityEvaluator.java
@@ -3,23 +3,36 @@ package ch.sbb.polarion.extension.pdf_exporter.util.velocity;
 import ch.sbb.polarion.extension.generic.util.ObjectUtils;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.documents.DocumentData;
 import com.polarion.alm.projects.model.IUniqueObject;
+import com.polarion.alm.server.ServerUiContext;
 import com.polarion.alm.server.api.model.rp.widget.RichPageScriptRenderer;
 import com.polarion.alm.server.api.model.rp.widget.impl.RichPageRenderingContextImpl;
+import com.polarion.alm.server.html.HtmlFragmentParser;
+import com.polarion.alm.server.html.ServerHtmlNodeFactory;
+import com.polarion.alm.shared.api.Scope;
+import com.polarion.alm.shared.api.impl.ScopeImpl;
+import com.polarion.alm.shared.api.model.rp.parameter.RichPageParameter;
+import com.polarion.alm.shared.api.model.rp.parameter.impl.HtmlRichPageParameters;
 import com.polarion.alm.shared.api.transaction.TransactionalExecutor;
 import com.polarion.alm.shared.api.transaction.internal.InternalReadOnlyTransaction;
+import com.polarion.alm.shared.api.utils.collections.ImmutableStrictMap;
+import com.polarion.alm.shared.html.HtmlElement;
 import com.polarion.alm.tracker.model.IModule;
 import com.polarion.alm.tracker.model.IRichPage;
 import com.polarion.alm.tracker.model.ITestRun;
 import com.polarion.alm.tracker.model.IWikiPage;
 import com.polarion.alm.tracker.model.baselinecollection.IBaselineCollection;
+import com.polarion.core.util.StringUtils;
+import com.polarion.portal.internal.shared.navigation.ProjectScope;
 import org.apache.velocity.VelocityContext;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 
 public class VelocityEvaluator {
 
     public @NotNull String evaluateVelocityExpressions(@NotNull DocumentData<? extends IUniqueObject> documentData, @NotNull String template) {
         return ObjectUtils.requireNotNull(TransactionalExecutor.executeSafelyInReadOnlyTransaction(transaction -> {
             RichPageRenderingContextImpl richPageRenderingContext = new RichPageRenderingContextImpl((InternalReadOnlyTransaction) transaction);
+            richPageRenderingContext.setPageParameters(getPageParameters(documentData));
             RichPageScriptRenderer richPageScriptRenderer = new RichPageScriptRenderer(richPageRenderingContext, template, documentData.getId().getDocumentId());
             VelocityContext velocityContext = richPageScriptRenderer.velocityContext();
             updateVelocityContext(velocityContext, documentData);
@@ -58,5 +71,24 @@ public class VelocityEvaluator {
         }
 
         velocityContext.put("projectName", documentData.getId().getDocumentProject() != null ? documentData.getId().getDocumentProject().getName() : "");
+    }
+
+    /**
+     * Extracts page parameters from the document content.
+     * The implementation idea is taken from {@link com.polarion.alm.shared.rpe.RpeRenderer}.
+     */
+    @VisibleForTesting
+    ImmutableStrictMap<String, RichPageParameter> getPageParameters(@NotNull DocumentData<? extends IUniqueObject> documentData) {
+        String content = documentData.getContent();
+        if (StringUtils.isEmpty(content)) {
+            return new ImmutableStrictMap<>();
+        }
+        HtmlFragmentParser fragmentParser = new HtmlFragmentParser(content);
+        HtmlElement htmlElement = HtmlRichPageParameters.findElement(fragmentParser.getHtmlNodes(new ServerHtmlNodeFactory()));
+        if (htmlElement == null) {
+            return new ImmutableStrictMap<>();
+        }
+        Scope scope = new ScopeImpl(new ProjectScope(documentData.getDocumentObject().getProjectId()));
+        return new HtmlRichPageParameters(htmlElement, ServerUiContext.getInstance(), scope).get(null).toImmutable();
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/velocity/VelocityEvaluatorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/velocity/VelocityEvaluatorTest.java
@@ -1,0 +1,128 @@
+package ch.sbb.polarion.extension.pdf_exporter.util.velocity;
+
+import ch.sbb.polarion.extension.pdf_exporter.rest.model.documents.DocumentData;
+import ch.sbb.polarion.extension.pdf_exporter.rest.model.documents.id.DocumentId;
+import com.polarion.alm.projects.model.IUniqueObject;
+import com.polarion.alm.server.html.HtmlFragmentParser;
+import com.polarion.alm.shared.api.model.rp.parameter.RichPageParameter;
+import com.polarion.alm.shared.api.model.rp.parameter.impl.HtmlRichPageParameters;
+import com.polarion.alm.shared.api.utils.collections.ImmutableStrictMap;
+import com.polarion.alm.shared.api.utils.collections.ReadOnlyStrictMap;
+import com.polarion.alm.shared.html.HtmlElement;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings({"unchecked", "rawtypes"})
+class VelocityEvaluatorTest {
+
+    private VelocityEvaluator velocityEvaluator;
+
+    @Mock
+    private DocumentData<IUniqueObject> documentData;
+
+    @Mock
+    private IUniqueObject documentObject;
+
+    @Mock
+    private DocumentId documentId;
+
+    private HtmlElement htmlElement;
+
+    @Mock
+    private ReadOnlyStrictMap readOnlyStrictMap;
+
+    @Mock
+    private ImmutableStrictMap immutableStrictMap;
+
+    private MockedConstruction<HtmlFragmentParser> mockedHtmlFragmentParserConstruction;
+    private MockedConstruction<HtmlRichPageParameters> mockedHtmlRichPageParametersConstruction;
+    private MockedStatic<HtmlRichPageParameters> htmlRichPageParametersMockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        velocityEvaluator = new VelocityEvaluator();
+        lenient().when(documentData.getDocumentObject()).thenReturn(documentObject);
+        lenient().when(documentData.getId()).thenReturn(documentId);
+        lenient().when(readOnlyStrictMap.toImmutable()).thenReturn(immutableStrictMap);
+
+        mockedHtmlFragmentParserConstruction = mockConstruction(HtmlFragmentParser.class, (mock, context) -> {
+        });
+        mockedHtmlRichPageParametersConstruction = mockConstruction(HtmlRichPageParameters.class, (mock, context) -> when(mock.get(isNull())).thenReturn(readOnlyStrictMap));
+
+        htmlRichPageParametersMockedStatic = mockStatic(HtmlRichPageParameters.class);
+        htmlRichPageParametersMockedStatic.when(() -> HtmlRichPageParameters.findElement(any())).thenAnswer((Answer<HtmlElement>) invocationOnMock -> htmlElement);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedHtmlFragmentParserConstruction.close();
+        mockedHtmlRichPageParametersConstruction.close();
+        htmlRichPageParametersMockedStatic.close();
+    }
+
+    @Test
+    void getPageParametersEmptyWhenNoContent() {
+        when(documentData.getContent()).thenReturn("");
+        ImmutableStrictMap<String, RichPageParameter> result = velocityEvaluator.getPageParameters(documentData);
+        assertTrue(result.isEmpty());
+
+        when(documentData.getContent()).thenReturn(null);
+        result = velocityEvaluator.getPageParameters(documentData);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getPageParametersEmptyWhenNullHtmlElement() {
+        when(documentData.getContent()).thenReturn("<div>Some content without parameters</div>");
+        ImmutableStrictMap<String, RichPageParameter> result = velocityEvaluator.getPageParameters(documentData);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getPageParametersReturnsProperMap() {
+        when(documentData.getContent()).thenReturn("<div>Some content</div>");
+        htmlElement = mock(HtmlElement.class);
+        ImmutableStrictMap<String, RichPageParameter> result = velocityEvaluator.getPageParameters(documentData);
+        assertEquals(immutableStrictMap, result);
+    }
+
+//    @Test
+//    void getPageParameters_ValidContentWithParameters_ReturnsParametersMap() {
+//        // This test requires more complex mocking due to static and final methods
+//        // We'll need to use MockedStatic for ServerUiContext and mock the HTML parsing chain
+//
+//        try (MockedStatic<StringUtils> stringUtilsMock = mockStatic(StringUtils.class)) {
+//            // Skip the StringUtils.isEmpty check
+//            stringUtilsMock.when(() -> StringUtils.isEmpty(anyString())).thenReturn(false);
+//
+//            // Set up mock for content with parameters HTML
+//            String contentWithParameters = "<div data-parameters=\"true\">Some content with parameters</div>";
+////            when(documentData.getContent()).thenReturn(contentWithParameters);
+////            when(documentObject.getProjectId()).thenReturn("TEST_PROJECT");
+//
+//            // Use a spy to avoid complex mocking of the HTML parsing chain
+//            VelocityEvaluator spyEvaluator = spy(velocityEvaluator);
+//            ImmutableStrictMap<String, RichPageParameter> mockMap = mock(ImmutableStrictMap.class);
+//            doReturn(mockMap).when(spyEvaluator).getPageParameters(documentData);
+//
+//            // When
+//            ImmutableStrictMap<String, RichPageParameter> result = spyEvaluator.getPageParameters(documentData);
+//
+//            // Then
+//            assertNotNull(result);
+//            assertSame(mockMap, result);
+//        }
+//    }
+}


### PR DESCRIPTION
Refs: #439

### Proposed changes

We have to add the $pageParameters to the evaluation context for header/footer.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
