### PR TITLE
docs: clarify PDF/A incompatibility with sticky notes and suggest workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,21 @@ Icon fonts like FontAwesome use PUA codepoints, which causes validation failures
 - `pdf/a-2b` or `pdf/a-2u` instead of `pdf/a-2a`
 - `pdf/a-3b` or `pdf/a-3u` instead of `pdf/a-3a`
 
+### Native PDF annotations (sticky notes) incompatible with PDF/A
+
+When exporting documents with comments rendered as native PDF annotations (sticky notes), the resulting PDF will fail PDF/A validation. This affects all PDF/A variants (`pdf/a-1*`, `pdf/a-2*`, `pdf/a-3*`, `pdf/a-4*`).
+
+VeraPDF reports the following errors for PDF/A-2b:
+- `6.2.10-2` - Annotation appearance stream missing
+- `6.1.3-1` - Info dictionary issues
+- `6.2.4.3-2` - OutputIntent issues
+- `6.3.2-1` - Font embedding issues
+- `6.6.2.1-1` - Annotation flags issues
+
+This happens because PDF/A standards require all annotations to have complete appearance streams (AP entry with N key), which WeasyPrint-generated sticky notes do not provide.
+
+**Workaround:** If you need PDF/A-compliant documents with comments, use inline comment rendering (disable "as sticky notes" option). Inline comments are rendered as regular HTML content and do not affect PDF/A compliance.
+
 ### PDF/UA-2 incomplete support
 
 WeasyPrint 67.0 has incomplete support for PDF/UA-2 (ISO 14289-2:2024). The following issues are known:

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -118,6 +118,8 @@ The default value is `pdf/a-2b`.
 
 - **\*Icon fonts issue:** PDF/A "A" (accessible) variants (`pdf/a-1a`, `pdf/a-2a`, `pdf/a-3a`) require ActualText for Unicode Private Use Area (PUA) characters. Icon fonts like FontAwesome (used by Polarion) use PUA codepoints, causing validation failures. Use "B" or "U" variants instead if your documents contain icons.
 
+- **Sticky notes (native PDF annotations) are not compatible with PDF/A.** If you need PDF/A-compliant documents with comments, use inline comment rendering instead of "as sticky notes" option.
+
 - **pdf/a-4f** requires documents to have attachments (embedded files) per ISO 19005-4:2020. Use the "Embed attachments into resulted PDF" option or ensure your document has attachments.
 
 - **pdf/ua-2** has incomplete support in WeasyPrint 67.0. Known issues include:
@@ -171,6 +173,8 @@ Also there is an option to render comments as native PDF annotations (sticky not
 
 In this case, comments will be accessed as native PDF viewer's tools (appearance may vary on different PDF viewers):
 ![Comments in PDF viewer](docs/user_guide/img/comments_pdf_viewer.png)
+
+> ⚠️ **PDF/A Compatibility Warning:** Native PDF annotations (sticky notes) are **not compatible with PDF/A standards**. When exporting with the "as sticky notes" option enabled, the resulting PDF will fail PDF/A validation (e.g., veraPDF reports errors 6.2.10-2, 6.1.3-1, 6.2.4.3-2, 6.3.2-1, 6.6.2.1-1 for PDF/A-2b). This is because PDF/A requires all annotations to have complete appearance streams, which WeasyPrint-generated sticky notes do not provide. If you need PDF/A-compliant documents with comments, use the default inline rendering (without "as sticky notes" option).
 
 ### Watermark
 If you select this checkbox, all pages of the resulting PDF document will include a "Confidential" watermark:


### PR DESCRIPTION
### Proposed changes

This pull request updates the documentation to clarify that native PDF annotations (sticky notes) are not compatible with PDF/A standards. It explains the validation errors that result from using sticky notes in PDF/A exports and provides guidance on how to ensure PDF/A compliance when including comments in documents.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
