### PR TITLE
fix(ci): prevent Claude Code Review from attempting Maven commands

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,13 +45,23 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
             Review the PR diff. Report ONLY actual problems in changed lines.
-            Focus on:
+            FOCUS ON:
             - Bugs or logic errors
             - Security vulnerabilities (SQL injection, XSS, auth bypass, secrets exposure)
             - Breaking changes not mentioned in PR description
             - Missing tests for new functionality
             - Critical performance issues introduced by changes
-            Format (be TERSE):
+            DO NOT:
+            - Review unchanged code, style/formatting, optional improvements, or provide praise
+            - Run build tools (Maven, npm, gradle, etc.)
+            - Check external dependency versions
+            GUIDELINES:
+            - Use Read/Grep/Glob to search the codebase for context
+            - If you need to understand parent classes or dependencies, search for usage patterns
+            - The PR branch is already checked out in the current working directory
+            - Post your review using `gh pr comment` as a top-level PR comment
+            - Only post GitHub comments - don't submit review text as messages
+            FORMAT (be TERSE):
             ## Issues Found
 
             ### 🔴 Critical
@@ -60,10 +70,6 @@ jobs:
             ### 🟡 Important
             - `file:line` - Issue description - Suggestion: specific fix
             If NO issues found: "✅ No issues found."
-            DO NOT review: unchanged code, style/formatting, optional improvements, or provide praise.
-            Note: The PR branch is already checked out in the current working directory.
-            Use `gh pr comment` to post your review as a top-level PR comment.
-            Only post GitHub comments - don't submit review text as messages.
 
           # Official recommendation: Enable GitHub commenting tools for posting PR comments
           claude_args: |-


### PR DESCRIPTION
Refs: #708

## Proposed changes

The Claude Code Review workflow was occasionally failing when the agent tried to run `mvn dependency:tree` to check parent dependencies. Since Maven commands are not in the allowed-tools list, this caused the agent to hit the max turn limit and fail.

This PR reorganizes and clarifies the review prompt to prevent such issues:

### Changes
- **Reorganized prompt structure** into clear sections:
  - **FOCUS ON**: What to look for in reviews
  - **DO NOT**: What to avoid (unchanged code, build tools, dependency versions)
  - **GUIDELINES**: How to use tools (Read/Grep/Glob) and post results
  - **FORMAT**: Output structure specification

- **Added explicit instruction** not to run build tools (Maven, npm, gradle)
- **Directed agent** to use Read/Grep/Glob for searching the codebase instead
- **Consolidated constraints** into the DO NOT section (previously scattered)

### Benefits
- Prevents permission denial errors from blocked Maven commands
- Avoids hitting max turn limits (10 turns)
- Maintains security by not adding new permissions
- Improves prompt clarity and organization
- Reduces review costs by preventing wasted turns

### Example failure resolved
https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.pdf-exporter/actions/runs/21706896600/job/62600206095?pr=697

## Checklist

- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation