### PR TITLE
fix: more proper handling of images with empty source (prevent logging errors)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,10 +241,11 @@
             <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Route SLF4J (used by flying-saucer) to Log4j2 so its logs can be captured by InMemoryAppender in tests -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/TableAnalyzer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/TableAnalyzer.java
@@ -6,10 +6,17 @@ import org.jetbrains.annotations.NotNull;
 import org.jsoup.helper.W3CDom;
 import org.jsoup.nodes.Element;
 import org.w3c.dom.Document;
+import org.xhtmlrenderer.extend.ReplacedElement;
+import org.xhtmlrenderer.extend.ReplacedElementFactory;
+import org.xhtmlrenderer.extend.UserAgentCallback;
+import org.xhtmlrenderer.layout.LayoutContext;
 import org.xhtmlrenderer.newtable.TableSectionBox;
+import org.xhtmlrenderer.render.BlockBox;
 import org.xhtmlrenderer.render.Box;
 import org.xhtmlrenderer.render.LineBox;
 import org.xhtmlrenderer.simple.Graphics2DRenderer;
+import org.xhtmlrenderer.simple.extend.FormSubmissionListener;
+import org.xhtmlrenderer.swing.EmptyReplacedElement;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -77,6 +84,15 @@ public class TableAnalyzer {
 
     private Box render(@NotNull Document doc, int pageWidth) {
         Graphics2DRenderer renderer = new Graphics2DRenderer(doc, "");
+
+        // This is a throwaway measurement-only layout over an isolated shell document with an empty base URL,
+        // so image sources are not resolvable here anyway. Source-less images would otherwise drive
+        // flying-saucer into building a -1x-1 placeholder image, which throws internally and gets logged at
+        // ERROR (see SwingReplacedElementFactory#newIrreplaceableImageElement). Short-circuit those images to
+        // an empty element while delegating healthy images to the default factory so they still contribute
+        // their intrinsic width to the measurement. Must be set before layout().
+        ReplacedElementFactory defaultFactory = renderer.getSharedContext().getReplacedElementFactory();
+        renderer.getSharedContext().setReplacedElementFactory(new SourceAwareReplacedElementFactory(defaultFactory));
 
         BufferedImage image = new BufferedImage(pageWidth, PAGE_HEIGHT, BufferedImage.TYPE_BYTE_GRAY);
         Graphics2D g2d = image.createGraphics();
@@ -190,5 +206,51 @@ public class TableAnalyzer {
             }
         }
         return adjustedWidths;
+    }
+
+    /**
+     * A {@link ReplacedElementFactory} for the measurement-only pre-render that neutralises source-less images.
+     * <p>
+     * flying-saucer's default factory tries to build a "missing image" placeholder for an {@code <img>} whose
+     * source is absent/empty. When the element additionally has no explicit width/height both CSS dimensions
+     * resolve to {@code -1}, and the placeholder construction throws {@code IllegalArgumentException} internally,
+     * which is swallowed but logged at ERROR with a full stacktrace. Such images are returned as an empty
+     * element here so that buggy path is never reached. Everything else (healthy images, form controls, ...)
+     * is delegated to the default factory so it still contributes its real intrinsic width to the measurement.
+     */
+    private static class SourceAwareReplacedElementFactory implements ReplacedElementFactory {
+        private final ReplacedElementFactory delegate;
+
+        SourceAwareReplacedElementFactory(ReplacedElementFactory delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ReplacedElement createReplacedElement(LayoutContext c, BlockBox box, UserAgentCallback uac, int cssWidth, int cssHeight) {
+            org.w3c.dom.Element element = box.getElement();
+            if (element != null && c.getNamespaceHandler().isImageElement(element)) {
+                String src = c.getNamespaceHandler().getImageSourceURI(element);
+                if (src == null || src.isEmpty()) {
+                    // No usable source in this measurement-only pass: avoid the -1x-1 placeholder attempt.
+                    return new EmptyReplacedElement(Math.max(cssWidth, 0), Math.max(cssHeight, 0));
+                }
+            }
+            return delegate.createReplacedElement(c, box, uac, cssWidth, cssHeight);
+        }
+
+        @Override
+        public void reset() {
+            delegate.reset();
+        }
+
+        @Override
+        public void remove(org.w3c.dom.Element e) {
+            delegate.remove(e);
+        }
+
+        @Override
+        public void setFormSubmissionListener(FormSubmissionListener listener) {
+            delegate.setFormSubmissionListener(listener);
+        }
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/TableAnalyzer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/TableAnalyzer.java
@@ -218,7 +218,7 @@ public class TableAnalyzer {
      * element here so that buggy path is never reached. Everything else (healthy images, form controls, ...)
      * is delegated to the default factory so it still contributes its real intrinsic width to the measurement.
      */
-    private static class SourceAwareReplacedElementFactory implements ReplacedElementFactory {
+    static class SourceAwareReplacedElementFactory implements ReplacedElementFactory {
         private final ReplacedElementFactory delegate;
 
         SourceAwareReplacedElementFactory(ReplacedElementFactory delegate) {
@@ -230,7 +230,7 @@ public class TableAnalyzer {
             org.w3c.dom.Element element = box.getElement();
             if (element != null && c.getNamespaceHandler().isImageElement(element)) {
                 String src = c.getNamespaceHandler().getImageSourceURI(element);
-                if (src == null || src.isEmpty()) {
+                if (src == null || src.isBlank()) {
                     // No usable source in this measurement-only pass: avoid the -1x-1 placeholder attempt.
                     return new EmptyReplacedElement(Math.max(cssWidth, 0), Math.max(cssHeight, 0));
                 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/SourceAwareReplacedElementFactoryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/SourceAwareReplacedElementFactoryTest.java
@@ -1,0 +1,122 @@
+package ch.sbb.polarion.extension.pdf_exporter.util.adjuster;
+
+import ch.sbb.polarion.extension.pdf_exporter.util.adjuster.TableAnalyzer.SourceAwareReplacedElementFactory;
+import org.junit.jupiter.api.Test;
+import org.xhtmlrenderer.extend.NamespaceHandler;
+import org.xhtmlrenderer.extend.ReplacedElement;
+import org.xhtmlrenderer.extend.ReplacedElementFactory;
+import org.xhtmlrenderer.extend.UserAgentCallback;
+import org.xhtmlrenderer.layout.LayoutContext;
+import org.xhtmlrenderer.render.BlockBox;
+import org.xhtmlrenderer.simple.extend.FormSubmissionListener;
+import org.xhtmlrenderer.swing.EmptyReplacedElement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class SourceAwareReplacedElementFactoryTest {
+
+    private final ReplacedElementFactory delegate = mock(ReplacedElementFactory.class);
+    private final SourceAwareReplacedElementFactory factory = new SourceAwareReplacedElementFactory(delegate);
+
+    private final LayoutContext context = mock(LayoutContext.class);
+    private final BlockBox box = mock(BlockBox.class);
+    private final UserAgentCallback uac = mock(UserAgentCallback.class);
+    private final NamespaceHandler namespaceHandler = mock(NamespaceHandler.class);
+    private final org.w3c.dom.Element element = mock(org.w3c.dom.Element.class);
+
+    @Test
+    void returnsEmptyElementForImageWithNullSourceWithoutDelegating() {
+        when(box.getElement()).thenReturn(element);
+        when(context.getNamespaceHandler()).thenReturn(namespaceHandler);
+        when(namespaceHandler.isImageElement(element)).thenReturn(true);
+        when(namespaceHandler.getImageSourceURI(element)).thenReturn(null);
+
+        ReplacedElement result = factory.createReplacedElement(context, box, uac, -1, -1);
+
+        EmptyReplacedElement empty = assertInstanceOf(EmptyReplacedElement.class, result);
+        // -1 dimensions must be clamped to 0 to avoid flying-saucer's -1x-1 placeholder attempt
+        assertEquals(0, empty.getIntrinsicWidth());
+        assertEquals(0, empty.getIntrinsicHeight());
+        verify(delegate, org.mockito.Mockito.never()).createReplacedElement(context, box, uac, -1, -1);
+    }
+
+    @Test
+    void returnsEmptyElementForImageWithBlankSourceClampingNegativeDimensions() {
+        when(box.getElement()).thenReturn(element);
+        when(context.getNamespaceHandler()).thenReturn(namespaceHandler);
+        when(namespaceHandler.isImageElement(element)).thenReturn(true);
+        when(namespaceHandler.getImageSourceURI(element)).thenReturn("   ");
+
+        ReplacedElement result = factory.createReplacedElement(context, box, uac, 50, -1);
+
+        EmptyReplacedElement empty = assertInstanceOf(EmptyReplacedElement.class, result);
+        assertEquals(50, empty.getIntrinsicWidth());
+        assertEquals(0, empty.getIntrinsicHeight());
+    }
+
+    @Test
+    void delegatesForImageWithUsableSource() {
+        ReplacedElement delegated = mock(ReplacedElement.class);
+        when(box.getElement()).thenReturn(element);
+        when(context.getNamespaceHandler()).thenReturn(namespaceHandler);
+        when(namespaceHandler.isImageElement(element)).thenReturn(true);
+        when(namespaceHandler.getImageSourceURI(element)).thenReturn("image.png");
+        when(delegate.createReplacedElement(context, box, uac, 100, 80)).thenReturn(delegated);
+
+        ReplacedElement result = factory.createReplacedElement(context, box, uac, 100, 80);
+
+        assertSame(delegated, result);
+    }
+
+    @Test
+    void delegatesForNonImageElement() {
+        ReplacedElement delegated = mock(ReplacedElement.class);
+        when(box.getElement()).thenReturn(element);
+        when(context.getNamespaceHandler()).thenReturn(namespaceHandler);
+        when(namespaceHandler.isImageElement(element)).thenReturn(false);
+        when(delegate.createReplacedElement(context, box, uac, 10, 20)).thenReturn(delegated);
+
+        ReplacedElement result = factory.createReplacedElement(context, box, uac, 10, 20);
+
+        assertSame(delegated, result);
+        // For non-image elements the source must never be inspected
+        verify(namespaceHandler, org.mockito.Mockito.never()).getImageSourceURI(element);
+    }
+
+    @Test
+    void delegatesWhenBoxHasNoElement() {
+        ReplacedElement delegated = mock(ReplacedElement.class);
+        when(box.getElement()).thenReturn(null);
+        when(delegate.createReplacedElement(context, box, uac, 5, 5)).thenReturn(delegated);
+
+        ReplacedElement result = factory.createReplacedElement(context, box, uac, 5, 5);
+
+        assertSame(delegated, result);
+        verifyNoInteractions(namespaceHandler);
+    }
+
+    @Test
+    void resetDelegates() {
+        factory.reset();
+        verify(delegate).reset();
+    }
+
+    @Test
+    void removeDelegates() {
+        factory.remove(element);
+        verify(delegate).remove(element);
+    }
+
+    @Test
+    void setFormSubmissionListenerDelegates() {
+        FormSubmissionListener listener = mock(FormSubmissionListener.class);
+        factory.setFormSubmissionListener(listener);
+        verify(delegate).setFormSubmissionListener(listener);
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/TableAnalyzerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/TableAnalyzerTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.Test;
 
 import java.awt.*;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -189,6 +192,42 @@ class TableAnalyzerTest {
                 "Shorter text column should be narrower: col0=" + columnWidths.get(0) + ", col1=" + columnWidths.get(1));
         assertTrue(columnWidths.get(1) < columnWidths.get(2),
                 "Medium text column should be narrower than long: col1=" + columnWidths.get(1) + ", col2=" + columnWidths.get(2));
+    }
+
+    // Dedicated file that flying-saucer (org.xhtmlrenderer) logs into during tests; configured in
+    // src/test/resources/log4j2.xml via the SLF4J -> Log4j2 bridge.
+    private static final Path FLYING_SAUCER_LOG = Path.of("target", "flying-saucer.log");
+
+    @Test
+    @SneakyThrows
+    void getColumnWidthsWithSourcelessImageDoesNotLogErrors() {
+        // An <img> with no usable src and no explicit width/height: during the measurement-only
+        // pre-render flying-saucer resolves both CSS dimensions to -1 and (without the fix) tries to
+        // build a -1x-1 placeholder image, which throws IllegalArgumentException internally and is
+        // logged at ERROR by org.xhtmlrenderer.swing.SwingReplacedElementFactory. The export still
+        // completes, but the log noise is the bug we guard against here.
+        Element table = new Element(Tag.valueOf("table"), "");
+        Element row = table.appendElement("tr");
+        row.appendElement("td").appendElement("img"); // no src, no width/height
+        row.appendElement("td").text("Some text");
+
+        // The log file accumulates across the test run, so compare what flying-saucer logs *during* this call.
+        String logBefore = readFlyingSaucerLog();
+        Map<Integer, Integer> columnWidths = TableAnalyzer.getColumnWidths(table, 600);
+        String logged = readFlyingSaucerLog().substring(logBefore.length());
+
+        assertFalse(logged.contains("Failed to create image element"),
+                "Source-less image must not trigger flying-saucer's failed-image ERROR during measurement, but it logged:\n" + logged);
+        assertFalse(logged.contains("cannot be <= 0"),
+                "Source-less image must not trigger an IllegalArgumentException for a -1x-1 placeholder, but it logged:\n" + logged);
+
+        // Measurement must still succeed and yield both columns.
+        assertEquals(2, columnWidths.size(), "Both columns should still be measured");
+    }
+
+    @SneakyThrows
+    private static String readFlyingSaucerLog() {
+        return Files.exists(FLYING_SAUCER_LOG) ? Files.readString(FLYING_SAUCER_LOG, StandardCharsets.UTF_8) : "";
     }
 
     private Element createSimpleTable() {

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -9,9 +9,21 @@
 		<!-- InMemoryAppender -->
 		<InMemoryAppender name="InMemoryAppender"/>
 
+		<!-- Dedicated file for flying-saucer (org.xhtmlrenderer) logs, so tests can assert on what it logged
+		     without hijacking System.out. Truncated on every test JVM start (append=false). -->
+		<File name="FlyingSaucerFile" fileName="target/flying-saucer.log" append="false">
+			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+		</File>
+
 	</Appenders>
 
 	<Loggers>
+		<!-- flying-saucer logs (routed here via SLF4J -> Log4j2 bridge) go only to their own file, keeping
+		     the console and the InMemoryAppender free of rendering noise. -->
+		<Logger name="org.xhtmlrenderer" level="warn" additivity="false">
+			<AppenderRef ref="FlyingSaucerFile"/>
+		</Logger>
+
 		<Root level="DEBUG">
 			<AppenderRef ref="Console"/>
 			<AppenderRef ref="InMemoryAppender"/>

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,4 +1,0 @@
-org.slf4j.simpleLogger.logFile=System.out
-org.slf4j.simpleLogger.defaultLogLevel=info
-org.slf4j.simpleLogger.showDateTime=true
-org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS


### PR DESCRIPTION
### Proposed changes

When html with images which don't have a source converted to HTML we see errors in logs. This is not critical as conversion still runs successfully. This fix handle such cases more properly to suppress those errors from being logging. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
