### PR TITLE
fix: when author of a comment was deleted as a user in polarion, generation of pdf shouldn't fail

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/LiveDocCommentsProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/LiveDocCommentsProcessor.java
@@ -163,7 +163,7 @@ public class LiveDocCommentsProcessor {
 
     private CommentData getCommentData(LiveDocComment liveDocComment) {
         User user = liveDocComment.getAuthor().get();
-        String authorName = user != null ? user.fields().name().get() : null;
+        String authorName = user != null ? (user.isUnresolvable() ? user.label() : user.fields().name().get()) : null;
         String commentText = liveDocComment.getText().persistedHtml();
         boolean resolved = liveDocComment.getResolved().get();
         return CommentData.builder()

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/LiveDocCommentsProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/LiveDocCommentsProcessor.java
@@ -163,7 +163,7 @@ public class LiveDocCommentsProcessor {
 
     private CommentData getCommentData(LiveDocComment liveDocComment) {
         User user = liveDocComment.getAuthor().get();
-        String authorName = user != null ? (user.isUnresolvable() ? user.label() : user.fields().name().get()) : null;
+        String authorName = user != null ? getUserName(user) : null;
         String commentText = liveDocComment.getText().persistedHtml();
         boolean resolved = liveDocComment.getResolved().get();
         return CommentData.builder()
@@ -173,6 +173,10 @@ public class LiveDocCommentsProcessor {
                 .text(commentText)
                 .resolved(resolved)
                 .build();
+    }
+
+    private String getUserName(@NotNull User user) {
+        return user.isUnresolvable() ? user.label() : user.fields().name().get();
     }
 
     @VisibleForTesting

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/LiveDocCommentsProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/LiveDocCommentsProcessorTest.java
@@ -329,6 +329,47 @@ class LiveDocCommentsProcessorTest {
         assertEquals(html, result);
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void addLiveDocCommentsUsesUserLabelWhenAuthorIsUnresolvable() {
+        ProxyDocument document = mock(ProxyDocument.class, RETURNS_DEEP_STUBS);
+
+        UpdatableDocumentFields fields = mock(UpdatableDocumentFields.class);
+        CommentBasesTreeField<CommentBase> comments = mock(CommentBasesTreeField.class);
+        doCallRealMethod().when(comments).forEach(any(Consumer.class));
+        when(fields.comments()).thenReturn(comments);
+        when(document.fields()).thenReturn(fields);
+
+        String html = """
+                <span id="polarion-comment:1"></span>
+                """;
+
+        CommentBase unresolvableAuthorComment = mockCommentWithUnresolvableAuthor("1", "text1", "deleted-user-label");
+        when(comments.iterator()).thenReturn(List.of(unresolvableAuthorComment).iterator());
+
+        LiveDocCommentsProcessor processor = new LiveDocCommentsProcessor();
+        Map<String, LiveDocComment> liveDocComments = processor.getLiveDocComments(document, CommentsRenderType.OPEN);
+        String result = processor.addLiveDocComments(html, liveDocComments, false, new HashSet<>());
+
+        assertTrue(result.contains("[span class=author]deleted-user-label[/span]"));
+    }
+
+    @SneakyThrows
+    private CommentBase mockCommentWithUnresolvableAuthor(String id, String text, String userLabel) {
+        CommentBase comment = mock(CommentBase.class, RETURNS_DEEP_STUBS);
+        CommentBasesField<CommentBase> emptyChildComments = mockEmptyChildComment();
+        lenient().when(comment.fields().parentComment().get()).thenReturn(null);
+        lenient().when(comment.fields().id().get()).thenReturn(id);
+        lenient().when(comment.fields().created().get()).thenReturn(new SimpleDateFormat("yyyy-MM-dd HH:mm").parse("2025-03-13 16:21"));
+        lenient().when(comment.fields().text().persistedHtml()).thenReturn(text);
+        com.polarion.alm.shared.api.model.user.User user = Objects.requireNonNull(comment.fields().author().get());
+        lenient().when(user.isUnresolvable()).thenReturn(true);
+        lenient().when(user.label()).thenReturn(userLabel);
+        lenient().when(comment.fields().childComments()).thenReturn(emptyChildComments);
+        lenient().when(comment.fields().resolved().get()).thenReturn(false);
+        return comment;
+    }
+
     @SneakyThrows
     private CommentBase mockComment(String id, String text, String author, boolean resolved, boolean rootComment, boolean addChildComment) {
         CommentBase comment = mock(CommentBase.class, RETURNS_DEEP_STUBS);


### PR DESCRIPTION
### Proposed changes

When author of a comment was deleted as a user in Polarion, generation of pdf fails. This PR fixes this

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
