### PR TITLE
fix: 'fit to page width' does not work for test records table

### DIFF
--- a/src/main/resources/default/dle-pdf-export.css
+++ b/src/main/resources/default/dle-pdf-export.css
@@ -437,7 +437,7 @@ ul.toc li > a.page-number::after {
     word-break: break-all;
 }
 
-.polarion-Document-table td {
+.polarion-Document-table td, .polarion-TestRecordsTable tr, .polarion-TestRecordsTable th {
     overflow-wrap: anywhere;
     white-space: normal;
 }


### PR DESCRIPTION
Refs: #694

### Proposed changes

'Fit to page width' option must be properly applied to Test Records tables on LiveReport pages.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
