### PR TITLE
ci: revert sonarcloud conditional logic

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -57,16 +57,7 @@ jobs:
             echo "version=${VERSION}"
             echo "is_release=${IS_RELEASE}"
           } >> "$GITHUB_OUTPUT"
-      - name: 🔑 Check SonarCloud availability
-        id: sonar_check
-        run: |
-          if [ -n "${SONAR_TOKEN}" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          fi
       - name: 🔍 Cache SonarQube packages
-        if: steps.sonar_check.outputs.available == 'true'
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: ~/.sonar/cache
@@ -82,27 +73,14 @@ jobs:
           else
             mvn --batch-mode -s "${SETTINGS_XML}" clean verify -P tests-with-weasyprint-docker -Dweasyprint.service.url="${WEASYPRINT_SERVICE_URL}" sonar:sonar
           fi
-      - name: 📦 Build with Maven for PRs (with SonarCloud)
-        if: github.event_name == 'pull_request' && steps.sonar_check.outputs.available == 'true'
+      - name: 📦 Build with Maven for PRs
+        if: github.event_name == 'pull_request'
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_PR_NUMBER_REF: ${{ github.event.pull_request.number }}
         run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify -P tests-with-weasyprint-docker -Dweasyprint.service.url="${WEASYPRINT_SERVICE_URL}" sonar:sonar -Dsonar.pullrequest.base="${GITHUB_BASE_REF}"
           -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" -Dsonar.pullrequest.key="${GITHUB_PR_NUMBER_REF}"
-      - name: 📦 Build with Maven for PRs (without SonarCloud)
-        if: github.event_name == 'pull_request' && steps.sonar_check.outputs.available != 'true'
-        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify -P tests-with-weasyprint-docker -Dweasyprint.service.url="${WEASYPRINT_SERVICE_URL}"
-      - name: 🔍 Check new code coverage
-        if: github.event_name == 'pull_request' && steps.sonar_check.outputs.available != 'true'
-        env:
-          GITHUB_BASE_REF: ${{ github.base_ref }}
-        run: |
-          pip install diff-cover
-          diff-cover target/site/jacoco/jacoco.xml \
-            --compare-branch="origin/${GITHUB_BASE_REF}" \
-            --diff-range-notation='..' \
-            --fail-under=80
       - name: 📋 Analyze dependencies
         run: mvn --batch-mode -s "${SETTINGS_XML}" dependency:analyze
         continue-on-error: false


### PR DESCRIPTION
### Proposed changes

This pull request simplifies the GitHub Actions workflow for Maven builds by removing conditional logic and steps related to checking SonarCloud token availability. The workflow now always attempts to run SonarCloud analysis for both push and pull request events, and removes alternative build and coverage steps that were previously used when SonarCloud was unavailable.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the Maven CI workflow by removing the conditional `SONAR_TOKEN` availability check and all related fallback steps, so SonarCloud analysis is now always attempted for both push and pull_request events.

Key changes:
- Removes the **"Check SonarCloud availability"** step that gated subsequent steps on `steps.sonar_check.outputs.available`
- Removes the **fallback build steps** (push and PR variants) that ran `mvn clean verify` without `sonar:sonar` when the token was absent
- Removes the **fallback `diff-cover` code coverage check** (Python/pip step) that enforced ≥80% coverage on new code for PRs when Sonar was unavailable
- The SonarQube cache step and the two remaining build steps (push and PR) now run unconditionally

**Potential concern:** The `pull_request` trigger includes PRs from forked repositories, where GitHub withholds secrets. With the fallback removed, any fork PR will fail at the `sonar:sonar` goal since `SONAR_TOKEN` will resolve to an empty string. If this repository only ever receives PRs from internal branches (not forks), the simplification is safe. Otherwise, a conditional fallback should be retained.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe for internal-only PRs, but will break CI for any pull request opened from a forked repository.
- The change is a clean simplification for repositories that receive no fork PRs. However, the unconditional use of `sonar:sonar` without a token fallback is a correctness issue for fork PRs on public repositories, which lowers confidence.
- .github/workflows/maven-build.yml — specifically the PR build step at lines 76–83 where secrets are unavailable for fork events.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/maven-build.yml | Removes SonarCloud availability check and fallback build steps; the workflow now unconditionally runs sonar:sonar, which will fail for fork PRs where SONAR_TOKEN is unavailable. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow Triggered] --> B{Event Type}
    B -- push --> C[Cache SonarQube packages]
    B -- pull_request --> C
    C --> D{Event Type}
    D -- push --> E[Build with Maven for Pushes\nAlways runs sonar:sonar]
    D -- pull_request --> F[Build with Maven for PRs\nAlways runs sonar:sonar]
    E --> G[Analyze dependencies]
    F --> G
    G --> H[Upload build artifacts]

    style E fill:#ffcccc,stroke:#cc0000
    style F fill:#ffcccc,stroke:#cc0000

    note1[/"⚠️ SONAR_TOKEN empty for fork PRs\nsonar:sonar will fail"/]
    F -.-> note1
```
</details>


<sub>Last reviewed commit: 2a4364a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->