### PR TITLE
ci: publish SNAPSHOTs to sbb.jfrog.io and stop using GitHub Packages

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,5 @@ jobs:
       contents: read
       security-events: write
       actions: read
-      packages: read
     secrets:
       IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,5 +17,6 @@ jobs:
       contents: read
       security-events: write
       actions: read
+      packages: read
     secrets:
       IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -126,7 +126,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     env:
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_USERNAME }}
       COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN: ${{ secrets.COM_SONATYPE_CENTRAL_POLARION_OPENSOURCE_TOKEN }}

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -104,20 +104,6 @@ jobs:
             target/*.pom
           retention-days: 1
           if-no-files-found: error
-      - name: 📦 Deploy snapshot to JFrog Artifactory
-        # Reuse the artifact just built above (no rebuild); SNAPSHOTs from main only.
-        # Main JAR + POM only — sources/javadoc are intentionally not attached to
-        # snapshots; they are produced and published only for Maven Central releases.
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.project_metadata.outputs.is_release == 'false' }}
-        env:
-          PROJECT_VERSION: ${{ steps.project_metadata.outputs.version }}
-        run: |
-          jar=(target/*-"${PROJECT_VERSION}".jar)
-          mvn --batch-mode -s "${SETTINGS_XML}" deploy:deploy-file \
-            -DrepositoryId=jfrog_io \
-            -Durl=https://sbb.jfrog.io/artifactory/polarion-mvn \
-            -DpomFile=pom.xml \
-            -Dfile="${jar[0]}"
   # Deploy releases to Maven Central from main and LTS branches (release-v*)
   # See RELEASE.md for LTS branch documentation
   deploy-maven-central:
@@ -157,11 +143,54 @@ jobs:
             -Dmaven.wagon.http.connectionTimeout=3600000 \
             -Dmaven.wagon.http.readTimeout=3600000 \
             -Dcentral-publishing-maven-plugin.autoPublish=${{ github.event.repository.visibility == 'public' }}
-  # Upload release assets (the built JAR) to the GitHub Release. Nothing is published to
-  # GitHub Packages: releases go to Maven Central, SNAPSHOTs to JFrog Artifactory.
-  upload-release-assets:
+  # Publish to JFrog Artifactory (sbb.jfrog.io/artifactory/polarion-mvn).
+  # SNAPSHOTs from main always; releases only when the repo is private (public
+  # releases go to Maven Central, see deploy-maven-central). Reuses the artifact
+  # built by the build job via deploy:deploy-file (no rebuild).
+  deploy-jfrog-io:
     needs: build
     if: ${{ github.ref == 'refs/heads/main' || (needs.build.outputs.is_release == 'true' && startsWith(github.ref, 'refs/heads/release-v')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
+      PROJECT_VERSION: ${{ needs.build.outputs.project_version }}
+    steps:
+      - name: 📄 Checkout the repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: 📥 Download build artifacts
+        # The artifacts are generated in the 'build' job
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: maven-artifacts
+          path: target/
+      - name: 🧱 Set up JDK and Maven
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+      - name: 📦 Deploy to JFrog Artifactory
+        # SNAPSHOTs always; releases only when the repo is private (public releases
+        # go to Maven Central). Main JAR + POM only — sources/javadoc are produced
+        # only for Maven Central releases.
+        if: ${{ needs.build.outputs.is_release == 'false' || github.event.repository.visibility == 'private' }}
+        run: |
+          jar=(target/*-"${PROJECT_VERSION}".jar)
+          mvn --batch-mode -s "${SETTINGS_XML}" deploy:deploy-file \
+            -DrepositoryId=jfrog_io \
+            -Durl=https://sbb.jfrog.io/artifactory/polarion-mvn \
+            -DpomFile=pom.xml \
+            -Dfile="${jar[0]}"
+  # Attach the built JAR to the GitHub Release page. Releases are published to Maven
+  # Central (public repos) or JFrog Artifactory (private repos); SNAPSHOTs go to JFrog.
+  upload-release-assets:
+    needs: build
+    if: ${{ needs.build.outputs.is_release == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -181,6 +210,5 @@ jobs:
           name: maven-artifacts
           path: target/
       - name: 📦 Upload assets to GitHub Release
-        if: ${{ needs.build.outputs.is_release == 'true' }}
         run: |-
           gh release upload "v${PROJECT_VERSION}" "target/*-${PROJECT_VERSION}.jar" --clobber

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -159,18 +159,16 @@ jobs:
             -Dmaven.wagon.http.connectionTimeout=3600000 \
             -Dmaven.wagon.http.readTimeout=3600000 \
             -Dcentral-publishing-maven-plugin.autoPublish=${{ github.event.repository.visibility == 'public' }}
-  # Deploy releases to GitHub Packages (private repos only) and upload release assets to GitHub Release.
-  # SNAPSHOTs are published to JFrog Artifactory from the build job instead.
-  deploy-github-packages:
+  # Upload release assets (the built JAR) to the GitHub Release. Nothing is published to
+  # GitHub Packages: releases go to Maven Central, SNAPSHOTs to JFrog Artifactory.
+  upload-release-assets:
     needs: build
     if: ${{ needs.build.outputs.is_release == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      GITHUB_REPO_NAME: ${{ github.repository }}
       PROJECT_VERSION: ${{ needs.build.outputs.project_version }}
     steps:
       - name: 📄 Checkout the repository
@@ -184,23 +182,6 @@ jobs:
         with:
           name: maven-artifacts
           path: target/
-      - name: 🧱 Set up JDK and Maven
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
-        with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-          cache: maven
-      - name: 📦 Deploy to GitHub Packages
-        # Releases should only be deployed to GitHub Packages when the repo is private
-        # SNAPSHOTs go to JFrog Artifactory (published from the build job).
-        if: ${{ github.event.repository.visibility == 'private' }}
-        run: |
-          mvn --batch-mode -s "${SETTINGS_XML}" deploy \
-            -Dmaven.test.skip=true \
-            -Dmaven.javadoc.skip=true \
-            -Dmaven.source.skip=true \
-            -P deploy-github-packages
       - name: 📦 Upload assets to GitHub Release
-        if: ${{ needs.build.outputs.is_release == 'true' }}
         run: |-
           gh release upload "v${PROJECT_VERSION}" "target/*-${PROJECT_VERSION}.jar" --clobber

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -105,6 +105,20 @@ jobs:
             target/*.pom
           retention-days: 1
           if-no-files-found: error
+      - name: 📦 Deploy snapshot to JFrog Artifactory
+        # Reuse the artifact just built above (no rebuild); SNAPSHOTs from main only.
+        # Main JAR + POM only; sources/javadoc are intentionally not published for
+        # snapshots, matching the previous GitHub Packages deployment.
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.project_metadata.outputs.is_release == 'false' }}
+        env:
+          PROJECT_VERSION: ${{ steps.project_metadata.outputs.version }}
+        run: |
+          jar=(target/*-"${PROJECT_VERSION}".jar)
+          mvn --batch-mode -s "${SETTINGS_XML}" deploy:deploy-file \
+            -DrepositoryId=jfrog_io \
+            -Durl=https://sbb.jfrog.io/artifactory/polarion-mvn \
+            -DpomFile=pom.xml \
+            -Dfile="${jar[0]}"
   # Deploy releases to Maven Central from main and LTS branches (release-v*)
   # See RELEASE.md for LTS branch documentation
   deploy-maven-central:
@@ -145,11 +159,11 @@ jobs:
             -Dmaven.wagon.http.connectionTimeout=3600000 \
             -Dmaven.wagon.http.readTimeout=3600000 \
             -Dcentral-publishing-maven-plugin.autoPublish=${{ github.event.repository.visibility == 'public' }}
-  # Deploy to GitHub Packages (snapshots from main only) and upload release assets to GitHub Release
-  # LTS branches (release-v*) only upload release assets, no snapshot deployment
+  # Deploy releases to GitHub Packages (private repos only) and upload release assets to GitHub Release.
+  # SNAPSHOTs are published to JFrog Artifactory from the build job instead.
   deploy-github-packages:
     needs: build
-    if: ${{ github.ref == 'refs/heads/main' || (needs.build.outputs.is_release == 'true' && startsWith(github.ref, 'refs/heads/release-v')) }}
+    if: ${{ needs.build.outputs.is_release == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -178,8 +192,8 @@ jobs:
           cache: maven
       - name: 📦 Deploy to GitHub Packages
         # Releases should only be deployed to GitHub Packages when the repo is private
-        # Snapshots are always deployed to GitHub Packages
-        if: ${{ needs.build.outputs.is_release == 'false' || github.event.repository.visibility == 'private' }}
+        # SNAPSHOTs go to JFrog Artifactory (published from the build job).
+        if: ${{ github.event.repository.visibility == 'private' }}
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" deploy \
             -Dmaven.test.skip=true \

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -107,8 +107,8 @@ jobs:
           if-no-files-found: error
       - name: 📦 Deploy snapshot to JFrog Artifactory
         # Reuse the artifact just built above (no rebuild); SNAPSHOTs from main only.
-        # Main JAR + POM only; sources/javadoc are intentionally not published for
-        # snapshots, matching the previous GitHub Packages deployment.
+        # Main JAR + POM only — sources/javadoc are intentionally not attached to
+        # snapshots; they are produced and published only for Maven Central releases.
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.project_metadata.outputs.is_release == 'false' }}
         env:
           PROJECT_VERSION: ${{ steps.project_metadata.outputs.version }}

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     services:
       weasyprint:
         image: ghcr.io/schweizerischebundesbahnen/weasyprint-service:latest@sha256:3b5113e120e5f079b17eeb24ed89072e0ae1f123c726ebb6c6590ec07eb3ad9f  # zizmor: ignore[unpinned-images]

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -162,7 +162,7 @@ jobs:
   # GitHub Packages: releases go to Maven Central, SNAPSHOTs to JFrog Artifactory.
   upload-release-assets:
     needs: build
-    if: ${{ needs.build.outputs.is_release == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-v')) }}
+    if: ${{ github.ref == 'refs/heads/main' || (needs.build.outputs.is_release == 'true' && startsWith(github.ref, 'refs/heads/release-v')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -182,5 +182,6 @@ jobs:
           name: maven-artifacts
           path: target/
       - name: 📦 Upload assets to GitHub Release
+        if: ${{ needs.build.outputs.is_release == 'true' }}
         run: |-
           gh release upload "v${PROJECT_VERSION}" "target/*-${PROJECT_VERSION}.jar" --clobber

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,11 +1,11 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <activeProfiles>
-        <activeProfile>github</activeProfile>
+        <activeProfile>repositories</activeProfile>
     </activeProfiles>
     <profiles>
         <profile>
-            <id>github</id>
+            <id>repositories</id>
             <repositories>
                 <repository>
                     <id>jfrog_io</id>
@@ -23,12 +23,6 @@
             </repositories>
             <pluginRepositories/>
         </profile>
-        <profile>
-            <id>deploy-github-packages</id>
-            <properties>
-                <altDeploymentRepository>github::https://maven.pkg.github.com/${env.GITHUB_REPO_NAME}</altDeploymentRepository>
-            </properties>
-        </profile>
     </profiles>
     <servers>
         <server>
@@ -41,11 +35,6 @@
                     </property>
                 </httpHeaders>
             </configuration>
-        </server>
-        <server>
-            <id>github</id>
-            <username>${env.GITHUB_ACTOR}</username>
-            <password>${env.GITHUB_TOKEN}</password>
         </server>
         <server>
             <id>sonatype-central</id>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -15,6 +15,10 @@
                         <enabled>true</enabled>
                         <updatePolicy>never</updatePolicy>
                     </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
                 </repository>
             </repositories>
             <pluginRepositories/>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,11 +1,11 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <activeProfiles>
-        <activeProfile>repositories</activeProfile>
+        <activeProfile>jfrog</activeProfile>
     </activeProfiles>
     <profiles>
         <profile>
-            <id>repositories</id>
+            <id>jfrog</id>
             <repositories>
                 <repository>
                     <id>jfrog_io</id>


### PR DESCRIPTION
### Proposed changes

Final artifact-publishing scheme for **pdf-exporter** (pilot):

- **Releases → Maven Central** — unchanged (`deploy-maven-central` job).
- **SNAPSHOTs → JFrog Artifactory** (`sbb.jfrog.io/artifactory/polarion-mvn`) — published from the `build` job by reusing the already-built artifact (`deploy:deploy-file`, no rebuild), gated to `-SNAPSHOT` pushes on `main`. `<snapshots>` resolution is enabled on the `jfrog_io` repository so consumers can resolve them.
- **GitHub Packages → nothing** — removed the GitHub Packages deploy step, the `deploy-github-packages` profile and the `github` server from `.mvn/settings.xml`. The former `deploy-github-packages` job now only uploads the release JAR to the GitHub Release page (renamed `upload-release-assets`).
- Renamed the settings profile `github` → `jfrog` (it only holds the JFrog read repository).

Preparation for the broader migration (system tests Bitbucket → GitHub). The parent `generic` settings will be updated separately once this pilot is validated.

Closes #858

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works _(N/A — CI publishing config)_
- [x] If applicable, I have checked that any relevant tests pass after adding my changes _(the `build` job runs on this PR)_
- [ ] I have updated any relevant documentation _(N/A — internal CI publishing change)_
