### PR TITLE
ci: enhance Maven build workflow with caching and artefact management

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -9,6 +9,8 @@ on:
   workflow_dispatch:
 env:
   SETTINGS_XML: ${{ github.workspace }}/.mvn/settings.xml
+  JAVA_VERSION: 17
+  JAVA_DISTRIBUTION: temurin
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,106 +25,123 @@ jobs:
       - name: 📄 Checkout the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0  # Sonar needs full history
           persist-credentials: false
-      - name: 🧱 Set up JDK and Maven
+      - name: 🧱 Set up JDK and Maven with cache
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00  # v4.7.1
         with:
-          distribution: temurin
-          java-version: 17
-      - name: 📝 Get the project version
-        id: project_version
-        run: echo "project_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
-      - name: 📝 Store cache key
-        id: cache_key
-        run: echo "cache_key=${{ runner.os }}-mvn-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}" >> "$GITHUB_OUTPUT"
-      - name: 💾 Prepare cache using cache key
-        id: prepare-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
-        with:
-          path: |
-            /home/runner/.m2
-            /home/runner/work
-          key: ${{ steps.cache_key.outputs.cache_key }}
-      - name: 🔘 Print settings.xml
-        run: cat "${SETTINGS_XML}"
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+      - name: 📝 Extract project metadata and build
+        id: project_metadata
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # Check if it is a release
+          if [[ ! "${VERSION}" =~ -SNAPSHOT$ ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: 📦 Build with Maven for Pushes
         if: github.event_name == 'push'
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
-        run: mvn --batch-mode -s "${SETTINGS_XML}" clean package sonar:sonar -Dsonar.branch.name="${GITHUB_HEAD_REF}"
+        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar -Dsonar.branch.name="${GITHUB_HEAD_REF}"
       - name: 📦 Build with Maven for PRs
         if: github.event_name == 'pull_request'
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_PR_NUMBER_REF: ${{ github.event.pull_request.number }}
-        run: mvn --batch-mode -s "${SETTINGS_XML}" clean package sonar:sonar -Dsonar.pullrequest.base="${GITHUB_HEAD_REF}" -Dsonar.pullrequest.branch="${GITHUB_BASE_REF}" -Dsonar.pullrequest.key="${GITHUB_PR_NUMBER_REF}"
+        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar -Dsonar.pullrequest.base="${GITHUB_HEAD_REF}" -Dsonar.pullrequest.branch="${GITHUB_BASE_REF}" -Dsonar.pullrequest.key="${GITHUB_PR_NUMBER_REF}"
+      - name: 📦 Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: maven-artifacts
+          path: |
+            target/*.jar
+            target/*.pom
+          retention-days: 1
     outputs:
-      project_version: ${{ steps.project_version.outputs.project_version }}
-      cache_key: ${{ steps.cache_key.outputs.cache_key }}
-
-  # Deploy release to Maven Central
+      project_version: ${{ steps.project_metadata.outputs.version }}
+      is_release: ${{ steps.project_metadata.outputs.is_release }}
   deploy-maven-central:
     needs: build
+    if: ${{ needs.build.outputs.is_release == 'true' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: read
-    if: ${{ !endsWith(needs.build.outputs.project_version, '-SNAPSHOT') && github.ref == 'refs/heads/main' }}
     env:
-      IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME }}
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN }}
+      COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_GPG_PRIVATE_KEY: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_GPG_PRIVATE_KEY }}
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_GPG_PASSPHRASE: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_GPG_PASSPHRASE }}
     steps:
-      - name: 🧱 Set up JDK and Maven
+      - name: 📄 Checkout the repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: 📥 Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: maven-artifacts
+      - name: 🧱 Set up JDK and Maven with cache
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00  # v4.7.1
         with:
-          distribution: temurin
-          java-version: 17
-      - name: 💾 Restore cache using cache key
-        id: restore-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
-        with:
-          path: |
-            /home/runner/.m2
-            /home/runner/work
-          key: ${{ needs.build.outputs.cache_key }}
-      - name: 📦 Deploy artifacts to Maven Central
-        run: mvn --batch-mode -s "${SETTINGS_XML}" -Dmaven.test.skip=true deploy -P gpg-sign -P central-publishing
-
-  # Deploy releases and snapshots for main branch to GitHub Packages
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+          gpg-private-key: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_GPG_PRIVATE_KEY }}
+      - name: 📦 Deploy to Maven Central
+        run: |
+          mvn --batch-mode -s "${SETTINGS_XML}" deploy \
+            -Dmaven.test.skip=true \
+            -Dmaven.main.skip=true \
+            -Dmaven.javadoc.skip=true \
+            -Dmaven.source.skip=true \
+            -P gpg-sign \
+            -P central-publishing
   deploy-github-packages:
     needs: build
-    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
     env:
-      IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
       GITHUB_TOKEN: ${{ github.token }}
       GITHUB_REPO_NAME: ${{ github.repository }}
     steps:
-      - name: 🧱 Set up JDK and Maven
+      - name: 📄 Checkout the repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: 📥 Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: maven-artifacts
+      - name: 🧱 Set up JDK and Maven with cache
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00  # v4.7.1
         with:
-          distribution: temurin
-          java-version: 17
-      - name: 💾 Restore cache using cache key
-        id: restore-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
-        with:
-          path: |
-            /home/runner/.m2
-            /home/runner/work
-          key: ${{ needs.build.outputs.cache_key }}
-      - name: 📦 Deploy artifacts to GitHub Packages
-        run: mvn --batch-mode -s "${SETTINGS_XML}" -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true deploy -P deploy-github-packages
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+      - name: 📦 Deploy to GitHub Packages
+        run: |
+          mvn --batch-mode -s "${SETTINGS_XML}" deploy \
+            -Dmaven.test.skip=true \
+            -Dmaven.main.skip=true \
+            -Dmaven.javadoc.skip=true \
+            -Dmaven.source.skip=true \
+            -P deploy-github-packages
       - name: 📦 Upload assets to GitHub Release
+        if: ${{ needs.build.outputs.is_release == 'true' }}
         env:
           RELEASE_VERSION: ${{ needs.build.outputs.project_version }}
-        if: ${{ !endsWith(env.RELEASE_VERSION, '-SNAPSHOT') }}
         run: |-
           gh release upload "v${RELEASE_VERSION}" "target/*-${RELEASE_VERSION}.jar" --clobber

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -17,46 +17,68 @@ jobs:
     permissions:
       contents: read
       packages: read
+    outputs:
+      project_version: ${{ steps.project_metadata.outputs.version }}
+      is_release: ${{ steps.project_metadata.outputs.is_release }}
     env:
       IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR: true
+      GITHUB_TOKEN: ${{ github.token }}  # providing this prevent from reaching GitHub requests limit
     steps:
       - name: 📄 Checkout the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0  # Sonar needs full history
           persist-credentials: false
-      - name: 🧱 Set up JDK and Maven with cache
+      - name: 🧱 Set up JDK and Maven
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00  # v4.7.1
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
-      - name: 📝 Extract project metadata and build
+      - name: 📝 Extract project metadata
         id: project_metadata
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           # Check if it is a release
           if [[ ! "${VERSION}" =~ -SNAPSHOT$ ]]; then
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            IS_RELEASE=true
           else
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            IS_RELEASE=false
           fi
+          {
+            echo "version=${VERSION}"
+            echo "is_release=${IS_RELEASE}"
+          } >> "$GITHUB_OUTPUT"
+      - name: 🔍 Cache SonarQube packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
       - name: 📦 Build with Maven for Pushes
         if: github.event_name == 'push'
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
-        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar -Dsonar.branch.name="${GITHUB_HEAD_REF}"
+        run: |
+          if [ -n "${GITHUB_HEAD_REF}" ]; then
+            mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar -Dsonar.branch.name="${GITHUB_HEAD_REF}"
+          else
+            mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar
+          fi
       - name: 📦 Build with Maven for PRs
         if: github.event_name == 'pull_request'
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_PR_NUMBER_REF: ${{ github.event.pull_request.number }}
-        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar -Dsonar.pullrequest.base="${GITHUB_HEAD_REF}" -Dsonar.pullrequest.branch="${GITHUB_BASE_REF}" -Dsonar.pullrequest.key="${GITHUB_PR_NUMBER_REF}"
+        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify sonar:sonar -Dsonar.pullrequest.base="${GITHUB_BASE_REF}" -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" -Dsonar.pullrequest.key="${GITHUB_PR_NUMBER_REF}"
+      - name: 📋 Analyze dependencies
+        run: mvn --batch-mode -s "${SETTINGS_XML}" dependency:analyze
+        continue-on-error: false
       - name: 📦 Upload build artifacts
+        # needed for uploads to Github Releases
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: maven-artifacts
@@ -64,9 +86,7 @@ jobs:
             target/*.jar
             target/*.pom
           retention-days: 1
-    outputs:
-      project_version: ${{ steps.project_metadata.outputs.version }}
-      is_release: ${{ steps.project_metadata.outputs.is_release }}
+          if-no-files-found: error
   deploy-maven-central:
     needs: build
     if: ${{ needs.build.outputs.is_release == 'true' && github.ref == 'refs/heads/main' }}
@@ -77,18 +97,14 @@ jobs:
     env:
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME }}
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN }}
-      COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_GPG_PRIVATE_KEY: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_GPG_PRIVATE_KEY }}
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_GPG_PASSPHRASE: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_GPG_PASSPHRASE }}
+      GITHUB_TOKEN: ${{ github.token }}  # providing this prevent from reaching GitHub requests limit
     steps:
       - name: 📄 Checkout the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
           persist-credentials: false
-      - name: 📥 Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
-        with:
-          name: maven-artifacts
       - name: 🧱 Set up JDK and Maven with cache
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00  # v4.7.1
         with:
@@ -98,13 +114,13 @@ jobs:
           gpg-private-key: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_GPG_PRIVATE_KEY }}
       - name: 📦 Deploy to Maven Central
         run: |
-          mvn --batch-mode -s "${SETTINGS_XML}" deploy \
+          # it cannot be implemented using deploy:deploy-file
+          # central-publishing-maven-plugin needs to be used instead due to a specific deployment
+          mvn --batch-mode -s "${SETTINGS_XML}" clean deploy \
             -Dmaven.test.skip=true \
-            -Dmaven.main.skip=true \
-            -Dmaven.javadoc.skip=true \
-            -Dmaven.source.skip=true \
             -P gpg-sign \
-            -P central-publishing
+            -P central-publishing \
+            -Dcentral.timeout=3600
   deploy-github-packages:
     needs: build
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -115,6 +131,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       GITHUB_REPO_NAME: ${{ github.repository }}
+      PROJECT_VERSION: ${{ needs.build.outputs.project_version }}
     steps:
       - name: 📄 Checkout the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -122,26 +139,28 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 📥 Download build artifacts
+        # needed for uploads to GitHub Releases
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: maven-artifacts
-      - name: 🧱 Set up JDK and Maven with cache
+          path: target/
+      - name: 🧱 Set up JDK and Maven
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00  # v4.7.1
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
       - name: 📦 Deploy to GitHub Packages
+        # Releases should be only deployed to GitHub packages when the repo is private
+        # only snapshots must be always deployed here
+        if: ${{ needs.build.outputs.is_release == 'false' }}
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" deploy \
             -Dmaven.test.skip=true \
-            -Dmaven.main.skip=true \
             -Dmaven.javadoc.skip=true \
             -Dmaven.source.skip=true \
             -P deploy-github-packages
       - name: 📦 Upload assets to GitHub Release
         if: ${{ needs.build.outputs.is_release == 'true' }}
-        env:
-          RELEASE_VERSION: ${{ needs.build.outputs.project_version }}
         run: |-
-          gh release upload "v${RELEASE_VERSION}" "target/*-${RELEASE_VERSION}.jar" --clobber
+          gh release upload "v${PROJECT_VERSION}" "target/*-${PROJECT_VERSION}.jar" --clobber

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -22,7 +22,7 @@
         <profile>
             <id>deploy-github-packages</id>
             <properties>
-                <altDeploymentRepository>github::default::https://maven.pkg.github.com/${env.GITHUB_REPO_NAME}</altDeploymentRepository>
+                <altDeploymentRepository>github::https://maven.pkg.github.com/${env.GITHUB_REPO_NAME}</altDeploymentRepository>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
This pull request updates the Maven build workflow and configuration to improve caching, artifact handling, and deployment processes. Key changes include streamlining the setup for Java and Maven, enhancing artifact management, and refining deployment logic for Maven Central and GitHub Packages.

### Workflow Enhancements:
* [`.github/workflows/maven-build.yml`](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2R12-R13): Added environment variables `JAVA_VERSION` and `JAVA_DISTRIBUTION` for dynamic Java setup, and switched `fetch-depth` to `0` to support Sonar analysis requiring full history. [[1]](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2R12-R13) [[2]](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2L26-L126)
* [`.github/workflows/maven-build.yml`](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2L26-L126): Simplified the Java and Maven setup by enabling built-in caching and removed redundant manual cache handling.

### Artifact Management:
* [`.github/workflows/maven-build.yml`](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2L26-L126): Added steps to upload and download build artifacts, improving the workflow for sharing artifacts between jobs.

### Deployment Refinements:
* [`.github/workflows/maven-build.yml`](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2L26-L126): Updated deployment logic to Maven Central and GitHub Packages, including dynamic checks for release versions and enhanced signing support using GPG keys.
* [`.mvn/settings.xml`](diffhunk://#diff-26a423ee4ab410cae36064fdabb68102eb9bb47c90297b82f8f129278dd8e18fL25-R25): Modified the `altDeploymentRepository` property for GitHub Packages deployment to remove the `default` keyword.


### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
