### PR TITLE
fix: use correct enum names for PDF variant fallback values

### DIFF
--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
@@ -322,7 +322,7 @@ export default class ExportPopup {
         this.ctx.setValue("popup-headers-color", stylePackage.headersColor);
         this.ctx.setValue("popup-paper-size-selector", stylePackage.paperSize || ExportParams.PaperSize.A4);
         this.ctx.setValue("popup-orientation-selector", stylePackage.orientation || ExportParams.Orientation.PORTRAIT);
-        this.ctx.setValue("popup-pdf-variant-selector", stylePackage.pdfVariant || ExportParams.PdfVariant.PDF_A_2B);
+        this.ctx.setValue("popup-pdf-variant-selector", stylePackage.pdfVariant || 'PDF_A_2B');
         this.ctx.setValue("popup-image-density-selector", stylePackage.imageDensity || ExportParams.ImageDensity.DPI_96);
         this.ctx.setCheckbox("popup-full-fonts", stylePackage.fullFonts);
         this.ctx.setCheckbox("popup-fit-to-page", stylePackage.fitToPage);


### PR DESCRIPTION
Refs: #812

### Proposed changes

Fix PdfVariant constants in ExportParams.js to use backend enum names (PDF_A_2B) instead of WeasyPrint format (pdf/a-2b)

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
