### PR TITLE
fix: trim trailing slashes without regex

### DIFF
--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/base/BaseWeasyPrintTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/base/BaseWeasyPrintTest.java
@@ -109,7 +109,7 @@ public abstract class BaseWeasyPrintTest {
         return new WeasyPrintServiceConnector(weasyPrintServiceBaseUrl);
     }
 
-    private static @NotNull String stripTrailingSlashes(@NotNull String value) {
+    static @NotNull String stripTrailingSlashes(@NotNull String value) {
         int end = value.length();
         while (end > 0 && value.charAt(end - 1) == '/') {
             end--;

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/base/BaseWeasyPrintTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/base/BaseWeasyPrintTest.java
@@ -96,7 +96,7 @@ public abstract class BaseWeasyPrintTest {
     public static @NotNull WeasyPrintServiceConnector getWeasyPrintServiceConnector() {
         String externalUrl = System.getProperty(WEASYPRINT_SERVICE_URL_PROPERTY);
         if (externalUrl != null) {
-            externalUrl = externalUrl.trim().replaceAll("/++$", "");
+            externalUrl = stripTrailingSlashes(externalUrl.trim());
             if (!externalUrl.isBlank()) {
                 return new WeasyPrintServiceConnector(externalUrl);
             }
@@ -107,6 +107,14 @@ public abstract class BaseWeasyPrintTest {
 
         String weasyPrintServiceBaseUrl = "http://" + weasyPrintService.getHost() + ":" + weasyPrintService.getFirstMappedPort();
         return new WeasyPrintServiceConnector(weasyPrintServiceBaseUrl);
+    }
+
+    private static @NotNull String stripTrailingSlashes(@NotNull String value) {
+        int end = value.length();
+        while (end > 0 && value.charAt(end - 1) == '/') {
+            end--;
+        }
+        return value.substring(0, end);
     }
 
     protected List<BufferedImage> exportAndGetAsImages(String fileName) {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/base/StripTrailingSlashesTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/base/StripTrailingSlashesTest.java
@@ -1,0 +1,35 @@
+package ch.sbb.polarion.extension.pdf_exporter.weasyprint.base;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StripTrailingSlashesTest {
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "http://localhost:9080      | http://localhost:9080",
+            "http://localhost:9080/     | http://localhost:9080",
+            "http://localhost:9080///   | http://localhost:9080",
+            "/                          | ''",
+            "////                       | ''",
+            "''                         | ''",
+            "http://host/path/          | http://host/path",
+    }, delimiterString = "|", ignoreLeadingAndTrailingWhitespace = true)
+    void stripsTrailingSlashes(String input, String expected) {
+        assertEquals(expected, BaseWeasyPrintTest.stripTrailingSlashes(input));
+    }
+
+    @Test
+    void leavesInnerSlashesUntouched() {
+        assertEquals("http://host//path", BaseWeasyPrintTest.stripTrailingSlashes("http://host//path//"));
+    }
+
+    @Test
+    void isLinearOnManyTrailingSlashes() {
+        String input = "x" + "/".repeat(100_000);
+        assertEquals("x", BaseWeasyPrintTest.stripTrailingSlashes(input));
+    }
+}


### PR DESCRIPTION
## Problem

The previous fix (#866, `/+$` → `/++$`) did not clear SonarCloud issue `java:S8786` on `BaseWeasyPrintTest`. Analyses ran after that commit (revisions `205abd6` and `cae5d73`) and the issue is still **OPEN**.

A possessive quantifier only removes backtracking *within* a single match attempt. The super-linear cost here comes from `Matcher.find()` retrying the match at every start position of the string — so any end-anchored repeated group (`/+$`, `/++$`) stays quadratic on slash-heavy input.

## Fix

Drop the regex entirely and trim trailing slashes with a plain linear character scan.

Refs: #865