### PR TITLE
feat: ability to load style package settings by external bundles

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettings.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettings.java
@@ -11,6 +11,7 @@ import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.ImageDensity
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage.StylePackageModel;
 import com.polarion.core.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
 public class StylePackageSettings extends GenericNamedSettings<StylePackageModel> {
@@ -35,7 +36,7 @@ public class StylePackageSettings extends GenericNamedSettings<StylePackageModel
      * Loads a style package by name. In OSGi, other bundles may use a different SettingId class
      * instance due to classloader boundaries, so using the name avoids ClassCastException.
      */
-    public StylePackageModel loadByName(String projectId, String name) {
+    public @NotNull StylePackageModel loadByName(@Nullable String projectId, @NotNull String name) {
         return load(projectId, SettingId.fromName(name));
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettings.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettings.java
@@ -1,6 +1,7 @@
 package ch.sbb.polarion.extension.pdf_exporter.settings;
 
 import ch.sbb.polarion.extension.generic.settings.GenericNamedSettings;
+import ch.sbb.polarion.extension.generic.settings.SettingId;
 import ch.sbb.polarion.extension.generic.settings.SettingsService;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.CommentsRenderType;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.Orientation;
@@ -28,6 +29,14 @@ public class StylePackageSettings extends GenericNamedSettings<StylePackageModel
     public void beforeSave(@NotNull StylePackageModel what) {
         adjustAndValidateWeight(what);
         validateMatchingQuery(what);
+    }
+
+    /**
+     * Loads a style package by name. In OSGi, other bundles may use a different SettingId class
+     * instance due to classloader boundaries, so using the name avoids ClassCastException.
+     */
+    public StylePackageModel loadByName(String projectId, String name) {
+        return load(projectId, SettingId.fromName(name));
     }
 
     @Override

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -3,4 +3,6 @@ Bundle-Name: PDF Exporter Extension for Polarion ALM
 Export-Package: ch.sbb.polarion.extension.pdf_exporter,
  ch.sbb.polarion.extension.pdf_exporter.converter,
  ch.sbb.polarion.extension.pdf_exporter.rest.model,
- ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion
+ ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion,
+ ch.sbb.polarion.extension.pdf_exporter.rest.model.settings.stylepackage,
+ ch.sbb.polarion.extension.pdf_exporter.settings

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettingsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettingsTest.java
@@ -227,7 +227,7 @@ class StylePackageSettingsTest {
             StylePackageModel result = stylePackageSettings.loadByName(projectId, settingName);
 
             assertSame(expectedModel, result);
-            verify(stylePackageSettings).load(eq(projectId), eq(SettingId.fromName(settingName)));
+            verify(stylePackageSettings).load(projectId, SettingId.fromName(settingName));
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettingsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettingsTest.java
@@ -211,6 +211,27 @@ class StylePackageSettingsTest {
     }
 
     @Test
+    void testLoadByNameDelegatesToLoad() {
+        try (MockedStatic<ScopeUtils> mockScopeUtils = mockStatic(ScopeUtils.class)) {
+            SettingsService mockedSettingsService = mock(SettingsService.class);
+            mockScopeUtils.when(() -> ScopeUtils.getFileContent(any())).thenCallRealMethod();
+
+            StylePackageSettings stylePackageSettings = spy(new StylePackageSettings(mockedSettingsService));
+
+            String projectId = "test_project";
+            String settingName = "my_style";
+            StylePackageModel expectedModel = StylePackageModel.builder().css("testCss").build();
+
+            doReturn(expectedModel).when(stylePackageSettings).load(eq(projectId), any(SettingId.class));
+
+            StylePackageModel result = stylePackageSettings.loadByName(projectId, settingName);
+
+            assertSame(expectedModel, result);
+            verify(stylePackageSettings).load(eq(projectId), eq(SettingId.fromName(settingName)));
+        }
+    }
+
+    @Test
     void testValidateMatchingQuery() {
         try (MockedStatic<ScopeUtils> mockScopeUtils = mockStatic(ScopeUtils.class)) {
             SettingsService mockedSettingsService = mock(SettingsService.class);

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettingsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/settings/StylePackageSettingsTest.java
@@ -232,6 +232,26 @@ class StylePackageSettingsTest {
     }
 
     @Test
+    void testLoadByNameWithNullProjectId() {
+        try (MockedStatic<ScopeUtils> mockScopeUtils = mockStatic(ScopeUtils.class)) {
+            SettingsService mockedSettingsService = mock(SettingsService.class);
+            mockScopeUtils.when(() -> ScopeUtils.getFileContent(any())).thenCallRealMethod();
+
+            StylePackageSettings stylePackageSettings = spy(new StylePackageSettings(mockedSettingsService));
+
+            String settingName = "my_style";
+            StylePackageModel expectedModel = StylePackageModel.builder().css("testCss").build();
+
+            doReturn(expectedModel).when(stylePackageSettings).load(isNull(), any(SettingId.class));
+
+            StylePackageModel result = stylePackageSettings.loadByName(null, settingName);
+
+            assertSame(expectedModel, result);
+            verify(stylePackageSettings).load(isNull(), eq(SettingId.fromName(settingName)));
+        }
+    }
+
+    @Test
     void testValidateMatchingQuery() {
         try (MockedStatic<ScopeUtils> mockScopeUtils = mockStatic(ScopeUtils.class)) {
             SettingsService mockedSettingsService = mock(SettingsService.class);


### PR DESCRIPTION
Refs: #780

### Proposed changes

We must allow external bundles to read style package settings in order to be able to implement some advanced workflows.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
