### PR TITLE
feat: include meta data in generated PDF

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1828,6 +1828,14 @@
             "description": "Referenced work items should be marked in the document",
             "type": "boolean"
           },
+          "metadataFields": {
+            "description": "CSV list of document field names or wildcard patterns to be exported as HTML meta (LiveDoc only)",
+            "items": {
+              "description": "CSV list of document field names or wildcard patterns to be exported as HTML meta (LiveDoc only)",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "numberedListStyles": {
             "description": "SCC styles to be applied to numbered lists in the document",
             "type": "string"

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <tika.version>1.28.5</tika.version>
         <cssparser.version>0.9.30</cssparser.version>
+        <commons-text.version>1.14.0</commons-text.version>
 
         <maven-jar-plugin.Extension-Context>pdf-exporter</maven-jar-plugin.Extension-Context>
         <maven-jar-plugin.Automatic-Module-Name>ch.sbb.polarion.extension.pdf_exporter</maven-jar-plugin.Automatic-Module-Name>
@@ -79,6 +80,7 @@
         <!--suppress UnresolvedMavenProperty -->
         <skipJavaScriptTests>${skipTests}</skipJavaScriptTests>
     </properties>
+
 
     <profiles>
         <profile>
@@ -174,6 +176,11 @@
             <groupId>net.sourceforge.cssparser</groupId>
             <artifactId>cssparser</artifactId>
             <version>${cssparser.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons-text.version}</version>
         </dependency>
 
         <!--  Test dependencies  -->

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/PdfExportFunction.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/PdfExportFunction.java
@@ -128,6 +128,7 @@ public class PdfExportFunction implements IFunction<IModule> {
                 .followHTMLPresentationalHints(stylePackage.isFollowHTMLPresentationalHints())
                 .numberedListStyles(stylePackage.getCustomNumberedListStyles())
                 .chapters(stylePackage.getSpecificChapters() == null ? null : List.of(stylePackage.getSpecificChapters().split(",")))
+                .metadataFields(stylePackage.getMetadataFields() == null ? null : List.of(stylePackage.getMetadataFields().split(",")))
                 .language(stylePackage.getLanguage())
                 .linkedWorkitemRoles(stylePackage.getLinkedWorkitemRoles())
                 .attachmentsFilter(stylePackage.getAttachmentsFilter())

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/PdfExporterFormExtension.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/PdfExporterFormExtension.java
@@ -101,6 +101,7 @@ public class PdfExporterFormExtension implements IFormExtension {
             form = adjustPresentationalHints(form, selectedStylePackage);
             form = adjustCustomNumberedListsStyles(form, selectedStylePackage);
             form = adjustChapters(form, selectedStylePackage);
+            form = adjustMetadataFields(form, selectedStylePackage);
             form = adjustLocalizeEnums(form, selectedStylePackage, module.getCustomField(DOC_LANGUAGE_FIELD));
             form = adjustLinkRoles(form, EnumValuesProvider.getAllLinkRoleNames(module.getProject()), selectedStylePackage);
             form = adjustFilename(form, module);
@@ -263,6 +264,14 @@ public class PdfExporterFormExtension implements IFormExtension {
         if (!StringUtils.isEmpty(stylePackage.getSpecificChapters())) {
             form = form.replace("<input id='specific-chapters'", "<input id='specific-chapters' checked");
             form = form.replace("<input id='chapters' style='display: none;", String.format("<input id='chapters' value='%s' style='", stylePackage.getSpecificChapters()));
+        }
+        return form;
+    }
+
+    private String adjustMetadataFields(String form, StylePackageModel stylePackage) {
+        if (!StringUtils.isEmpty(stylePackage.getMetadataFields())) {
+            form = form.replace("<input id='metadata-fields'", "<input id='metadata-fields' checked");
+            form = form.replace("<input id='metadata-fields-input' style='display: none;", String.format("<input id='metadata-fields-input' value='%s' style='", stylePackage.getMetadataFields()));
         }
         return form;
     }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessor.java
@@ -52,13 +52,11 @@ public class CoverPageProcessor {
     }
 
     @SneakyThrows
-    public byte[] generatePdfWithTitle(DocumentData<? extends IUniqueObject> documentData, ExportParams exportParams,
-                                       String contentHtml, PdfGenerationLog generationLog) {
-        WeasyPrintOptions weasyPrintOptions = WeasyPrintOptions.builder()
-                .followHTMLPresentationalHints(exportParams.isFollowHTMLPresentationalHints())
-                .pdfVariant(exportParams.getPdfVariant())
-                .build();
-
+    public byte[] generatePdfWithTitle(DocumentData<? extends IUniqueObject> documentData,
+                                       ExportParams exportParams,
+                                       String contentHtml,
+                                       WeasyPrintOptions weasyPrintOptions,
+                                       PdfGenerationLog generationLog) {
         generationLog.log("Starting generation for document content...");
         byte[] pdfContent = weasyPrintServiceConnector.convertToPdf(contentHtml, weasyPrintOptions);
         generationLog.log("Document content has been completed");

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverter.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverter.java
@@ -41,6 +41,7 @@ import com.polarion.core.util.StringUtils;
 import com.polarion.core.util.logging.Logger;
 import com.polarion.platform.internal.security.UserAccountVault;
 import lombok.AllArgsConstructor;
+import org.apache.commons.text.StringEscapeUtils;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -348,9 +349,9 @@ public class PdfConverter {
             if (!value.isEmpty()) {
                 result
                         .append("<meta name=\"")
-                        .append(escapeHtmlAttr(metadataField))
+                        .append(StringEscapeUtils.escapeHtml4(metadataField))
                         .append("\" content=\"")
-                        .append(escapeHtmlAttr(value))
+                        .append(StringEscapeUtils.escapeHtml4(value))
                         .append("\"/>");
             }
         }
@@ -358,33 +359,6 @@ public class PdfConverter {
             return "<!--" + CUSTOM_METADATA_TAG + "-->" + result + "<!--/" + CUSTOM_METADATA_TAG + "-->";
         }
         return "";
-    }
-
-    private static String escapeHtmlAttr(String input) {
-        if (input == null || input.isEmpty()) {
-            return "";
-        }
-
-        StringBuilder sb = new StringBuilder(input.length() * 2);
-        for (int i = 0; i < input.length(); i++) {
-            char c = input.charAt(i);
-            switch (c) {
-                case '&' -> sb.append("&amp;");
-                case '<' -> sb.append("&lt;");
-                case '>' -> sb.append("&gt;");
-                case '"' -> sb.append("&quot;");
-                case '\'' -> sb.append("&#39;"); // safer than &apos; for HTML
-                default -> {
-                    // control chars: escape everything under 0x20 except tab, newline, carriage return
-                    if (c < 0x20 && c != '\t' && c != '\n' && c != '\r') {
-                        sb.append("&#").append((int) c).append(';');
-                    } else {
-                        sb.append(c);
-                    }
-                }
-            }
-        }
-        return sb.toString();
     }
 
     record HtmlData(String cssContent, String documentContent, String headerFooterContent) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/conversion/ExportParams.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/conversion/ExportParams.java
@@ -75,6 +75,9 @@ public class ExportParams extends ConversionParams {
     @Schema(description = "Specific higher level chapters")
     private List<String> chapters;
 
+    @Schema(description = "CSV list of document field names or wildcard patterns to be exported as HTML meta (LiveDoc only)")
+    private List<String> metadataFields;
+
     @Schema(description = "Language in the exported document")
     private String language;
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/settings/stylepackage/StylePackageModel.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/settings/stylepackage/StylePackageModel.java
@@ -48,6 +48,7 @@ public class StylePackageModel extends SettingsModel {
     private static final String CUT_LOCAL_URLS_ENTRY_NAME= "CUT LOCAL URLS";
     private static final String FOLLOW_HTML_PRESENTATIONAL_HINTS_ENTRY_NAME = "FOLLOW HTML PRESENTATIONAL HINTS";
     private static final String SPECIFIC_CHAPTERS_ENTRY_NAME = "SPECIFIC CHAPTERS";
+    private static final String METADATA_FIELDS_ENTRY_NAME = "METADATA FIELDS";
     private static final String TESTCASE_FIELD_ID_ENTRY_NAME = "TESTCASE FILTER ATTACHMENTS FIELD ID";
     private static final String CUSTOM_NUMBERED_LIST_STYLES_ENTRY_NAME = "CUSTOM NUMBERED LIST STYLES";
     private static final String LANGUAGE_ENTRY_NAME = "LANGUAGE";
@@ -76,6 +77,7 @@ public class StylePackageModel extends SettingsModel {
     private boolean cutLocalURLs;
     private boolean followHTMLPresentationalHints;
     private String specificChapters;
+    private String metadataFields;
     private String customNumberedListStyles;
     private String language;
     private List<String> linkedWorkitemRoles;
@@ -106,6 +108,7 @@ public class StylePackageModel extends SettingsModel {
                 serializeEntry(CUT_LOCAL_URLS_ENTRY_NAME, cutLocalURLs) +
                 serializeEntry(FOLLOW_HTML_PRESENTATIONAL_HINTS_ENTRY_NAME, followHTMLPresentationalHints) +
                 serializeEntry(SPECIFIC_CHAPTERS_ENTRY_NAME, specificChapters) +
+                serializeEntry(METADATA_FIELDS_ENTRY_NAME, metadataFields) +
                 serializeEntry(CUSTOM_NUMBERED_LIST_STYLES_ENTRY_NAME, customNumberedListStyles) +
                 serializeEntry(LANGUAGE_ENTRY_NAME, language) +
                 serializeEntry(LINKED_WORKITEM_ROLES_ENTRY_NAME, linkedWorkitemRoles) +
@@ -138,6 +141,7 @@ public class StylePackageModel extends SettingsModel {
         cutLocalURLs = Boolean.parseBoolean(deserializeEntry(CUT_LOCAL_URLS_ENTRY_NAME, serializedString));
         followHTMLPresentationalHints = Boolean.parseBoolean(deserializeEntry(FOLLOW_HTML_PRESENTATIONAL_HINTS_ENTRY_NAME, serializedString));
         specificChapters = deserializeEntry(SPECIFIC_CHAPTERS_ENTRY_NAME, serializedString);
+        metadataFields = deserializeEntry(METADATA_FIELDS_ENTRY_NAME, serializedString);
         customNumberedListStyles = deserializeEntry(CUSTOM_NUMBERED_LIST_STYLES_ENTRY_NAME, serializedString);
         language = deserializeEntry(LANGUAGE_ENTRY_NAME, serializedString);
         linkedWorkitemRoles = deserializeListEntry(LINKED_WORKITEM_ROLES_ENTRY_NAME, serializedString, String.class);

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfTemplateProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfTemplateProcessor.java
@@ -19,6 +19,10 @@ public class PdfTemplateProcessor {
 
     @NotNull
     public String processUsing(@NotNull ExportParams exportParams, @NotNull String documentName, @NotNull String css, @NotNull String content) {
+        return processUsing(exportParams, documentName, css, content, "");
+    }
+
+    public String processUsing(@NotNull ExportParams exportParams, @NotNull String documentName, @NotNull String css, @NotNull String content, @NotNull String metaTags) {
         css += buildSizeCss(exportParams.getOrientation(), exportParams.getPaperSize());
 
         if (exportParams.isMarkReferencedWorkitems()) {
@@ -43,7 +47,8 @@ public class PdfTemplateProcessor {
                 .replace("{BASE_URL}", buildBaseUrlHeader())
                 .replace("{CSS}", css)
                 .replace("{BODY_CLASS}", exportParams.isWatermark() ? "watermark" : "")
-                .replace("{DOC_CONTENT}", content);
+                .replace("{DOC_CONTENT}", content)
+                .replace("{META_TAGS}", metaTags);
     }
 
     public String buildSizeCss(Orientation orientation, PaperSize paperSize) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PolarionTypes.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PolarionTypes.java
@@ -1,0 +1,88 @@
+package ch.sbb.polarion.extension.pdf_exporter.util;
+
+import com.polarion.alm.projects.model.IUser;
+import com.polarion.alm.tracker.internal.model.TypeOpt;
+import com.polarion.core.util.types.Currency;
+import com.polarion.core.util.types.DateOnly;
+import com.polarion.core.util.types.Text;
+import com.polarion.core.util.types.TimeOnly;
+import com.polarion.platform.persistence.IEnumOption;
+import com.polarion.platform.persistence.spi.CustomTypedList;
+import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+
+@UtilityClass
+public class PolarionTypes {
+
+    public @NotNull String convertFieldValueToString(@Nullable Object fieldValue) {
+        Locale locale = Locale.getDefault();
+        TimeZone timeZone = TimeZone.getDefault();
+        return convertFieldValueToString(fieldValue, locale, timeZone);
+    }
+
+    public @NotNull String convertFieldValueToString(@Nullable Object fieldValue, @NotNull Locale locale, @NotNull TimeZone timeZone) {
+        if (fieldValue instanceof CustomTypedList customTypedList) {
+            return convertListToString(customTypedList, locale, timeZone);
+        } else {
+            return convertSingleFieldValueToString(fieldValue, locale, timeZone);
+        }
+    }
+
+    public @NotNull String convertSingleFieldValueToString(@Nullable Object fieldValue, @NotNull Locale locale, @NotNull TimeZone timeZone) {
+        if (fieldValue == null) {
+            return "";
+        }
+
+        if (fieldValue instanceof TypeOpt typeOpt) {
+            return typeOpt.getName();
+        } else if (fieldValue instanceof Text text) {
+            return text.convertToHTML().getContent();
+        } else if (fieldValue instanceof DateOnly dateOnly) {
+            return DateFormat.getDateInstance(DateFormat.LONG, locale).format(dateOnly.getDate());
+        } else if (fieldValue instanceof TimeOnly timeOnly) {
+            return convertToTime(timeOnly.getDate(), locale, timeZone);
+        } else if (fieldValue instanceof Date date) {
+            return convertToDateTime(date, locale, timeZone);
+        } else if (fieldValue instanceof Currency currency) {
+            return currency.getValue().toString();
+        } else if (fieldValue instanceof IEnumOption enumOption) {
+            return enumOption.getName() != null ? enumOption.getName() : enumOption.getId();
+        } else if (fieldValue instanceof IUser user) {
+            return user.getLabel();
+        }
+
+        return fieldValue.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public @NotNull String convertListToString(@NotNull CustomTypedList list, @NotNull Locale locale, @NotNull TimeZone timeZone) {
+        return (String) list.stream()
+                .map(n -> convertFieldValueToString(n, locale, timeZone))
+                .collect(Collectors.joining(", "));
+    }
+
+    public @NotNull String convertToTime(@NotNull Date fieldValue, @NotNull Locale locale, @NotNull TimeZone timeZone) {
+        DateFormat timeFormat = DateFormat.getTimeInstance(DateFormat.LONG, locale);
+        return formatForTimeZone(fieldValue, timeFormat, timeZone);
+    }
+
+    public @NotNull String convertToDateTime(@NotNull Date fieldValue, @NotNull Locale locale, @NotNull TimeZone timeZone) {
+        DateFormat dateTimeFormat = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG, locale);
+        return formatForTimeZone(fieldValue, dateTimeFormat, timeZone);
+    }
+
+    public @NotNull String formatForTimeZone(@NotNull Date fieldValue, @NotNull DateFormat format, @NotNull TimeZone timeZone) {
+        if (timeZone != null) {
+            format.setTimeZone(timeZone);
+        }
+        return format.format(fieldValue);
+    }
+
+}

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PolarionTypes.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PolarionTypes.java
@@ -79,9 +79,7 @@ public class PolarionTypes {
     }
 
     public @NotNull String formatForTimeZone(@NotNull Date fieldValue, @NotNull DateFormat format, @NotNull TimeZone timeZone) {
-        if (timeZone != null) {
-            format.setTimeZone(timeZone);
-        }
+        format.setTimeZone(timeZone);
         return format.format(fieldValue);
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/WeasyPrintOptions.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/WeasyPrintOptions.java
@@ -6,9 +6,10 @@ import lombok.Builder;
 @Builder
 public record WeasyPrintOptions(
         boolean followHTMLPresentationalHints,
-        PdfVariant pdfVariant
+        PdfVariant pdfVariant,
+        boolean customMetadata
 ) {
     public WeasyPrintOptions() {
-        this(false, PdfVariant.PDF_A_2B);
+        this(false, PdfVariant.PDF_A_2B, false);
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/service/WeasyPrintServiceConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/service/WeasyPrintServiceConnector.java
@@ -51,7 +51,8 @@ public class WeasyPrintServiceConnector implements WeasyPrintConverter {
             client = ClientBuilder.newClient();
             WebTarget webTarget = client.target(getWeasyPrintServiceBaseUrl() + "/convert/html")
                     .queryParam("presentational_hints", weasyPrintOptions.followHTMLPresentationalHints())
-                    .queryParam("pdf_variant", weasyPrintOptions.pdfVariant().toWeasyPrintParameter());
+                    .queryParam("pdf_variant", weasyPrintOptions.pdfVariant().toWeasyPrintParameter())
+                    .queryParam("custom_metadata", weasyPrintOptions.customMetadata());
 
             try (Response response = webTarget.request("application/pdf").post(Entity.entity(htmlPage, MediaType.TEXT_HTML))) {
                 if (response.getStatus() == Response.Status.OK.getStatusCode()) {

--- a/src/main/resources/webapp/pdf-exporter-admin/js/modules/style-packages.js
+++ b/src/main/resources/webapp/pdf-exporter-admin/js/modules/style-packages.js
@@ -228,6 +228,7 @@ function saveStylePackage() {
             'cutLocalURLs': ctx.getCheckboxValueById('cut-urls'),
             'followHTMLPresentationalHints': ctx.getCheckboxValueById('presentational-hints'),
             'specificChapters': ctx.getCheckboxValueById('specific-chapters') ? ctx.getValueById('chapters') : null,
+            'metadataFields': ctx.getCheckboxValueById('metadata-fields') ? ctx.getValueById('metadata-fields-input') : null,
             'customNumberedListStyles': ctx.getCheckboxValueById('custom-list-styles') ? ctx.getValueById('numbered-list-styles') : null,
             'language': ctx.getCheckboxValueById('localization') ? Languages.languageSelect.getSelectedValue() : null,
             'linkedWorkitemRoles': ctx.getCheckboxValueById('selected-roles') ? LinkRoles.rolesSelect.getSelectedValue() : null,
@@ -299,9 +300,17 @@ function setStylePackage(content) {
     ctx.setCheckboxValueById('cut-urls', stylePackage.cutLocalURLs);
     ctx.setCheckboxValueById('presentational-hints', stylePackage.followHTMLPresentationalHints);
 
+    ctx.setCheckboxValueById('metadata-fields', !!stylePackage.metadataFields);
+    ctx.getElementById('metadata-fields').dispatchEvent(new Event('change'));
+    ctx.setValueById('metadata-fields-input', stylePackage.metadataFields || "");
+
     ctx.setCheckboxValueById('specific-chapters', !!stylePackage.specificChapters);
     ctx.getElementById('specific-chapters').dispatchEvent(new Event('change'));
     ctx.setValueById('chapters', stylePackage.specificChapters || "");
+
+    ctx.setCheckboxValueById('metadata-fields', !!stylePackage.metadataFields);
+    ctx.getElementById('metadata-fields').dispatchEvent(new Event('change'));
+    ctx.setValueById('metadata-fields-input', stylePackage.metadataFields || "");
 
     ctx.setCheckboxValueById('custom-list-styles', !!stylePackage.customNumberedListStyles);
     ctx.getElementById('custom-list-styles').dispatchEvent(new Event('change'));

--- a/src/main/resources/webapp/pdf-exporter-admin/js/modules/style-packages.js
+++ b/src/main/resources/webapp/pdf-exporter-admin/js/modules/style-packages.js
@@ -300,10 +300,6 @@ function setStylePackage(content) {
     ctx.setCheckboxValueById('cut-urls', stylePackage.cutLocalURLs);
     ctx.setCheckboxValueById('presentational-hints', stylePackage.followHTMLPresentationalHints);
 
-    ctx.setCheckboxValueById('metadata-fields', !!stylePackage.metadataFields);
-    ctx.getElementById('metadata-fields').dispatchEvent(new Event('change'));
-    ctx.setValueById('metadata-fields-input', stylePackage.metadataFields || "");
-
     ctx.setCheckboxValueById('specific-chapters', !!stylePackage.specificChapters);
     ctx.getElementById('specific-chapters').dispatchEvent(new Event('change'));
     ctx.setValueById('chapters', stylePackage.specificChapters || "");

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
@@ -251,7 +251,14 @@
                         <input id='specific-chapters' onchange='document.getElementById("chapters").style.visibility = this.checked ? "visible" : "hidden"' type='checkbox'/>
                         Specific higher level chapters
                     </label>
-                    <input id='chapters' placeholder='eg. 1,2,4 etc.' type='text' style="visibility: hidden; margin-left: 10px; width: 117px"/>
+                    <input id='chapters' placeholder='eg. 1,2,4 etc.' type='text' style="visibility: hidden; margin-left: 10px; width: 202px"/>
+                </div>
+                <div class='checkbox input-group'>
+                    <label for='metadata-fields'>
+                        <input id='metadata-fields' onchange='document.getElementById("metadata-fields-input").style.visibility = this.checked ? "visible" : "hidden"' type='checkbox'/>
+                        Metadata fields
+                    </label>
+                    <input id='metadata-fields-input' placeholder='e.g. docOwner, docLanguage, customField*' type='text' style='visibility: hidden; margin-left: 10px; width: 280px'/>
                 </div>
             </div>
             <div class="flex-column">

--- a/src/main/resources/webapp/pdf-exporter/html/pdfTemplate.html
+++ b/src/main/resources/webapp/pdf-exporter/html/pdfTemplate.html
@@ -9,6 +9,7 @@
     <style>
         {CSS}
     </style>
+    {META_TAGS}
 </head>
 <body class="{BODY_CLASS}">
 {DOC_CONTENT}

--- a/src/main/resources/webapp/pdf-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/pdf-exporter/html/popupForm.html
@@ -184,7 +184,14 @@
                         <input id='popup-specific-chapters' onchange='document.getElementById("popup-chapters").style.visibility = this.checked ? "visible" : "hidden"' type='checkbox'/>
                         Specific higher level chapters
                     </label>
-                    <input id='popup-chapters' placeholder='eg. 1,2,4 etc.' style='width: 101px' type='text'/>
+                    <input id='popup-chapters' placeholder='eg. 1,2,4 etc.' style='width: 122px' type='text'/>
+                </div>
+                <div class='property-wrapper hidden visible-for-LIVE_DOC'>
+                    <label for='popup-metadata-fields'>
+                        <input id='popup-metadata-fields' onchange='document.getElementById("popup-metadata-fields-input").style.visibility = this.checked ? "visible" : "hidden"' type='checkbox'/>
+                        Metadata fields
+                    </label>
+                    <input id='popup-metadata-fields-input' placeholder='e.g. docOwner, docLanguage, customField*' style='width: 200px' type='text'/>
                 </div>
             </div>
             <div class="flex-column">

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -153,11 +153,11 @@
             <input id='chapters' style='display: none; width: 200px' placeholder='eg. 1,2,4 etc.' type='text'/>
         </div>
         <div class='property-wrapper'>
-            <label for='metadata-fields' style='width: 195px'>
+            <label for='metadata-fields' style='width: 115px'>
                 <input id='metadata-fields' onchange='document.querySelector("#pdf-exporter-panel #metadata-fields-input").style.display = this.checked ? "block" : "none"' type='checkbox'/>
                 Metadata fields
             </label>
-            <input id='metadata-fields-input' style='display: none; width: 200px' placeholder='e.g. docOwner, docLanguage, customField*' type='text'/>
+            <input id='metadata-fields-input' style='display: none; width: 280px' placeholder='e.g. docOwner, docLanguage, customField*' type='text'/>
         </div>
         <div class='property-wrapper'>
             <label for='custom-list-styles' style='width: 210px'>

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -150,7 +150,14 @@
                 <input id='specific-chapters' onchange='document.querySelector("#pdf-exporter-panel #chapters").style.display = this.checked ? "block" : "none"' type='checkbox'/>
                 Specific higher level chapters
             </label>
-            <input id='chapters' style='display: none; width: 100px' placeholder='eg. 1,2,4 etc.' type='text'/>
+            <input id='chapters' style='display: none; width: 200px' placeholder='eg. 1,2,4 etc.' type='text'/>
+        </div>
+        <div class='property-wrapper'>
+            <label for='metadata-fields' style='width: 195px'>
+                <input id='metadata-fields' onchange='document.querySelector("#pdf-exporter-panel #metadata-fields-input").style.display = this.checked ? "block" : "none"' type='checkbox'/>
+                Metadata fields
+            </label>
+            <input id='metadata-fields-input' style='display: none; width: 200px' placeholder='e.g. docOwner, docLanguage, customField*' type='text'/>
         </div>
         <div class='property-wrapper'>
             <label for='custom-list-styles' style='width: 210px'>

--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportPanel.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportPanel.js
@@ -124,7 +124,7 @@ export default class ExportPanel {
             selectedChapters = this.getSelectedChapters();
             this.setClass("chapters", selectedChapters ? "" : "error");
             if (!selectedChapters) {
-                this.ctx.getJQueryElement("#export-error").append("Please, provide comma separated list of integer values in chapters field");
+                this.ctx.getJQueryElement("#export-error").append("Please, provide comma separated list of integer values in 'Specific higher level chapters' field");
                 return undefined;
             }
         }
@@ -134,7 +134,7 @@ export default class ExportPanel {
             selectedMetadataFields = this.getSelectedMetadataFields();
             this.setClass("metadata-fields-input", selectedMetadataFields ? "" : "error");
             if (!selectedMetadataFields) {
-                this.ctx.getJQueryElement("#export-error").append("Please, provide comma separated list of values in metadatas field");
+                this.ctx.getJQueryElement("#export-error").append("Please, provide comma separated list of values in 'Metadata fields' field");
                 return undefined;
             }
         }

--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportParams.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportParams.js
@@ -66,6 +66,7 @@ export default class ExportParams {
         this.followHTMLPresentationalHints = builder.followHTMLPresentationalHints;
         this.numberedListStyles = builder.numberedListStyles;
         this.chapters = builder.chapters;
+        this.metadataFields = builder.metadataFields;
         this.language = builder.language;
         this.linkedWorkitemRoles = builder.linkedWorkitemRoles;
         this.fileName = builder.fileName;
@@ -118,6 +119,7 @@ export default class ExportParams {
                 this.followHTMLPresentationalHints = undefined;
                 this.numberedListStyles = undefined;
                 this.chapters = undefined;
+                this.metadataFields = undefined;
                 this.language = undefined;
                 this.linkedWorkitemRoles = undefined;
                 this.fileName = undefined;
@@ -239,6 +241,11 @@ export default class ExportParams {
 
             setChapters(chapters) {
                 this.chapters = chapters;
+                return this;
+            }
+
+            setMetadataFields(metadataFields) {
+                this.metadataFields = metadataFields;
                 return this;
             }
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessorTest.java
@@ -71,7 +71,7 @@ class CoverPageProcessorTest {
         when(weasyPrintServiceConnector.convertToPdf(eq("test content"), any(WeasyPrintOptions.class))).thenReturn(createEmptyPdf(3));
 
         // Act
-        byte[] result = coverPageProcessor.generatePdfWithTitle(documentData, exportParams, "test content", new PdfGenerationLog());
+        byte[] result = coverPageProcessor.generatePdfWithTitle(documentData, exportParams, "test content", new WeasyPrintOptions(), new PdfGenerationLog());
 
         // Assert
         try (PDDocument document = Loader.loadPDF(result)) {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterTest.java
@@ -110,7 +110,7 @@ class PdfConverterTest {
         when(placeholderProcessor.replacePlaceholders(documentData, exportParams, "test css")).thenReturn("css content");
         when(placeholderProcessor.replacePlaceholders(eq(documentData), eq(exportParams), anyList())).thenReturn(List.of("hl", "hc", "hr", "fl", "fc", "fr"));
         when(velocityEvaluator.evaluateVelocityExpressions(eq(documentData), anyString())).thenAnswer(a -> a.getArguments()[1]);
-        when(pdfTemplateProcessor.processUsing(eq(exportParams), eq("testDocument"), eq("css content"), anyString())).thenReturn("test html content");
+        when(pdfTemplateProcessor.processUsing(eq(exportParams), eq("testDocument"), eq("css content"), anyString(), anyString())).thenReturn("test html content");
         when(weasyPrintServiceConnector.convertToPdf(eq("test html content"), any(WeasyPrintOptions.class))).thenReturn("test document content".getBytes());
         when(htmlProcessor.internalizeLinks(anyString())).thenAnswer(a -> a.getArgument(0));
         when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterTest.java
@@ -289,7 +289,7 @@ class PdfConverterTest {
                 .build();
         PdfGenerationLog pdfGenerationLog = new PdfGenerationLog();
         if (useCoverPageProcessor) {
-            when(coverPageProcessor.generatePdfWithTitle(documentData, exportParams, "test html content", pdfGenerationLog)).thenReturn("pdf result".getBytes());
+            when(coverPageProcessor.generatePdfWithTitle(eq(documentData), eq(exportParams), eq("test html content"), any(WeasyPrintOptions.class), eq(pdfGenerationLog))).thenReturn("pdf result".getBytes());
         } else {
             when(weasyPrintServiceConnector.convertToPdf(eq("test html content"), any(WeasyPrintOptions.class))).thenReturn("pdf result".getBytes());
         }
@@ -301,7 +301,7 @@ class PdfConverterTest {
         // Assert
         assertThat(result).isEqualTo("pdf result".getBytes());
         if (useCoverPageProcessor) {
-            verify(coverPageProcessor).generatePdfWithTitle(documentData, exportParams, "test html content", pdfGenerationLog);
+            verify(coverPageProcessor).generatePdfWithTitle(eq(documentData), eq(exportParams), eq("test html content"), any(WeasyPrintOptions.class), eq(pdfGenerationLog));
         } else {
             verify(weasyPrintServiceConnector).convertToPdf(eq("test html content"), any(WeasyPrintOptions.class));
         }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PolarionTypesTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PolarionTypesTest.java
@@ -77,16 +77,18 @@ class PolarionTypesTest {
     void convertsTimeOnlyWithTimezone() throws Exception {
         String result = PolarionTypes.convertSingleFieldValueToString(TimeOnly.parse("12:01:02.000 +0000"), Locale.US, TimeZone.getTimeZone("CET"));
         // Locale.US long time style should produce 'PM' marker
-        assertThat(result).contains("PM");
-        assertThat(result).contains(":01:02");
+        assertThat(result)
+                .contains("PM")
+                .contains(":01:02");
     }
 
     @Test
     void convertsDateWithTimezone() throws Exception {
         Date date = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSS Z").parse("2018-09-09 12:13:14.000 +0000");
         String result = PolarionTypes.convertSingleFieldValueToString(date, Locale.US, TimeZone.getTimeZone("Europe/Zurich"));
-        assertThat(result).contains("September 9, 2018");
-        assertThat(result).contains("2:13:14 AM"); // CET/CEST offset vs UTC
+        assertThat(result)
+                .contains("September 9, 2018")
+                .contains("2:13:14 AM"); // CET/CEST offset vs UTC
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PolarionTypesTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PolarionTypesTest.java
@@ -1,0 +1,163 @@
+package ch.sbb.polarion.extension.pdf_exporter.util;
+
+import com.polarion.alm.projects.model.IUser;
+import com.polarion.alm.tracker.internal.model.TypeOpt;
+import com.polarion.core.util.types.Currency;
+import com.polarion.core.util.types.DateOnly;
+import com.polarion.core.util.types.Text;
+import com.polarion.core.util.types.TimeOnly;
+import com.polarion.platform.persistence.IEnumOption;
+import com.polarion.platform.persistence.model.IPObject;
+import com.polarion.platform.persistence.spi.CustomTypedList;
+import com.polarion.platform.persistence.spi.EnumOption;
+import com.polarion.subterra.base.data.model.IListType;
+import com.polarion.subterra.base.data.model.internal.PrimitiveType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PolarionTypesTest {
+
+    private Locale defaultLocale;
+    private TimeZone defaultTz;
+
+    @BeforeEach
+    void saveDefaults() {
+        defaultLocale = Locale.getDefault();
+        defaultTz = TimeZone.getDefault();
+    }
+
+    @AfterEach
+    void restoreDefaults() {
+        Locale.setDefault(defaultLocale);
+        TimeZone.setDefault(defaultTz);
+    }
+
+    @Test
+    void convertSingleFieldValueToString_handlesNull() {
+        String result = PolarionTypes.convertSingleFieldValueToString(null, Locale.US, TimeZone.getTimeZone("CET"));
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void convertsTypeOptByName() {
+        TypeOpt typeOpt = mock(TypeOpt.class);
+        when(typeOpt.getName()).thenReturn("MyType");
+        String result = PolarionTypes.convertSingleFieldValueToString(typeOpt, Locale.US, TimeZone.getTimeZone("CET"));
+        assertThat(result).isEqualTo("MyType");
+    }
+
+    @Test
+    void convertsTextToHtmlContent() {
+        Text text = Text.html("Hello <b>World</b>");
+        String result = PolarionTypes.convertSingleFieldValueToString(text, Locale.US, TimeZone.getTimeZone("CET"));
+        assertThat(result).isEqualTo("Hello <b>World</b>");
+    }
+
+    @Test
+    void convertsDateOnlyWithLocale() throws Exception {
+        String result = PolarionTypes.convertSingleFieldValueToString(DateOnly.parse("2023-10-20"), Locale.US, TimeZone.getTimeZone("UTC"));
+        assertThat(result).isEqualTo("October 20, 2023");
+    }
+
+    @Test
+    void convertsTimeOnlyWithTimezone() throws Exception {
+        String result = PolarionTypes.convertSingleFieldValueToString(TimeOnly.parse("12:01:02.000 +0000"), Locale.US, TimeZone.getTimeZone("CET"));
+        // Locale.US long time style should produce 'PM' marker
+        assertThat(result).contains("PM");
+        assertThat(result).contains(":01:02");
+    }
+
+    @Test
+    void convertsDateWithTimezone() throws Exception {
+        Date date = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSS Z").parse("2018-09-09 12:13:14.000 +0000");
+        String result = PolarionTypes.convertSingleFieldValueToString(date, Locale.US, TimeZone.getTimeZone("Europe/Zurich"));
+        assertThat(result).contains("September 9, 2018");
+        assertThat(result).contains("2:13:14 AM"); // CET/CEST offset vs UTC
+    }
+
+    @Test
+    void convertsCurrencyValueToString() {
+        Currency currency = new Currency(BigDecimal.TEN);
+        String result = PolarionTypes.convertSingleFieldValueToString(currency, Locale.US, TimeZone.getTimeZone("CET"));
+        assertThat(result).isEqualTo("10.00");
+    }
+
+    @Test
+    void convertsEnumOptionPrefersNameThenId() {
+        IEnumOption withName = new EnumOption("status", "open", "Open", 1, false);
+        String r1 = PolarionTypes.convertSingleFieldValueToString(withName, Locale.US, TimeZone.getTimeZone("CET"));
+        assertThat(r1).isEqualTo("Open");
+
+        IEnumOption withoutName = new EnumOption("status", "open", null, 1, false);
+        String r2 = PolarionTypes.convertSingleFieldValueToString(withoutName, Locale.US, TimeZone.getTimeZone("CET"));
+        assertThat(r2).isEqualTo("open");
+    }
+
+    @Test
+    void convertsUserByLabel() {
+        IUser user = mock(IUser.class);
+        when(user.getLabel()).thenReturn("System Administrator");
+        String result = PolarionTypes.convertSingleFieldValueToString(user, Locale.US, TimeZone.getTimeZone("CET"));
+        assertThat(result).isEqualTo("System Administrator");
+    }
+
+    @Test
+    void fallsBackToToString() {
+        Object obj = new Object() {
+            @Override
+            public String toString() {
+                return "X";
+            }
+        };
+        String result = PolarionTypes.convertSingleFieldValueToString(obj, Locale.US, TimeZone.getTimeZone("CET"));
+        assertThat(result).isEqualTo("X");
+    }
+
+    @Test
+    void convertsCustomTypedListUsingJoinAndInnerConversion() {
+        IPObject iPObject = mock(IPObject.class);
+        IListType listType = mock(IListType.class);
+        when(listType.getItemType()).thenReturn(new PrimitiveType("string"));
+        CustomTypedList list = new CustomTypedList(iPObject, listType, false, List.of("A", "B"));
+        String result = PolarionTypes.convertListToString(list, Locale.US, TimeZone.getTimeZone("UTC"));
+        assertThat(result).isEqualTo("A, B");
+    }
+
+    @Test
+    void topLevelConvertDispatchesListVsSingle() {
+        // list path
+        IPObject iPObject = mock(IPObject.class);
+        IListType listType = mock(IListType.class);
+        when(listType.getItemType()).thenReturn(new PrimitiveType("string"));
+        CustomTypedList list = new CustomTypedList(iPObject, listType, false, List.of("A", "B"));
+        String r1 = PolarionTypes.convertFieldValueToString(list, Locale.US, TimeZone.getTimeZone("UTC"));
+        assertThat(r1).isEqualTo("A, B");
+
+        // single path
+        String r2 = PolarionTypes.convertFieldValueToString("C", Locale.US, TimeZone.getTimeZone("UTC"));
+        assertThat(r2).isEqualTo("C");
+    }
+
+    @Test
+    void overloadWithoutLocaleUsesDefaults() {
+        Locale.setDefault(Locale.US);
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Date date = new GregorianCalendar(2020, Calendar.JANUARY, 15, 10, 5, 0).getTime();
+        String result = PolarionTypes.convertFieldValueToString(date);
+        assertThat(result).contains("January 15, 2020");
+    }
+}


### PR DESCRIPTION
### Proposed changes

This pull request adds support for exporting selected document fields as HTML meta tags in LiveDoc PDF exports. It introduces a new `metadataFields` parameter, updates the form and style package model to handle this setting, and ensures the meta tags are correctly injected into the generated HTML and PDF. Additionally, it refactors the PDF generation flow to pass meta tag information through the relevant layers.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
