### PR TITLE
ci: add zizmor config to suppress secrets-outside-env

### DIFF
--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,6 +1,7 @@
 ---
 rules:
-  # Secrets are protected by GitHub's fork PR approval requirement,
-  # which prevents untrusted workflows from accessing secrets without explicit approval.
+  # These secrets are passed as required step inputs (with:) to third-party actions
+  # (claude-code-action, actions/setup-java) and cannot be moved to env: blocks.
+  # Fork-PR workflows are additionally protected by GitHub's approval requirement.
   secrets-outside-env:
     ignore: [claude-code-review.yml, maven-build.yml]


### PR DESCRIPTION
## Summary
- Adds `zizmor.yml` config file to suppress `secrets-outside-env` findings for `claude-code-review.yml` and `maven-build.yml`
- These workflows are already protected by GitHub's fork PR approval requirement, which prevents untrusted workflows from accessing secrets

## Test plan
- [ ] Verify `pre-commit run -a` passes (zizmor hook)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `zizmor.yml` configuration file at the repository root to suppress `secrets-outside-env` findings for `claude-code-review.yml` and `maven-build.yml`, allowing `pre-commit run -a` to pass cleanly with the existing zizmor v1.23.1 pre-commit hook.

**Key points:**
- **`zizmor.yml` added** – uses the `rules.<rule>.ignore: [files]` config-file suppression mechanism, consistent with how the existing inline `# zizmor: ignore[unpinned-images]` suppression works in `maven-build.yml`
- **Suppression is justified** – Both workflows pass secrets that must be used as required step inputs to third-party actions (`anthropics/claude-code-action` and `actions/setup-java`) and therefore cannot be moved to `env:` blocks
- **Runtime protections in place:**
  - `claude-code-review.yml`: Fork-PR check prevents execution on untrusted workflows
  - `maven-build.yml`: Branch conditions restrict deployment job to `main`/`release-v*` branches
- **Documentation improvement needed** – the inline comment should clarify that the suppression is necessary due to action-input requirements, not primarily due to fork-PR approval

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor documentation improvement suggested.
- The suppression is technically justified and both workflows have appropriate runtime protections (fork-PR check and branch conditions). The only concern is that the inline comment should more accurately describe why the suppression is needed. The actual code change is sound and poses no safety risk.
- Only `zizmor.yml` requires attention: clarify the justification comment to explain that the secrets are required action inputs (not primarily due to fork-PR approval).
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer runs\npre-commit run -a] --> B[zizmor hook\nv1.23.1]
    B --> C{Load zizmor.yml\nconfig from repo root}
    C --> D[Scan .github/workflows/*.yml]
    D --> E{secrets-outside-env\nfinding?}
    E -- "claude-code-review.yml\nOR maven-build.yml" --> F[Suppressed by\nzizmor.yml ignore list]
    E -- "other workflow files" --> G[Report finding\nPre-commit fails]
    F --> H[Pre-commit passes]
    G --> I[Developer must fix\nor add suppression]
    D --> J{Other rules\ne.g. unpinned-images}
    J -- "inline # zizmor: ignore[...]" --> H
    J -- "no suppression" --> G
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Azizmor.yml%3A3-6%0AThe%20justification%20comment%20doesn't%20fully%20explain%20why%20the%20suppression%20is%20necessary.%0A%0AThese%20secrets%20are%20**required%20step%20inputs**%20%28%60with%3A%60%20%2F%20%60gpg-private-key%3A%60%29%20for%20third-party%20actions%20%28%60anthropics%2Fclaude-code-action%60%20and%20%60actions%2Fsetup-java%60%29%20and%20therefore%20cannot%20be%20moved%20to%20%60env%3A%60%20blocks%20%E2%80%94%20which%20is%20what%20the%20%60secrets-outside-env%60%20rule%20requests.%0A%0AThe%20fork-PR%20protection%20and%20branch%20conditions%20are%20valid%20additional%20layers%20of%20defence%2C%20but%20the%20primary%20reason%20for%20the%20suppression%20is%20the%20action-input%20requirement.%0A%0ASuggested%20improvement%3A%0A%0A%60%60%60suggestion%0A%20%20%23%20These%20secrets%20are%20passed%20as%20required%20step%20inputs%20%28with%3A%29%20to%20third-party%20actions%0A%20%20%23%20%28claude-code-action%2C%20actions%2Fsetup-java%29%20and%20cannot%20be%20moved%20to%20env%3A%20blocks.%0A%20%20%23%20Fork-PR%20workflows%20are%20additionally%20protected%20by%20GitHub's%20approval%20requirement.%0A%20%20secrets-outside-env%3A%0A%20%20%20%20ignore%3A%20%5Bclaude-code-review.yml%2C%20maven-build.yml%5D%0A%60%60%60%0A%0A&repo=schweizerischebundesbahnen%2Fch.sbb.polarion.extension.pdf-exporter"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: 8a161a6</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=e6558864-56dc-444c-a9dc-e6bc419983a7))

<!-- /greptile_comment -->