### PR TITLE
fix: use Polarion 2606 spinner (progressWheel)

### DIFF
--- a/src/main/resources/webapp/pdf-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/pdf-exporter/html/popupForm.html
@@ -1,5 +1,5 @@
 <div class="form-wrapper">
-    <div class="in-progress-overlay"><img src='/polarion/ria/images/progress.gif' alt=""/><span id="in-progress-message"></span></div>
+    <div class="in-progress-overlay"><img src='/polarion/ria/images/progressWheel48.svg' alt=""/><span id="in-progress-message"></span></div>
 
     <div class="notifications">
         <div class="alert alert-warning" style="display: none"></div>

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -252,7 +252,7 @@
         <button type='button' id='export-pdf'>
             <img class='append-build-number' src='/polarion/ria/images/dle/operations/actionPdfExport16.svg' alt=''/>Export to PDF
         </button>
-        <img id='export-pdf-progress' src='/polarion/ria/images/progress_grey.gif' alt=''/>
+        <img id='export-pdf-progress' src='/polarion/ria/images/progressWheel48.svg' alt=''/>
         <div id='export-error'></div>
         <div id='export-warning'></div>
     </div>
@@ -261,7 +261,7 @@
             <img class='append-build-number' src='/polarion/ria/images/dle/align_center.png' alt=''/>Validate pages width
         </button>
         <div id='validate-ok'></div>
-        <img id='validate-pdf-progress' src='/polarion/ria/images/progress_grey.gif' alt=''/>
+        <img id='validate-pdf-progress' src='/polarion/ria/images/progressWheel48.svg' alt=''/>
         <br>
         <div id='validate-error'></div>
     </div>

--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportBulk.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportBulk.js
@@ -141,7 +141,7 @@ export default class ExportBulk {
             fontAwesomeIcon.className = "fa";
             iconSpan.appendChild(fontAwesomeIcon);
             const inProgressIcon = document.createElement("img");
-            inProgressIcon.src = '/polarion/ria/images/progress.gif';
+            inProgressIcon.src = '/polarion/ria/images/progressWheel48.svg';
             iconSpan.appendChild(inProgressIcon);
             div.appendChild(iconSpan);
 


### PR DESCRIPTION
### Proposed changes

Polarion 2606 removed `/polarion/ria/images/progress.gif` (now 404); the export popup loader now uses Polarion's served `progressWheel48.svg` (popupForm.html + ExportBulk.js).

Closes #868

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
