### PR TITLE
fix: skip formula images in adjustImageAlignment to preserve text flow

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -513,6 +513,7 @@ public class HtmlProcessor {
     }
 
     @VisibleForTesting
+    @SuppressWarnings("java:S135") //multiple continues for early-exit guard clauses
     void adjustImageAlignment(@NotNull Document document) {
         Elements images = document.select(HtmlTag.IMG);
         for (Element image : images) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -525,6 +525,12 @@ public class HtmlProcessor {
                     continue;
                 }
 
+                // Formula images already have correct block/centering styles from Polarion,
+                // wrapping them in an extra <div> disrupts the text flow around them
+                if (image.hasClass("polarion-rte-formula")) {
+                    continue;
+                }
+
                 Element wrapper = new Element(HtmlTag.DIV);
                 String marginValue = CssUtils.getPropertyValue(cssStyles, CssProp.MARGIN);
                 if (RIGHT_ALIGNMENT_MARGIN.equals(marginValue)) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -531,25 +531,26 @@ public class HtmlProcessor {
                     continue;
                 }
 
-                Element wrapper = new Element(HtmlTag.DIV);
-                String marginValue = CssUtils.getPropertyValue(cssStyles, CssProp.MARGIN);
-                if (RIGHT_ALIGNMENT_MARGIN.equals(marginValue)) {
-                    wrapper.attr(HtmlTagAttr.STYLE, String.format("%s: %s;", CssProp.TEXT_ALIGN, CssProp.TEXT_ALIGN_RIGHT_VALUE));
-                } else {
-                    wrapper.attr(HtmlTagAttr.STYLE, String.format("%s: %s;", CssProp.TEXT_ALIGN, CssProp.TEXT_ALIGN_CENTER_VALUE));
-                }
-
-                Element previousSibling = image.previousElementSibling();
-                if (previousSibling != null) {
-                    previousSibling.after(wrapper);
-                } else {
-                    Element parent = image.parent();
-                    Objects.requireNonNullElse(parent, document.body()).prependChild(wrapper);
-                }
-                image.remove();
-                wrapper.appendChild(image);
+                wrapImageWithAlignment(document, image, cssStyles);
             }
         }
+    }
+
+    private void wrapImageWithAlignment(@NotNull Document document, @NotNull Element image, @NotNull CSSDeclarationList cssStyles) {
+        String marginValue = CssUtils.getPropertyValue(cssStyles, CssProp.MARGIN);
+        String alignment = RIGHT_ALIGNMENT_MARGIN.equals(marginValue) ? CssProp.TEXT_ALIGN_RIGHT_VALUE : CssProp.TEXT_ALIGN_CENTER_VALUE;
+
+        Element wrapper = new Element(HtmlTag.DIV);
+        wrapper.attr(HtmlTagAttr.STYLE, String.format("%s: %s;", CssProp.TEXT_ALIGN, alignment));
+
+        Element previousSibling = image.previousElementSibling();
+        if (previousSibling != null) {
+            previousSibling.after(wrapper);
+        } else {
+            Objects.requireNonNullElse(image.parent(), document.body()).prependChild(wrapper);
+        }
+        image.remove();
+        wrapper.appendChild(image);
     }
 
     @VisibleForTesting

--- a/src/test/resources/imageAlignmentAfterProcessing.html
+++ b/src/test/resources/imageAlignmentAfterProcessing.html
@@ -11,3 +11,4 @@
         <img src="image.png" style="display: block; inset: auto 0px auto auto;" />
     </div>
 </aside>
+<p>Formula 1 : <img class="polarion-rte-formula" src="data:image/svg+xml;base64,abc" style="display: block; padding: 5px 0px; margin-left: auto; margin-right: auto;" /></p>

--- a/src/test/resources/imageAlignmentBeforeProcessing.html
+++ b/src/test/resources/imageAlignmentBeforeProcessing.html
@@ -7,3 +7,4 @@
     <p>Paragraph</p>
     <img src="image.png" style="display: block; inset: auto 0px auto auto;" />
 </aside>
+<p>Formula 1 : <img class="polarion-rte-formula" src="data:image/svg+xml;base64,abc" style="display: block; padding: 5px 0px; margin-left: auto; margin-right: auto;" /></p>


### PR DESCRIPTION
Refs: #831

### Proposed changes

  Formula images (class="polarion-rte-formula") already have correct display:block                                                                                                                                                                                                                                                                                                                                                                                                 
  and centering styles from Polarion.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
