### PR TITLE
refactor: remove redundant UriInfo parameter from REST controller methods and clean up related mocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -157,6 +157,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -197,6 +198,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/ConverterApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/ConverterApiController.java
@@ -18,7 +18,6 @@ import org.springframework.web.context.request.RequestContextHolder;
 
 import javax.inject.Singleton;
 import javax.ws.rs.Path;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
@@ -35,8 +34,8 @@ public class ConverterApiController extends ConverterInternalController {
 
     @VisibleForTesting
     @SuppressWarnings("squid:S5803")
-    ConverterApiController(PdfExporterPolarionService pdfExporterPolarionService, PdfConverter pdfConverter, PdfWidthValidationService pdfWidthValidationService, PdfConverterJobsService pdfConverterJobService, HtmlToPdfConverter htmlToPdfConverter) {
-        super(pdfConverter, pdfWidthValidationService, pdfConverterJobService, htmlToPdfConverter);
+    ConverterApiController(PdfExporterPolarionService pdfExporterPolarionService, PdfConverter pdfConverter, PdfWidthValidationService pdfWidthValidationService, PdfConverterJobsService pdfConverterJobService, UriInfo uriInfo, HtmlToPdfConverter htmlToPdfConverter) {
+        super(pdfConverter, pdfWidthValidationService, pdfConverterJobService, uriInfo, htmlToPdfConverter);
         this.polarionService = pdfExporterPolarionService;
     }
 
@@ -51,16 +50,16 @@ public class ConverterApiController extends ConverterInternalController {
     }
 
     @Override
-    public Response startPdfConverterJob(ExportParams exportParams, @Context UriInfo uriInfo) {
+    public Response startPdfConverterJob(ExportParams exportParams) {
         // In async case logout inside the filter must be deactivated. Async Job itself will care about logout after finishing
         deactivateLogoutFilter();
 
-        return polarionService.callPrivileged(() -> super.startPdfConverterJob(exportParams, uriInfo));
+        return polarionService.callPrivileged(() -> super.startPdfConverterJob(exportParams));
     }
 
     @Override
-    public Response getPdfConverterJobStatus(String jobId, @Context UriInfo uriInfo) {
-        return polarionService.callPrivileged(() -> super.getPdfConverterJobStatus(jobId, uriInfo));
+    public Response getPdfConverterJobStatus(String jobId) {
+        return polarionService.callPrivileged(() -> super.getPdfConverterJobStatus(jobId));
     }
 
     @Override

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/ConverterInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/ConverterInternalController.java
@@ -75,6 +75,9 @@ public class ConverterInternalController {
     private final PropertiesUtility propertiesUtility;
     private final HtmlToPdfConverter htmlToPdfConverter;
 
+    @Context
+    private UriInfo uriInfo;
+
     public ConverterInternalController() {
         this.pdfConverter = new PdfConverter();
         this.pdfWidthValidationService = new PdfWidthValidationService(pdfConverter);
@@ -85,10 +88,11 @@ public class ConverterInternalController {
     }
 
     @VisibleForTesting
-    ConverterInternalController(PdfConverter pdfConverter, PdfWidthValidationService pdfWidthValidationService, PdfConverterJobsService pdfConverterJobService, HtmlToPdfConverter htmlToPdfConverter) {
+    ConverterInternalController(PdfConverter pdfConverter, PdfWidthValidationService pdfWidthValidationService, PdfConverterJobsService pdfConverterJobService, UriInfo uriInfo, HtmlToPdfConverter htmlToPdfConverter) {
         this.pdfConverter = pdfConverter;
         this.pdfWidthValidationService = pdfWidthValidationService;
         this.pdfConverterJobService = pdfConverterJobService;
+        this.uriInfo = uriInfo;
         this.propertiesUtility = new PropertiesUtility();
         this.htmlToPdfConverter = htmlToPdfConverter;
     }
@@ -187,7 +191,7 @@ public class ConverterInternalController {
                             description = "Conversion process is started, job URI is returned in Location header"
                     )
             })
-    public Response startPdfConverterJob(ExportParams exportParams, @Context UriInfo uriInfo) {
+    public Response startPdfConverterJob(ExportParams exportParams) {
         validateExportParameters(exportParams);
 
         String jobId = pdfConverterJobService.startJob(exportParams, propertiesUtility.getInProgressJobTimeout());
@@ -217,7 +221,7 @@ public class ConverterInternalController {
                             description = "Conversion job id is unknown"
                     )
             })
-    public Response getPdfConverterJobStatus(@PathParam("id") String jobId, @Context UriInfo uriInfo) {
+    public Response getPdfConverterJobStatus(@PathParam("id") String jobId) {
         JobState jobState = pdfConverterJobService.getJobState(jobId);
 
         ConverterJobStatus converterJobStatus = convertToJobStatus(jobState);

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/ConverterApiControllerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/ConverterApiControllerTest.java
@@ -13,7 +13,6 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import javax.ws.rs.core.UriInfo;
 import java.util.concurrent.Callable;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,9 +26,6 @@ class ConverterApiControllerTest {
     @Mock
     private ServletRequestAttributes requestAttributes;
 
-    @Mock
-    private UriInfo uriInfo;
-
     @InjectMocks
     private ConverterApiController converterApiController;
 
@@ -41,7 +37,7 @@ class ConverterApiControllerTest {
     @Test
     @SuppressWarnings("unchecked")
     void shouldSetLogoutSkipProperty() {
-        converterApiController.startPdfConverterJob(ExportParams.builder().build(), uriInfo);
+        converterApiController.startPdfConverterJob(ExportParams.builder().build());
         verify(requestAttributes).setAttribute(LogoutFilter.ASYNC_SKIP_LOGOUT, Boolean.TRUE, RequestAttributes.SCOPE_REQUEST);
         verify(polarionService).callPrivileged(any(Callable.class));
     }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/ConverterInternalControllerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/rest/controller/ConverterInternalControllerTest.java
@@ -50,7 +50,7 @@ class ConverterInternalControllerTest {
                 .build();
         when(pdfConverterJobService.startJob(params, 60)).thenReturn("testJobId");
         when(uriInfo.getRequestUri()).thenReturn(UriBuilder.fromUri("http://testHost:8090/polarion/pdf-exporter/rest/api/convert/jobs").build());
-        try (Response response = internalController.startPdfConverterJob(params, uriInfo)) {
+        try (Response response = internalController.startPdfConverterJob(params)) {
             assertThat(response.getStatus()).isEqualTo(HttpStatus.ACCEPTED.value());
             assertThat(response.getHeaderString(HttpHeaders.LOCATION)).isEqualTo("/polarion/pdf-exporter/rest/api/convert/jobs/testJobId");
         }
@@ -59,7 +59,7 @@ class ConverterInternalControllerTest {
     @ParameterizedTest
     @MethodSource("getWrongConverterExportParams")
     void startPdfConverterJob_badRequest(ExportParams exportParams, String expectedErrorMessage) {
-        assertThatThrownBy(() -> internalController.startPdfConverterJob(exportParams, uriInfo))
+        assertThatThrownBy(() -> internalController.startPdfConverterJob(exportParams))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessageContaining(expectedErrorMessage);
     }
@@ -85,7 +85,7 @@ class ConverterInternalControllerTest {
             when(uriInfo.getRequestUri()).thenReturn(UriBuilder.fromUri("http://testHost:8090/polarion/pdf-exporter/rest/api/convert/jobs/testJobId").build());
         }
         when(pdfConverterJobService.getJobState("testJobId")).thenReturn(jobState);
-        try (Response response = internalController.getPdfConverterJobStatus("testJobId", uriInfo)) {
+        try (Response response = internalController.getPdfConverterJobStatus("testJobId")) {
             assertThat(response.getStatus()).isEqualTo(expectedHttpStatus.value());
             assertThat(response.getEntity()).isInstanceOf(ConverterJobDetails.class);
             assertThat(((ConverterJobDetails) response.getEntity()).getStatus()).isEqualTo(expectedJobStatus);
@@ -112,7 +112,7 @@ class ConverterInternalControllerTest {
         when(pdfConverterJobService.getJobState(anyString())).thenAnswer(id -> {
             throw new NoSuchElementException("Job not found: " + id);
         });
-        assertThatThrownBy(() -> internalController.getPdfConverterJobStatus("testJobIdUnknown", uriInfo))
+        assertThatThrownBy(() -> internalController.getPdfConverterJobStatus("testJobIdUnknown"))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessageContaining("testJobIdUnknown");
     }


### PR DESCRIPTION
### Proposed changes

Simplify method signatures for `startPdfConverterJob` and `getPdfConverterJobStatus` by removing unused `UriInfo` parameter. Update tests and constructor dependencies accordingly.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
