### PR TITLE
fix: silence headless anti-alias hint warning in table analyzer

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/TableAnalyzer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/TableAnalyzer.java
@@ -34,6 +34,18 @@ import java.util.Set;
 public class TableAnalyzer {
     private static final Logger logger = Logger.getLogger(TableAnalyzer.class);
 
+    static {
+        // flying-saucer ships a broken default for "xr.text.aa-rendering-hint"
+        // ("RenderingHints.VALUE_TEXT_ANTIALIAS_HGRB" - unqualified class name, non-existent constant), so
+        // Java2DTextRenderer can never resolve it and instead queries the AWT desktop font hints. On a headless
+        // server those are null, the subsequent map lookup throws an NPE which flying-saucer swallows but logs at
+        // WARN with a full stack trace - once per renderer, i.e. once per table we measure. Pin a valid,
+        // fully-qualified constant before flying-saucer's Configuration singleton is first read (it absorbs xr.*
+        // system properties at init, and TableAnalyzer is this project's only flying-saucer entry point) so the
+        // desktop-hints path - and its noise - is never reached, keeping anti-aliasing deterministic too.
+        System.setProperty("xr.text.aa-rendering-hint", "java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON");
+    }
+
     private static final String TABLE = "table";
     private static final String TBODY = "tbody";
     private static final String TR = "tr";

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/TableAnalyzerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/adjuster/TableAnalyzerTest.java
@@ -225,6 +225,24 @@ class TableAnalyzerTest {
         assertEquals(2, columnWidths.size(), "Both columns should still be measured");
     }
 
+    @Test
+    @SneakyThrows
+    void antiAliasRenderingHintResolvesToRealConstant() {
+        // Force TableAnalyzer's static initializer to run, pinning xr.text.aa-rendering-hint before
+        // flying-saucer's Configuration singleton is first read.
+        Class.forName(TableAnalyzer.class.getName());
+
+        // flying-saucer's own default ("RenderingHints.VALUE_TEXT_ANTIALIAS_HGRB") is unresolvable, so without
+        // the fix this returns the sentinel and Java2DTextRenderer falls back to the AWT desktop hints - null on
+        // a headless server - which throws an NPE logged at WARN for every renderer (one per table). Verify the
+        // hint instead resolves to a real constant so that path is never taken.
+        Object sentinel = new Object();
+        Object hint = org.xhtmlrenderer.util.Configuration.valueFromClassConstant("xr.text.aa-rendering-hint", sentinel);
+
+        assertNotSame(sentinel, hint, "aa-rendering-hint must resolve to a real RenderingHints constant, not the fallback");
+        assertSame(RenderingHints.VALUE_TEXT_ANTIALIAS_ON, hint, "aa-rendering-hint should resolve to VALUE_TEXT_ANTIALIAS_ON");
+    }
+
     @SneakyThrows
     private static String readFlyingSaucerLog() {
         return Files.exists(FLYING_SAUCER_LOG) ? Files.readString(FLYING_SAUCER_LOG, StandardCharsets.UTF_8) : "";


### PR DESCRIPTION
### Proposed changes

flying-saucer's default xr.text.aa-rendering-hint is an unresolvable class constant, so Java2DTextRenderer falls back to the AWT desktop font hints, which are null on a headless server. The resulting NPE is swallowed but logged at WARN with a full stack trace once per renderer (one per measured table). Pin a valid, fully-qualified RenderingHints constant before flying-saucer's Configuration singleton initializes so the desktop-hints path is never reached, also making anti-aliasing deterministic.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
