### PR TITLE
fix: prevent text from being pulled onto next page by single-row tables

### DIFF
--- a/src/main/resources/default/dle-pdf-export.css
+++ b/src/main/resources/default/dle-pdf-export.css
@@ -414,7 +414,7 @@ ul.toc li > a.page-number::after {
         break-after: avoid;
     }
 
-    tr:last-child {
+    tr:last-child:not(:first-child) {
         break-before: avoid;
     }
 

--- a/src/main/resources/default/dle-pdf-export.css
+++ b/src/main/resources/default/dle-pdf-export.css
@@ -410,7 +410,7 @@ ul.toc li > a.page-number::after {
         break-inside: avoid;
     }
 
-    tr:first-child {
+    tr:first-child:not(:last-child) {
         break-after: avoid;
     }
 


### PR DESCRIPTION
Refs: #793

### Proposed changes

Prevent text from being pulled onto next page by tables.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
