### PR TITLE
ci: add release-please-guard caller workflow

### DIFF
--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -1,0 +1,11 @@
+---
+name: release-please-guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions: {}
+jobs:
+  release-please-guard:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-release-please-guard.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary

- Add `release-please-guard` workflow that calls the reusable workflow from `github-workflows-polarion`
- Blocks PR merges when the base branch `pom.xml` version is not a SNAPSHOT, preventing commits from landing between a release and the snapshot version bump

## Setup required after merge

- Add `release-please-guard` as a required status check in branch protection rules
- Enable "Require branches to be up to date before merging"