### PR TITLE
docs: add performance benchmarks and resource planning guidelines for WeasyPrint service

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,13 +303,7 @@ The weasyprint-service container requires a minimum of **2 GB** of memory. Actua
 | Large without images | ~2000 | none | 2.6 GB | 4.3 MB |
 | Large with images | ~2000 | 1 SVG per WI (1920×1080 px) | 2.8 GB | 18 MB |
 
-**Capacity planning formula:**
-
-```
-Total RAM ≈ 1.7 GB (baseline) + N × (WI_count × 0.5 MB + image_overhead)
-```
-
-Where `N` is the number of concurrent conversions and `image_overhead` depends on image count and resolution (typically 200–300 MB for large images). For example, 3 concurrent conversions of large documents with images: `1.7 + 3 × 1.2 ≈ 5.3 GB`.
+Each concurrent conversion requires additional memory proportional to the values above. For example, 3 concurrent conversions of large documents with images: approximately `1.7 + 3 × 1.2 ≈ 5.3 GB`.
 
 After a conversion completes, container memory (RSS) may not decrease — this is normal Python/glibc behavior, not a leak. To reclaim memory after traffic spikes, enable `RECLAIM_MEMORY_AFTER_CONVERSION=true` in weasyprint-service (runs `gc.collect` + `malloc_trim` after each conversion). See [weasyprint-service README](https://github.com/SchweizerischeBundesbahnen/weasyprint-service#post-conversion-memory-reclamation) for details.
 


### PR DESCRIPTION
### Proposed changes

- Include memory requirements, benchmarks, and capacity planning formulas.
- Document memory reclamation support with the `RECLAIM_MEMORY_AFTER_CONVERSION` setting.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new **"Performance and Resource Planning"** section to `README.md`, documenting memory requirements, benchmark results, and a capacity planning formula for the `weasyprint-service` container. It also explains the expected memory-retention behavior of Python/glibc and documents the `RECLAIM_MEMORY_AFTER_CONVERSION` setting as a mitigation.

**Key changes:**
- Adds minimum memory requirement (2 GB) for the weasyprint-service container.
- Introduces a benchmark table covering three document sizes/image configurations with peak RAM and PDF size measurements.
- Provides a capacity planning formula: `Total RAM ≈ 1.7 GB (baseline) + N × (WI_count × 0.5 MB + image_overhead)`.
- Documents the RSS memory retention behavior and the `RECLAIM_MEMORY_AFTER_CONVERSION=true` knob.

**Issue found:**
- The capacity planning formula is internally inconsistent with the "Small with images" benchmark row. The formula predicts ≈1.95 GB for 500 work items with small images, but the measured peak RAM is 1.8 GB. This numerical inconsistency could mislead users when sizing deployments for smaller workloads. The formula should either be adjusted to match measured data, or clarified as being calibrated for larger documents.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Documentation-only change with no runtime risk; however, capacity planning formula contains a numerical inconsistency with benchmark data.
- The PR is safe to merge from a code perspective (documentation-only). However, the capacity planning formula predicts approximately 1.95 GB for the "Small with images" scenario while the benchmark shows 1.8 GB. This inconsistency should be resolved before merging to prevent misleading users during deployment sizing. The issue is substantive but straightforward to address.
- README.md — the capacity planning formula (lines 302–312) needs adjustment to align with the "Small with images" benchmark measurement.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant WeasyPrintService
    participant Python/glibc

    Client->>WeasyPrintService: PDF conversion request
    WeasyPrintService->>Python/glibc: Allocate memory (document, images)
    Note over Python/glibc: Peak RAM = 1.7 GB baseline<br/>+ N × (WI_count × 0.5 MB + image_overhead)
    Python/glibc-->>WeasyPrintService: PDF output
    WeasyPrintService-->>Client: PDF response

    alt RECLAIM_MEMORY_AFTER_CONVERSION=true
        WeasyPrintService->>Python/glibc: gc.collect() + malloc_trim()
        Python/glibc-->>WeasyPrintService: RSS reduced (memory returned to OS)
    else default behaviour
        Note over Python/glibc: RSS stays elevated (not a leak)
    end
```
</details>

<sub>Last reviewed commit: fa8481d</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->