### PR TITLE
ci: integrate SonarCloud availability check and conditional caching in Maven workflows

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -57,7 +57,16 @@ jobs:
             echo "version=${VERSION}"
             echo "is_release=${IS_RELEASE}"
           } >> "$GITHUB_OUTPUT"
+      - name: 🔑 Check SonarCloud availability
+        id: sonar_check
+        run: |
+          if [ -n "${SONAR_TOKEN}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: 🔍 Cache SonarQube packages
+        if: steps.sonar_check.outputs.available == 'true'
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: ~/.sonar/cache
@@ -73,14 +82,27 @@ jobs:
           else
             mvn --batch-mode -s "${SETTINGS_XML}" clean verify -P tests-with-weasyprint-docker -Dweasyprint.service.url="${WEASYPRINT_SERVICE_URL}" sonar:sonar
           fi
-      - name: 📦 Build with Maven for PRs
-        if: github.event_name == 'pull_request'
+      - name: 📦 Build with Maven for PRs (with SonarCloud)
+        if: github.event_name == 'pull_request' && steps.sonar_check.outputs.available == 'true'
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_PR_NUMBER_REF: ${{ github.event.pull_request.number }}
         run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify -P tests-with-weasyprint-docker -Dweasyprint.service.url="${WEASYPRINT_SERVICE_URL}" sonar:sonar -Dsonar.pullrequest.base="${GITHUB_BASE_REF}"
           -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" -Dsonar.pullrequest.key="${GITHUB_PR_NUMBER_REF}"
+      - name: 📦 Build with Maven for PRs (without SonarCloud)
+        if: github.event_name == 'pull_request' && steps.sonar_check.outputs.available != 'true'
+        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify -P tests-with-weasyprint-docker -Dweasyprint.service.url="${WEASYPRINT_SERVICE_URL}"
+      - name: 🔍 Check new code coverage
+        if: github.event_name == 'pull_request' && steps.sonar_check.outputs.available != 'true'
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          pip install diff-cover
+          diff-cover target/site/jacoco/jacoco.xml \
+            --compare-branch="origin/${GITHUB_BASE_REF}" \
+            --diff-range-notation='..' \
+            --fail-under=80
       - name: 📋 Analyze dependencies
         run: mvn --batch-mode -s "${SETTINGS_XML}" dependency:analyze
         continue-on-error: false


### PR DESCRIPTION
### Proposed changes

- Add SonarCloud token validation step.
- Apply conditional logic for SonarQube caching and PR builds based on SonarCloud availability.
- Introduce new steps for handling builds without SonarCloud and verifying code coverage using `diff-cover` for PRs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds SonarCloud availability detection by checking `SONAR_TOKEN` and conditionalizes SonarQube caching and PR builds accordingly. Introduces `diff-cover` for code coverage verification when SonarCloud is unavailable.

**Issues found:**
- Push builds (lines 75-84) still run `sonar:sonar` unconditionally, which will fail when `SONAR_TOKEN` is not set - this defeats the purpose of the PR
- Missing Python setup before `pip install diff-cover` (line 101)

<details open><summary><h3>Confidence Score: 2/5</h3></summary>

- This PR has a critical logical error that will cause push builds to fail when SonarCloud is unavailable
- Score reflects incomplete implementation - PR adds conditional SonarCloud logic for PR builds but fails to apply the same logic to push builds, which will break when SONAR_TOKEN is not available
- `.github/workflows/maven-build.yml` lines 75-84 need conditional logic like PR builds
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/maven-build.yml | adds SonarCloud availability check and conditional PR builds, but push builds still run sonar:sonar unconditionally |

</details>


</details>


<sub>Last reviewed commit: 80830da</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->