### PR TITLE
feat: add support for LTS bugfix releases

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['**']
   pull_request:
-    branches: [main]
+    branches: [main, release-v*]
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 env:
@@ -96,7 +96,7 @@ jobs:
           if-no-files-found: error
   deploy-maven-central:
     needs: build
-    if: ${{ needs.build.outputs.is_release == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.build.outputs.is_release == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -133,7 +133,7 @@ jobs:
             -Dmaven.wagon.http.readTimeout=3600000
   deploy-github-packages:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@
 name: release-please
 on:
   push:
-    branches: [main]
+    branches: [main, release-v*]
   workflow_dispatch:
 jobs:
   release-please:
@@ -17,4 +17,4 @@ jobs:
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38  # v4.4.0
         with:
           release-type: maven
-          target-branch: main
+          target-branch: ${{ github.ref_name }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,3 +16,41 @@ Releases within our project are exclusively overseen by designated code owners, 
 
 
 For comprehensive information, please consult the [Release Please documentation](https://github.com/googleapis/release-please).
+
+## LTS (Long-Term Support) Releases
+
+LTS branches allow releasing bug fixes and security patches for older major versions while development continues on `main`.
+
+### Branch Naming Convention
+
+LTS branches follow the pattern: `release-v{major}` (e.g., `release-v6`, `release-v7`)
+
+### Creating an LTS Branch
+
+Create the branch from the last tag of the major version:
+
+```bash
+git checkout v11.1.1          # Last tag of the major version
+git checkout -b release-v11
+git push origin release-v11
+```
+
+### Releasing from LTS Branches
+
+1. Cherry-pick or commit fixes to the LTS branch
+2. Push changes (Release Please automatically creates a release PR)
+3. Merge the release PR to trigger:
+    - Tag creation (e.g., `v11.1.2`)
+    - GitHub Release with artifacts
+    - Maven Central deployment
+
+### Deployment Matrix
+
+| Branch | Version Type | Maven Central | GitHub Packages | GitHub Release |
+|--------|--------------|---------------|-----------------|----------------|
+| `main` | SNAPSHOT | - | ✓ | - |
+| `main` | Release | ✓ | - | ✓ |
+| `release-v*` | SNAPSHOT | - | - | - |
+| `release-v*` | Release | ✓ | - | ✓ |
+
+Each LTS branch operates independently with its own release PR.


### PR DESCRIPTION
Refs: #744

### Proposed changes

Add support for releasing bugfixes for previous major versions using Long-Term Support (LTS) branches.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the CI/CD workflows to support LTS (Long-Term Support) branches for releasing bugfixes against older major versions. The key changes are:

- **release-please.yml**: Trigger extended to `release-v*` branches, with `target-branch` correctly set to `${{ github.ref_name }}` so each LTS branch maintains independent release PRs.
- **RELEASE.md**: Clear documentation added for LTS branch creation, release workflow, naming convention, and a deployment matrix.
- **maven-build.yml**: Updated to trigger on `release-v*` branches for both `deploy-maven-central` and `deploy-github-packages` jobs.

However, there is one functional gap: the SNAPSHOT-specific steps within `deploy-github-packages` (lines 164 and 174) do not exclude `release-v*` branches, causing SNAPSHOT artifacts from LTS branches to be incorrectly published to GitHub Packages. This contradicts the deployment matrix in `RELEASE.md` which specifies that `release-v*` SNAPSHOT should not deploy to GitHub Packages. The fix is to add `&& github.ref == 'refs/heads/main'` to both step conditions.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Merging is safe for the release infrastructure, but LTS SNAPSHOT builds will be incorrectly published to GitHub Packages until the step conditions are tightened.
- The `release-please.yml` and `RELEASE.md` changes are correct and low-risk. The `maven-build.yml` update has a logic gap: the `deploy-github-packages` job's SNAPSHOT-specific steps do not exclude `release-v*` branches, causing unintended GitHub Packages publications that contradict the documented matrix. This is a functional issue that should be fixed before merge, but it does not represent a critical safety concern.
- .github/workflows/maven-build.yml — specifically the SNAPSHOT-guarded steps (lines 164, 174) inside `deploy-github-packages`.
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/maven-build.yml`, line 164-174 ([link](https://github.com/schweizerischebundesbahnen/ch.sbb.polarion.extension.pdf-exporter/blob/f4ffc90db22235fd7b54c48a37d5b858e88ee128/.github/workflows/maven-build.yml#L164-L174)) 

   **SNAPSHOT deployments to GitHub Packages should be `main`-only**

   The SNAPSHOT-related steps (Delete existing SNAPSHOT and Deploy to GitHub Packages) will now run on `release-v*` branches whenever `is_release == 'false'`. However, the `RELEASE.md` deployment matrix explicitly documents that `release-v*` SNAPSHOT should not deploy to GitHub Packages (line 53: `-` indicates no deployment).

   When a SNAPSHOT commit is pushed to a `release-v*` branch:
   1. The job condition (line 136) allows the job to run
   2. Both SNAPSHOT steps execute because they only guard on `is_release == 'false'`
   3. SNAPSHOT artifacts are published to GitHub Packages, violating the documented intent

   To align implementation with the documented matrix, add `&& github.ref == 'refs/heads/main'` to both step conditions:

   

   and

   

   This ensures LTS branches only trigger the "Upload assets to GitHub Release" step (line 182) for release versions.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: f4ffc90</sub>

<!-- /greptile_comment -->