### PR TITLE
fix: avoid regex backtracking when trimming trailing slashes

### DIFF
--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/base/BaseWeasyPrintTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/base/BaseWeasyPrintTest.java
@@ -96,7 +96,7 @@ public abstract class BaseWeasyPrintTest {
     public static @NotNull WeasyPrintServiceConnector getWeasyPrintServiceConnector() {
         String externalUrl = System.getProperty(WEASYPRINT_SERVICE_URL_PROPERTY);
         if (externalUrl != null) {
-            externalUrl = externalUrl.trim().replaceAll("/+$", "");
+            externalUrl = externalUrl.trim().replaceAll("/++$", "");
             if (!externalUrl.isBlank()) {
                 return new WeasyPrintServiceConnector(externalUrl);
             }


### PR DESCRIPTION
### Proposed changes

replaceAll("/+$", "") backtracks super-linearly on inputs ending in many slashes (SonarCloud java:S8786). Use a possessive quantifier ("/++$"), which is semantically identical for trailing-slash trimming but cannot backtrack.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
