### PR TITLE
refactor: centralize URL query parameter definitions in `ExportParams` and adjust related references

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/conversion/ExportParams.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/conversion/ExportParams.java
@@ -20,6 +20,9 @@ import java.util.Map;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class ExportParams extends ConversionParams {
+    public static final String URL_QUERY_PARAM_QUERY = "query";
+    public static final String URL_QUERY_PARAM_LANGUAGE = "language";
+
     @Schema(description = "The unique identifier for the project", example = "elibrary")
     private @Nullable String projectId;
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/documents/adapters/LiveDocAdapter.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/documents/adapters/LiveDocAdapter.java
@@ -17,6 +17,7 @@ import com.polarion.alm.shared.dle.document.DocumentRendererParameters;
 import com.polarion.alm.tracker.model.IModule;
 import com.polarion.core.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Map;
@@ -24,8 +25,6 @@ import java.util.Optional;
 
 public class LiveDocAdapter extends CommonUniqueObjectAdapter {
     public static final String DOC_REVISION_CUSTOM_FIELD = "docRevision";
-    public static final String URL_QUERY_PARAM_LANGUAGE = "language";
-    public static final String URL_QUERY_PARAM_QUERY = "query";
 
     private final @NotNull IModule module;
 
@@ -79,9 +78,10 @@ public class LiveDocAdapter extends CommonUniqueObjectAdapter {
         });
     }
 
+    @VisibleForTesting
     static @NonNull ModifiedDocumentRenderer getDocumentRenderer(@NonNull ExportParams exportParams, InternalReadOnlyTransaction transaction, ProxyDocument document) {
         Map<String, String> documentParameters = exportParams.getUrlQueryParameters() == null ? Map.of() : exportParams.getUrlQueryParameters();
-        DocumentRendererParameters parameters = new DocumentRendererParameters(documentParameters.get(URL_QUERY_PARAM_QUERY), documentParameters.get(URL_QUERY_PARAM_LANGUAGE));
+        DocumentRendererParameters parameters = new DocumentRendererParameters(documentParameters.get(ExportParams.URL_QUERY_PARAM_QUERY), documentParameters.get(ExportParams.URL_QUERY_PARAM_LANGUAGE));
         return new ModifiedDocumentRenderer(transaction, document, RichTextRenderTarget.PDF_EXPORT, parameters);
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/placeholder/PlaceholderProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/placeholder/PlaceholderProcessor.java
@@ -3,7 +3,6 @@ package ch.sbb.polarion.extension.pdf_exporter.util.placeholder;
 import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.ExportParams;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.documents.DocumentData;
-import ch.sbb.polarion.extension.pdf_exporter.rest.model.documents.adapters.LiveDocAdapter;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.headerfooter.Placeholder;
 import ch.sbb.polarion.extension.pdf_exporter.service.PdfExporterPolarionService;
 import com.polarion.alm.projects.model.IUniqueObject;
@@ -16,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
 
 public class PlaceholderProcessor {
 
@@ -47,7 +47,7 @@ public class PlaceholderProcessor {
     public @NotNull PlaceholderValues getPlaceholderValues(@NotNull DocumentData<? extends IUniqueObject> documentData, @NotNull ExportParams exportParams, @NotNull List<String> templates) {
         String revision = exportParams.getRevision() != null ? exportParams.getRevision() : documentData.getLastRevision();
         String baselineName = documentData.getBaseline() != null ? documentData.getBaseline().asPlaceholder() : "";
-        String documentFilter = exportParams.getUrlQueryParameters() != null ? exportParams.getUrlQueryParameters().get(LiveDocAdapter.URL_QUERY_PARAM_QUERY) : null;
+        String documentFilter = exportParams.getUrlQueryParameters() != null ? exportParams.getUrlQueryParameters().get(ExportParams.URL_QUERY_PARAM_QUERY) : null;
 
         PlaceholderValues placeholderValues = PlaceholderValues.builder()
                 .productName(pdfExporterPolarionService.getPolarionProductName())
@@ -109,7 +109,8 @@ public class PlaceholderProcessor {
         String processedText = template;
         for (Map.Entry<String, String> entry : variables.entrySet()) {
             String regex = String.format("\\{\\{\\s*%s\\s*\\}\\}", entry.getKey());
-            processedText = processedText.replaceAll(regex, entry.getValue() != null ? entry.getValue() : "");
+            String replacement = entry.getValue() != null ? Matcher.quoteReplacement(entry.getValue()) : "";
+            processedText = processedText.replaceAll(regex, replacement);
         }
 
         return processedText;

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/documents/adapters/LiveDocAdapterGetDocumentRendererTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/documents/adapters/LiveDocAdapterGetDocumentRendererTest.java
@@ -38,8 +38,8 @@ class LiveDocAdapterGetDocumentRendererTest {
 
             ExportParams exportParams = ExportParams.builder()
                     .urlQueryParameters(Map.of(
-                            LiveDocAdapter.URL_QUERY_PARAM_QUERY, "type:requirement",
-                            LiveDocAdapter.URL_QUERY_PARAM_LANGUAGE, "de"
+                            ExportParams.URL_QUERY_PARAM_QUERY, "type:requirement",
+                            ExportParams.URL_QUERY_PARAM_LANGUAGE, "de"
                     ))
                     .build();
 
@@ -80,7 +80,7 @@ class LiveDocAdapterGetDocumentRendererTest {
                 (mock, context) -> capturedParameters.add((DocumentRendererParameters) context.arguments().get(3)))) {
 
             ExportParams exportParams = ExportParams.builder()
-                    .urlQueryParameters(Map.of(LiveDocAdapter.URL_QUERY_PARAM_QUERY, "status:approved"))
+                    .urlQueryParameters(Map.of(ExportParams.URL_QUERY_PARAM_QUERY, "status:approved"))
                     .build();
 
             LiveDocAdapter.getDocumentRenderer(exportParams, transaction, document);
@@ -100,7 +100,7 @@ class LiveDocAdapterGetDocumentRendererTest {
                 (mock, context) -> capturedParameters.add((DocumentRendererParameters) context.arguments().get(3)))) {
 
             ExportParams exportParams = ExportParams.builder()
-                    .urlQueryParameters(Map.of(LiveDocAdapter.URL_QUERY_PARAM_LANGUAGE, "fr"))
+                    .urlQueryParameters(Map.of(ExportParams.URL_QUERY_PARAM_LANGUAGE, "fr"))
                     .build();
 
             LiveDocAdapter.getDocumentRenderer(exportParams, transaction, document);

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/placeholder/PlaceholderProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/placeholder/PlaceholderProcessorTest.java
@@ -114,4 +114,14 @@ class PlaceholderProcessorTest {
         assertEquals("Filter: type:requirement", result);
     }
 
+    @Test
+    void testPlaceholderValueWithSpecialRegexCharacters() {
+        PlaceholderValues valuesWithSpecialChars = PlaceholderValues.builder()
+                .documentFilter("$100 cost\\item")
+                .build();
+        final String text = "Filter: {{ DOCUMENT_FILTER }}";
+        final String result = placeholderProcessor.processPlaceholders(text, valuesWithSpecialChars);
+        assertEquals("Filter: $100 cost\\item", result);
+    }
+
 }


### PR DESCRIPTION
### Proposed changes

- Move `URL_QUERY_PARAM_QUERY` and `URL_QUERY_PARAM_LANGUAGE` constants to `ExportParams`.
- Update all references and tests to use the new location.
- Fix placeholder processing to correctly handle special characters in regex replacements.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
