### PR TITLE
fix: preserve thumbnail parameter for non-renderable attachment icons…

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -21,6 +21,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
@@ -38,6 +39,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 
 import static ch.sbb.polarion.extension.pdf_exporter.util.TikaMimeTypeResolver.PARAM_RESULT;
@@ -55,6 +57,15 @@ public class MediaUtils {
     private static final int PDF_TO_PNG_DPI = 300;
     private static final String IMG_FORMAT_PNG = "png";
     private static final String ALLOWED_FOLDER_FOR_BINARY_FILES = "/default/";
+
+    /**
+     * File extensions for resources that Polarion can render as images.
+     * Includes native image formats and convertible diagram formats (e.g. vsdx).
+     * For these, the 'thumbnail' parameter is stripped to fetch the full-size image.
+     */
+    private static final Set<String> RENDERABLE_EXTENSIONS = Set.of(
+            "png", "jpg", "jpeg", "gif", "bmp", "svg", "webp", "tiff", "tif", "ico", "cur", "vsdx"
+    );
 
     private static final Map<String, String> CUSTOM_MIME_TYPES_MAP = Map.of(
             "cur", "image/x-icon",
@@ -265,7 +276,13 @@ public class MediaUtils {
     public String inlineBase64Resources(String content, FileResourceProvider fileResourceProvider) {
         RegexMatcher.IReplacementCalculator dataReplacement = engine -> {
             String url = engine.group("url");
-            String base64String = MediaUtils.isDataUrl(url) ? url : fileResourceProvider.getResourceAsBase64String(removeQueryParameter(url, THUMBNAIL_PARAMETER));
+            if (MediaUtils.isDataUrl(url)) {
+                return null;
+            }
+            // For renderable resources (images, diagrams like .vsdx), strip 'thumbnail' to get full-size content.
+            // For non-renderable attachments (e.g. .xlsx, .docx), keep 'thumbnail' so Polarion returns an icon preview.
+            String resourceUrl = isRenderableResourceUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
+            String base64String = fileResourceProvider.getResourceAsBase64String(resourceUrl);
             return base64String == null ? null : engine.group().replace(url, base64String);
         };
 
@@ -273,6 +290,21 @@ public class MediaUtils {
         String intermediateResult = RegexMatcher.get(IMG_SRC_REGEX).replace(content, dataReplacement);
         // replace CSS parameters like background: src('/polarion/...
         return RegexMatcher.get(URL_REGEX).useJavaUtil().replace(intermediateResult, dataReplacement);
+    }
+
+    /**
+     * Checks whether the URL points to a resource that Polarion can render as an image,
+     * based on its file extension.
+     */
+    @VisibleForTesting
+    static boolean isRenderableResourceUrl(@Nullable String url) {
+        if (url == null || url.isEmpty()) {
+            return false;
+        }
+        return RegexMatcher.get(RESOURCE_EXTENSION_REGEX)
+                .findFirst(url, engine -> engine.group("extension"))
+                .map(ext -> RENDERABLE_EXTENSIONS.contains(ext.toLowerCase()))
+                .orElse(false);
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -59,12 +59,14 @@ public class MediaUtils {
     private static final String ALLOWED_FOLDER_FOR_BINARY_FILES = "/default/";
 
     /**
-     * File extensions for resources that Polarion can render as images.
-     * Includes native image formats and convertible diagram formats (e.g. vsdx).
-     * For these, the 'thumbnail' parameter is stripped to fetch the full-size image.
+     * File extensions for attachments that cannot be rendered as images (e.g. spreadsheets, documents).
+     * For these, the 'thumbnail' query parameter is kept so Polarion returns an icon preview.
+     * All other extensions (images, diagrams, unknown formats) have 'thumbnail' stripped to fetch full content.
      */
-    private static final Set<String> RENDERABLE_EXTENSIONS = Set.of(
-            "png", "jpg", "jpeg", "gif", "bmp", "svg", "webp", "tiff", "tif", "ico", "cur", "vsdx"
+    private static final Set<String> NON_RENDERABLE_EXTENSIONS = Set.of(
+            "xlsx", "xls", "docx", "doc", "pptx", "ppt", "pdf", "zip", "rar", "7z",
+            "csv", "xml", "json", "yaml", "yml",
+            "jar", "war", "ear", "tar", "gz"
     );
 
     private static final Map<String, String> CUSTOM_MIME_TYPES_MAP = Map.of(
@@ -279,9 +281,9 @@ public class MediaUtils {
             if (MediaUtils.isDataUrl(url)) {
                 return null;
             }
-            // For renderable resources (images, diagrams like .vsdx), strip 'thumbnail' to get full-size content.
             // For non-renderable attachments (e.g. .xlsx, .docx), keep 'thumbnail' so Polarion returns an icon preview.
-            String resourceUrl = isRenderableResourceUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
+            // For everything else (images, diagrams, unknown formats), strip 'thumbnail' to get full-size content.
+            String resourceUrl = isNonRenderableResourceUrl(url) ? url : removeQueryParameter(url, THUMBNAIL_PARAMETER);
             String base64String = fileResourceProvider.getResourceAsBase64String(resourceUrl);
             return base64String == null ? null : engine.group().replace(url, base64String);
         };
@@ -293,17 +295,17 @@ public class MediaUtils {
     }
 
     /**
-     * Checks whether the URL points to a resource that Polarion can render as an image,
-     * based on its file extension.
+     * Checks whether the URL points to a non-renderable attachment (e.g. spreadsheet, document)
+     * that cannot be displayed as an image, based on its file extension.
      */
     @VisibleForTesting
-    static boolean isRenderableResourceUrl(@Nullable String url) {
+    static boolean isNonRenderableResourceUrl(@Nullable String url) {
         if (url == null || url.isEmpty()) {
             return false;
         }
         return RegexMatcher.get(RESOURCE_EXTENSION_REGEX)
                 .findFirst(url, engine -> engine.group("extension"))
-                .map(ext -> RENDERABLE_EXTENSIONS.contains(ext.toLowerCase()))
+                .map(ext -> NON_RENDERABLE_EXTENSIONS.contains(ext.toLowerCase()))
                 .orElse(false);
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -149,6 +149,24 @@ class MediaUtilsTest {
         assertEquals(expected, MediaUtils.removeQueryParameter(input, THUMBNAIL_PARAMETER));
     }
 
+    @Test
+    void isRenderableResourceUrlTest() {
+        // Image formats
+        assertTrue(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/photo.png"));
+        assertTrue(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/photo.jpg?revision=1"));
+        assertTrue(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/tw.svg?revision=123&view=true"));
+        assertTrue(MediaUtils.isRenderableResourceUrl("/polarion/icons/default/enums/req_status_draft.gif?buildId=123"));
+        // Convertible diagram formats
+        assertTrue(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/diagram.vsdx?revision=2&thumbnail=true"));
+        // Non-renderable attachments
+        assertFalse(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/Book1.xlsx?thumbnail=true"));
+        assertFalse(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/doc.docx?thumbnail=true"));
+        assertFalse(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/file.pdf?thumbnail=true"));
+        // Edge cases
+        assertFalse(MediaUtils.isRenderableResourceUrl(null));
+        assertFalse(MediaUtils.isRenderableResourceUrl(""));
+    }
+
     private void fillImageWithColor(BufferedImage image, Color color) {
         Graphics2D g2d = image.createGraphics();
         g2d.setColor(color);

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -150,21 +150,23 @@ class MediaUtilsTest {
     }
 
     @Test
-    void isRenderableResourceUrlTest() {
-        // Image formats
-        assertTrue(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/photo.png"));
-        assertTrue(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/photo.jpg?revision=1"));
-        assertTrue(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/tw.svg?revision=123&view=true"));
-        assertTrue(MediaUtils.isRenderableResourceUrl("/polarion/icons/default/enums/req_status_draft.gif?buildId=123"));
-        // Convertible diagram formats
-        assertTrue(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/diagram.vsdx?revision=2&thumbnail=true"));
+    void isNonRenderableResourceUrlTest() {
         // Non-renderable attachments
-        assertFalse(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/Book1.xlsx?thumbnail=true"));
-        assertFalse(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/doc.docx?thumbnail=true"));
-        assertFalse(MediaUtils.isRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/file.pdf?thumbnail=true"));
+        assertTrue(MediaUtils.isNonRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/Book1.xlsx?thumbnail=true"));
+        assertTrue(MediaUtils.isNonRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/doc.docx?thumbnail=true"));
+        assertTrue(MediaUtils.isNonRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/file.pdf?thumbnail=true"));
+        assertTrue(MediaUtils.isNonRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/archive.zip?thumbnail=true"));
+        // Image formats — renderable
+        assertFalse(MediaUtils.isNonRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/photo.png"));
+        assertFalse(MediaUtils.isNonRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/tw.svg?revision=123&view=true"));
+        assertFalse(MediaUtils.isNonRenderableResourceUrl("/polarion/icons/default/enums/req_status_draft.gif?buildId=123"));
+        // Convertible diagram formats — renderable
+        assertFalse(MediaUtils.isNonRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/diagram.vsdx?revision=2&thumbnail=true"));
+        // Unknown formats default to renderable (thumbnail stripped) to avoid breaking new image formats
+        assertFalse(MediaUtils.isNonRenderableResourceUrl("http://localhost/polarion/wi-attachment/project/WI-1/photo.avif"));
         // Edge cases
-        assertFalse(MediaUtils.isRenderableResourceUrl(null));
-        assertFalse(MediaUtils.isRenderableResourceUrl(""));
+        assertFalse(MediaUtils.isNonRenderableResourceUrl(null));
+        assertFalse(MediaUtils.isNonRenderableResourceUrl(""));
     }
 
     private void fillImageWithColor(BufferedImage image, Color color) {


### PR DESCRIPTION
… in PDF export

Refs: #832

### Proposed changes

Non-renderable attachments (e.g. .xlsx, .docx) referenced in Work Item descriptions                                                                                                                                                                                                                                                                                                                                                                                              are displayed in Polarion with a thumbnail preview icon via the 'thumbnail' query parameter.                                                                                                                                                                                                                                                                                                                                                                                     
Previously, this parameter was always stripped, causing Polarion to return raw binary content                                                                                                                                                                                                                                                                                                                                                                                  instead of a renderable icon — resulting in missing attachment icons in the exported PDF.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
