### PR TITLE
chore: remove unused SVG image processing methods and related tests

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -93,7 +93,6 @@ public class HtmlProcessor {
             case BASELINE_COLLECTION -> throw new IllegalArgumentException(UNSUPPORTED_DOCUMENT_TYPE.formatted(exportParams.getDocumentType()));
         };
         html = replaceResourcesAsBase64Encoded(html);
-        html = MediaUtils.removeSvgUnsupportedFeatureHint(html); //note that there is one more replacement attempt before replacing images with base64 representation
         html = properTableHeads(html);
         html = cleanExtraTableContent(html);
         html = switch (exportParams.getDocumentType()) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -224,10 +224,6 @@ public class MediaUtils {
         return RegexMatcher.get(URL_REGEX).useJavaUtil().replace(intermediateResult, dataReplacement);
     }
 
-    public String removeSvgUnsupportedFeatureHint(String html) {
-        return html.replaceAll("(?s)<switch>[^<]*?<g requiredFeatures=\"[^\"]+?\"/>.*?</switch>", "");
-    }
-
     /**
      * Attempt to guess media type using resource name or its content.
      * <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">More about media types.</a>

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -64,9 +63,6 @@ public class PdfExporterFileResourceProvider implements FileResourceProvider {
             if (MIME_TYPE_SVG.equals(mimeType)) {
                 // Additional check to verify that the content is indeed an SVG
                 mimeType = MediaUtils.getMimeTypeUsingTikaByContent(resource, resourceBytes);
-                if (MIME_TYPE_SVG.equals(mimeType)) {
-                    resourceBytes = processPossibleSvgImage(resourceBytes);
-                }
             }
             return String.format("data:%s;base64,%s", mimeType, Base64.getEncoder().encodeToString(resourceBytes));
         }
@@ -154,18 +150,6 @@ public class PdfExporterFileResourceProvider implements FileResourceProvider {
             return "";
         }
         return null;
-    }
-
-    @VisibleForTesting
-    @SuppressWarnings("squid:S1166") // no need to log or rethrow exception by design
-    public byte[] processPossibleSvgImage(byte[] possibleSvgImageBytes) {
-        try {
-            String svgContent = new String(possibleSvgImageBytes, StandardCharsets.UTF_8);
-            return MediaUtils.removeSvgUnsupportedFeatureHint(svgContent).getBytes(StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            // not a valid string, just nvm
-        }
-        return possibleSvgImageBytes;
     }
 
     /**

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -280,11 +280,11 @@ class HtmlProcessorTest {
         }
         when(fileResourceProvider.getResourceAsBytes(any())).thenReturn(imgBytes);
         when(fileResourceProvider.getResourceAsBase64String(any())).thenCallRealMethod();
-        when(fileResourceProvider.processPossibleSvgImage(any())).thenCallRealMethod();
         String result = processor.replaceResourcesAsBase64Encoded(html);
-        String expected = "<div><img id=\"image1\" src=\"data:image/svg+xml;base64," + Base64.getEncoder().encodeToString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg xmlns=\"http://www.w3.org/2000/svg\"></svg>".getBytes(StandardCharsets.UTF_8)) + "\"/> " +
-                "<img id='image2' src='data:image/svg+xml;base64," + Base64.getEncoder().encodeToString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg xmlns=\"http://www.w3.org/2000/svg\"></svg>".getBytes(StandardCharsets.UTF_8)) + "'/> " +
-                "<img id='image1' src='data:image/svg+xml;base64," + Base64.getEncoder().encodeToString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg xmlns=\"http://www.w3.org/2000/svg\"></svg>".getBytes(StandardCharsets.UTF_8)) + "'/></div>";
+        String base64SvgImage = Base64.getEncoder().encodeToString("<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg xmlns=\"http://www.w3.org/2000/svg\"><switch><g requiredFeatures=\"http://www.w3.org/TR/SVG11/feature#Extensibility\"/></switch></svg>".getBytes(StandardCharsets.UTF_8));
+        String expected = "<div><img id=\"image1\" src=\"data:image/svg+xml;base64," + base64SvgImage + "\"/> " +
+                "<img id='image2' src='data:image/svg+xml;base64," + base64SvgImage + "'/> " +
+                "<img id='image1' src='data:image/svg+xml;base64," + base64SvgImage + "'/></div>";
         assertEquals(expected, result);
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -16,33 +16,6 @@ import static org.junit.jupiter.api.Assertions.*;
 class MediaUtilsTest {
 
     @Test
-    void removeSvgUnsupportedFeatureHintTest() {
-        // svg sample from polarion diagram v23.10
-        assertEquals("<svg></svg>", MediaUtils.removeSvgUnsupportedFeatureHint("<svg><switch>" +
-                "<g requiredFeatures=\"http://www.w3.org/TR/SVG11/feature#Extensibility\"/>" +
-                "<a transform=\"translate(0,-5)\" xlink:href=\"https://www.diagrams.net/doc/faq/svg-export-text-problems\" target=\"_blank\">" +
-                "<text text-anchor=\"middle\" font-size=\"10px\" x=\"50%\" y=\"100%\">Text is not SVG - cannot display</text>" +
-                "<title>https://www.diagrams.net/doc/faq/svg-export-text-problems</title></a></switch>" +
-                "</svg>"));
-
-        // alternative hint from https://github.com/jgraph/drawio/issues/774 (also here is extra space before g)
-        assertEquals("<svg></svg>", MediaUtils.removeSvgUnsupportedFeatureHint("<svg><switch> " +
-                "<g requiredFeatures=\"http://www.w3.org/TR/SVG11/feature#Extensibility\"/>" +
-                "<a transform=\"translate(0,-5)\" xlink:href=\"https://desk.draw.io/support/solutions/articles/16000042487\" target=\"_blank\">" +
-                "<text text-anchor=\"middle\" font-size=\"10px\" x=\"50%\" y=\"100%\">Viewer does not support full SVG 1.1</text>" +
-                "</a></switch>" +
-                "</svg>"));
-
-        // potential issue with another feature, main idea here is to cut down all requiredFeatures checks no matter which feature it is
-        assertEquals("<svg></svg>", MediaUtils.removeSvgUnsupportedFeatureHint("<svg><switch>" +
-                "<g requiredFeatures=\"http://www.w3.org/TR/SVG11/feature#Gradient\"/>" +
-                "<a transform=\"translate(0,-5)\" xlink:href=\"https://some.url\" target=\"_blank\">" +
-                "<text text-anchor=\"middle\" font-size=\"10px\" x=\"50%\" y=\"100%\">Some warning</text>" +
-                "</a></switch>" +
-                "</svg>"));
-    }
-
-    @Test
     void dataUrlTest() {
         assertFalse(MediaUtils.isDataUrl(null));
         assertFalse(MediaUtils.isDataUrl(""));

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
@@ -49,12 +49,6 @@ class PdfExporterFileResourceProviderTest {
     }
 
     @Test
-    void processPossibleSvgImageTest() {
-        byte[] basicString = "basic".getBytes(StandardCharsets.UTF_8);
-        assertArrayEquals(basicString, resourceProvider.processPossibleSvgImage(basicString));
-    }
-
-    @Test
     @SneakyThrows
     void replaceImagesAsBase64EncodedTest() {
         byte[] imgBytes;


### PR DESCRIPTION
Refs: #515

### Proposed changes

This pull request removes custom logic and tests related to stripping unsupported SVG features from images during PDF export. The main change is the elimination of the `removeSvgUnsupportedFeatureHint` method and all code that used it, which simplifies SVG handling and test coverage.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
