### PR TITLE
feat: warn user that comments rendered as sticky notes are not compliant with PDF/A variants

### DIFF
--- a/src/main/resources/webapp/pdf-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/pdf-exporter/html/popupForm.html
@@ -148,7 +148,13 @@
                         <option value='ALL'>All</option>
                     </select>
                     <label for='popup-render-native-comments' id='popup-render-native-comments-container'>
-                        <input id='popup-render-native-comments' type='checkbox'/>
+                        <input id='popup-render-native-comments' type='checkbox' onchange='
+                            const warningPane = document.querySelector(".modal__content .notifications .alert.alert-warning");
+                            if (warningPane) {
+                                warningPane.textContent = this.checked ? "Be aware that comments rendered in PDF as sticky notes are not compliant with any of PDF/A variants" : "";
+                                warningPane.style.display = this.checked ? "block" : "none";
+                            }
+                        ' />
                         as sticky notes
                     </label>
                 </div>

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -129,7 +129,13 @@
                 <option value='ALL'>All</option>
             </select>
             <label for='render-native-comments' id='render-native-comments-container' style='display: none'>
-                <input id='render-native-comments' type='checkbox'/>
+                <input id='render-native-comments' type='checkbox' onchange='
+                    const warningPane = document.getElementById("export-warning");
+                    if (warningPane) {
+                        warningPane.textContent = this.checked ? "Be aware that comments rendered in PDF as sticky notes are not compliant with any of PDF/A variants" : "";
+                        warningPane.style.display = this.checked ? "block" : "none";
+                    }
+                ' />
                 as sticky notes
             </label>
         </div>


### PR DESCRIPTION
Warn user that comments rendered as sticky notes are not compliant with PDF/A variants

### Proposed changes

PDF documents with comments rendered as sticky notes won't be compliant with any of PDF/A variant. This modification introduces warning on UI about this.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
