### PR TITLE
chore: sync from open-source-polarion-java-repo-template@3dc98c4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,22 @@
+---
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # Weekly, off-peak Sunday — matches the cadence default setup uses.
+    - cron: 17 5 * * 0
+permissions: {}
+jobs:
+  analyze:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-codeql-java.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+      packages: read
+    secrets:
+      IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}

--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -12,4 +12,3 @@ jobs:
       contents: read
     with:
       spec-path: docs/openapi.json
-      redocly-args: --extends=minimal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,12 @@
 ## Gotchas
 
 - **`ch.sbb.polarion.extension.generic`** is the parent project providing reusable infrastructure for all Polarion plugins in this org (settings framework, REST base classes, OSGi helpers, etc.). Before implementing anything cross-cutting, check if it already exists there.
-
 - **Package naming**: Use `ch.sbb.polarion.extension.pdf_exporter` (underscore). Pre-v7.0.0 code used `pdf.exporter` (dot) — don't follow old patterns still present in the codebase.
-- **After any code change**: Delete `<polarion_home>/data/workspace/.config` before restarting Polarion or changes won't be picked up.
+- **Maven Settings**: Builds require `.mvn/settings.xml` (JFrog, GitHub Packages, Sonatype credentials via env vars). CI passes it with `-s .mvn/settings.xml`. `.mvn/maven.config` auto-activates the Polarion version profile.
+- **Polarion Dependencies**: You must extract dependencies from the Polarion installer using [polarion-artifacts-deployer](https://github.com/SchweizerischeBundesbahnen/polarion-artifacts-deployer) before the Maven build will work.
+- **Local Polarion Installation**: Requires `POLARION_HOME` environment variable. Use the `install-to-local-polarion` Maven profile: `mvn clean install -P install-to-local-polarion`
+- **After any code change**: Delete `<POLARION_HOME>/data/workspace/.config` before restarting Polarion or changes won't be picked up.
+- **Remote Debugging**: Add to Polarion's `config.sh`: `JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"`
+- **Logging**: Polarion logs: `<POLARION_HOME>/polarion/logs/main/*.log`
+- **Branch conventions**: Conventional commits enforced by commitizen (pre-commit hook). Feature branches: `feature/<name>`, bug fixes: `fix/<name>`, LTS branches: `release-v*` (e.g., `release-v6`).
 - **Pre-commit hooks block internal patterns**: some org-specific identifiers are treated as secrets. Run `pre-commit run -a` after implementation.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,10 @@ Releases within our project are exclusively overseen by designated code owners, 
 4. Subsequent to each release, the process iterates to update the version to X.Y.Z-SNAPSHOT, thereby preparing a new pull request for the forthcoming X.Y.Z version release.
 
 
+### Branch Protection
+
+The [`release-please-guard`](/.github/workflows/release-please-guard.yml) workflow prevents PRs from merging while a release-please snapshot PR is pending. This ensures the snapshot version bump lands immediately after the release, avoiding misordered commits on the target branch. To enforce this, add `release-please-guard` as a required status check in your branch protection rules for `main` and any `release-v*` branches, and enable "Require branches to be up to date before merging". This ensures PRs that previously passed the guard are rechecked when a release-please PR is opened.
+
 For comprehensive information, please consult the [Release Please documentation](https://github.com/googleapis/release-please).
 
 ## LTS (Long-Term Support) Releases
@@ -35,6 +39,8 @@ git checkout -b release-v11
 git push origin release-v11
 ```
 
+The `release-v*` pattern in the workflow automatically recognizes new LTS branches.
+
 ### Releasing from LTS Branches
 
 1. Cherry-pick or commit fixes to the LTS branch
@@ -53,4 +59,8 @@ git push origin release-v11
 | `release-v*` | SNAPSHOT | - | - | - |
 | `release-v*` | Release | ✓ | - | ✓ |
 
-Each LTS branch operates independently with its own release PR.
+### Notes
+
+- SNAPSHOT versions from LTS branches are NOT deployed to GitHub Packages
+- Only release versions from LTS branches are deployed to Maven Central
+- Each LTS branch operates independently with its own release PR


### PR DESCRIPTION
Syncs CI/docs drift from `open-source-polarion-java-repo-template`@`3dc98c4` (2026-06-08).

Closes #825.

This is a **surgical sync** — three template-eligible files were deliberately *not* synced because they carry intentional project-specific config (details below).

## Synced

| File | Action | Source (template) |
|------|--------|-------------------|
| `.github/workflows/codeql.yml` | **add** | #139 *add CodeQL workflow via reusable-codeql-java* |
| `.github/workflows/openapi-validation.yml` | update | #151 *drop --extends=minimal so redocly.yaml governs openapi lint* |
| `CLAUDE.md` | update (hand-merge) | #120, #132 |
| `RELEASE.md` | update (hand-merge) | #123, #132 |

- **codeql.yml** — repo was on CodeQL **default setup**, which silently overrides a committed `codeql.yml`. This PR's sync **switched the repo setting default→advanced** (`code-scanning/default-setup` → `not-configured`) so the workflow takes effect. ⚠️ Coverage trade-off: the reusable `codeql-java` workflow scans `java-kotlin` only; the `actions` scanning that default setup performed is dropped — actionlint + zizmor continue to cover workflows.
- **openapi-validation.yml** — drops the redundant `redocly-args: --extends=minimal`. `redocly.yaml` is byte-identical to the template and already tunes the relevant rule severities, so it is now the single source of truth. The OpenAPI Validation check on this PR confirms `docs/openapi.json` still validates.
- **CLAUDE.md** — grafts the template's generic gotchas (Maven settings, Polarion deps, local install, remote debugging, logging, branch conventions); **keeps** the repo-specific "Package naming (`pdf_exporter` underscore)" gotcha.
- **RELEASE.md** — adds the **Branch Protection** section (documents the already-present `release-please-guard.yml`) and the LTS **Notes** section; **keeps** this repo's `v11` LTS examples (template ships generic `v6` placeholders).

## Deliberately NOT synced (intentional project divergence)

| File | Reason |
|------|--------|
| `renovate.json` | `weasyprint-service.version` custom manager for `versions.properties` (#267). |
| `NOTICE` | Bundled **DejaVu fonts** attribution (#768). |
| `.github/workflows/maven-build.yml` | **weasyprint-service** test container + `tests-with-weasyprint-docker` profile. Only generic deltas were an `actions/checkout` pin bump (Renovate's job) and a minor `SONAR_SCANNER_OPTS` removal — not worth overwriting the test setup. |

## Repo-setting changed by this sync

- **CodeQL default → advanced setup** (see codeql.yml note above).
