### PR TITLE
Align CI workflows with template & revert SNAPSHOT delete workaround

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,3 +13,4 @@ jobs:
     permissions:
       checks: write
       contents: read
+      pull-requests: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,7 @@ jobs:
   claude-review:
     uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude-code-review.yml@main
     permissions:
+      actions: read
       contents: read
       pull-requests: write
       issues: write

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -66,15 +66,15 @@ jobs:
       - name: 📦 Build with Maven for Pushes
         if: github.event_name == 'push'
         env:
-          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          BRANCH_NAME: ${{ github.ref_name }}
           IS_PUBLIC: ${{ github.event.repository.visibility == 'public' }}
           IS_TEMPLATE: ${{ github.event.repository.is_template }}
         run: |
           SONAR_ARGS=()
           if [ "${IS_PUBLIC}" = "true" ] && [ "${IS_TEMPLATE}" != "true" ]; then
             SONAR_ARGS+=(sonar:sonar "-Dsonar.exclusions=.github/**")
-            if [ -n "${GITHUB_HEAD_REF}" ]; then
-              SONAR_ARGS+=("-Dsonar.branch.name=${GITHUB_HEAD_REF}")
+            if [ -n "${BRANCH_NAME}" ]; then
+              SONAR_ARGS+=("-Dsonar.branch.name=${BRANCH_NAME}")
             fi
           fi
           mvn --batch-mode -s "${SETTINGS_XML}" clean verify -P tests-with-weasyprint-docker -Dweasyprint.service.url="${WEASYPRINT_SERVICE_URL}" "${SONAR_ARGS[@]}"
@@ -84,8 +84,14 @@ jobs:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
           GITHUB_PR_NUMBER_REF: ${{ github.event.pull_request.number }}
-        run: mvn --batch-mode -s "${SETTINGS_XML}" clean verify -P tests-with-weasyprint-docker -Dweasyprint.service.url="${WEASYPRINT_SERVICE_URL}" sonar:sonar -Dsonar.pullrequest.base="${GITHUB_BASE_REF}"
-          -Dsonar.pullrequest.branch="${GITHUB_HEAD_REF}" -Dsonar.pullrequest.key="${GITHUB_PR_NUMBER_REF}"
+          IS_PUBLIC: ${{ github.event.repository.visibility == 'public' }}
+          IS_TEMPLATE: ${{ github.event.repository.is_template }}
+        run: |
+          SONAR_ARGS=()
+          if [ "${IS_PUBLIC}" = "true" ] && [ "${IS_TEMPLATE}" != "true" ]; then
+            SONAR_ARGS+=(sonar:sonar "-Dsonar.pullrequest.base=${GITHUB_BASE_REF}" "-Dsonar.pullrequest.branch=${GITHUB_HEAD_REF}" "-Dsonar.pullrequest.key=${GITHUB_PR_NUMBER_REF}" "-Dsonar.exclusions=.github/**")
+          fi
+          mvn --batch-mode -s "${SETTINGS_XML}" clean verify -P tests-with-weasyprint-docker -Dweasyprint.service.url="${WEASYPRINT_SERVICE_URL}" "${SONAR_ARGS[@]}"
       - name: 📋 Analyze dependencies
         run: mvn --batch-mode -s "${SETTINGS_XML}" dependency:analyze
         continue-on-error: false

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -170,21 +170,6 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: maven
-      - name: 🗑️ Delete existing SNAPSHOT version from GitHub Packages
-        # May fail if the SNAPSHOT is the only version in the package,
-        # as GitHub API does not allow deleting the last version.
-        # Safe to ignore — no accumulation problem with a single version.
-        if: ${{ needs.build.outputs.is_release == 'false' }}
-        continue-on-error: true
-        run: |
-          GROUP_ID=$(mvn -s "${SETTINGS_XML}" help:evaluate -Dexpression=project.groupId -q -DforceStdout)
-          ARTIFACT_ID=$(mvn -s "${SETTINGS_XML}" help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
-          PACKAGE_NAME="${GROUP_ID}.${ARTIFACT_ID}"
-          API_URL="/orgs/${GITHUB_REPOSITORY_OWNER}/packages/maven/${PACKAGE_NAME}/versions"
-          VERSION_ID=$(gh api --paginate "${API_URL}" --jq ".[] | select(.name == \"${PROJECT_VERSION}\") | .id" || true)
-          if [ -n "${VERSION_ID}" ]; then
-            gh api --method DELETE "${API_URL}/${VERSION_ID}"
-          fi
       - name: 📦 Deploy to GitHub Packages
         # Releases should only be deployed to GitHub Packages when the repo is private
         # Snapshots are always deployed to GitHub Packages


### PR DESCRIPTION
## Summary
- **Revert SNAPSHOT delete workaround** (closes #795): the workaround from #713 / issue #712 is no longer needed now that the upstream Ansible `community.general` `maven_artifact` fix has landed (https://github.com/ansible-collections/community.general/pull/11501) and been verified.
- **Align CI workflows with template** (`open-source-polarion-java-repo-template`):
  - `actionlint.yml`: add `pull-requests: read` permission — closes #774 (required by the upstream reusable workflow `reusable-actionlint.yml`).
  - `claude-code-review.yml`: add `actions: read` permission.
  - `maven-build.yml` push job: use `BRANCH_NAME` (`github.ref_name`) for `sonar.branch.name`. `github.head_ref` is empty on push events, so the previous code never set `sonar.branch.name` for branch analysis.
  - `maven-build.yml` PR job: gate `sonar:sonar` with `IS_PUBLIC && !IS_TEMPLATE` (matches the push job; prevents forks/templates from pushing to SonarCloud).

## Test plan
- [ ] CI green on this PR
- [ ] After merge, confirm a SNAPSHOT push to `main` resolves correctly via Ansible `maven_artifact` (already verified by issue reporter)
- [ ] After merge, confirm SonarCloud picks up the correct branch name on push events
- [ ] After merge, confirm the actionlint reusable workflow no longer emits `startup_failure` on PR runs