### PR TITLE
docs: add workaround for icon fonts issue in PDF/A accessible variants and update related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,19 @@ jobs.timeout.in-progress.minutes=60
 
 ## Known issues
 
+### PDF/A-*A variants with icon fonts (FontAwesome)
+
+PDF/A "A" (accessible) variants require that characters from Unicode Private Use Area (PUA) have `ActualText` entries for accessibility.
+Icon fonts like FontAwesome use PUA codepoints, which causes validation failures with VeraPDF for:
+- `pdf/a-1a`
+- `pdf/a-2a`
+- `pdf/a-3a`
+
+**Workaround:** If your documents contain icon fonts (e.g., FontAwesome icons from Polarion), use "B" or "U" variants instead:
+- `pdf/a-1b` instead of `pdf/a-1a`
+- `pdf/a-2b` or `pdf/a-2u` instead of `pdf/a-2a`
+- `pdf/a-3b` or `pdf/a-3u` instead of `pdf/a-3a`
+
 ### PDF/UA-2 incomplete support
 
 WeasyPrint 67.0 has incomplete support for PDF/UA-2 (ISO 14289-2:2024). The following issues are known:

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -98,12 +98,12 @@ This configuration property allows selecting a PDF variant to be used for PDF ge
 
 | Variant      | Description                                                      | Notes |
 |--------------|------------------------------------------------------------------|-------|
-| **pdf/a-1a** | Accessible PDF/A-1 (tagged, Unicode)                             | |
+| **pdf/a-1a** | Accessible PDF/A-1 (tagged, Unicode)                             | Icon fonts issue* |
 | **pdf/a-1b** | Basic visual preservation (older PDF standard)                   | |
-| **pdf/a-2a** | Accessible PDF/A-2 (tagged, Unicode, modern features)            | |
+| **pdf/a-2a** | Accessible PDF/A-2 (tagged, Unicode, modern features)            | Icon fonts issue* |
 | **pdf/a-2b** | Basic visual preservation with modern features like transparency | Default |
 | **pdf/a-2u** | Visual preservation + searchable text (Unicode)                  | |
-| **pdf/a-3a** | Accessible PDF/A-3 (tagged, Unicode, file attachments)           | |
+| **pdf/a-3a** | Accessible PDF/A-3 (tagged, Unicode, file attachments)           | Icon fonts issue* |
 | **pdf/a-3b** | Visual preservation with file attachments                        | |
 | **pdf/a-3u** | Visual preservation + searchable text with file attachments      | |
 | **pdf/a-4e** | PDF/A-4 for engineering documents (allows 3D, RichMedia)         | |
@@ -115,6 +115,8 @@ This configuration property allows selecting a PDF variant to be used for PDF ge
 The default value is `pdf/a-2b`.
 
 **Important notes:**
+
+- **\*Icon fonts issue:** PDF/A "A" (accessible) variants (`pdf/a-1a`, `pdf/a-2a`, `pdf/a-3a`) require ActualText for Unicode Private Use Area (PUA) characters. Icon fonts like FontAwesome (used by Polarion) use PUA codepoints, causing validation failures. Use "B" or "U" variants instead if your documents contain icons.
 
 - **pdf/a-4f** requires documents to have attachments (embedded files) per ISO 19005-4:2020. Use the "Embed attachments into resulted PDF" option or ensure your document has attachments.
 


### PR DESCRIPTION
### Proposed changes

This pull request updates documentation to clarify issues with using icon fonts (such as FontAwesome) in accessible PDF/A variants. It adds a new known issue section to the `README.md` and updates the PDF variant table and notes in the `USER_GUIDE.md` to warn users about validation failures and recommend workarounds.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
