### PR TITLE
chore: null-guard refactoring

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterJobsService.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterJobsService.java
@@ -4,6 +4,7 @@ import ch.sbb.polarion.extension.generic.rest.filter.LogoutFilter;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.ExportParams;
 import ch.sbb.polarion.extension.pdf_exporter.util.DebugDataStorage;
 import ch.sbb.polarion.extension.pdf_exporter.util.ExportContext;
+import com.polarion.core.util.StringUtils;
 import com.polarion.core.util.logging.Logger;
 import com.polarion.platform.security.ISecurityService;
 import lombok.Builder;
@@ -59,7 +60,7 @@ public class PdfConverterJobsService {
             } catch (Exception e) {
                 String errorMessage = String.format("PDF conversion job '%s' is failed with error: %s", jobId, e.getMessage());
                 logger.error(errorMessage, e);
-                failedJobsReasons.put(jobId, e.getMessage());
+                failedJobsReasons.put(jobId, StringUtils.getEmptyIfNull(e.getMessage()));
                 throw e;
             } finally {
                 // Clear current job ID
@@ -74,7 +75,7 @@ public class PdfConverterJobsService {
         asyncConversionJob
                 .orTimeout(timeoutInMinutes, TimeUnit.MINUTES)
                 .exceptionally(e -> {
-                    String failedReason = e.getMessage();
+                    String failedReason = StringUtils.getEmptyIfNull(e.getMessage());
                     if (e instanceof TimeoutException) {
                         failedReason = String.format("Timeout after %d min", timeoutInMinutes);
                     }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterJobsServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterJobsServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.security.auth.Subject;
 import java.security.PrivilegedAction;
+import java.util.ConcurrentModificationException;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -134,6 +135,33 @@ class PdfConverterJobsServiceTest {
         assertThatThrownBy(() -> pdfConverterJobsService.getJobResult(jobId))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("test error");
+        verify(securityService).logout(subject);
+    }
+
+    @Test
+    void shouldRecordRealReasonWhenExceptionMessageIsNull() {
+        // Regression: an exception with a null message (e.g. ConcurrentModificationException thrown deep in
+        // Polarion's ImportExportStatusKeeper) must not produce a secondary NullPointerException when the failure
+        // reason is stored into the ConcurrentHashMap (which rejects null values). The real cause must survive.
+        prepareSecurityServiceSubject(subject);
+        when(requestAttributes.getAttribute(LogoutFilter.XSRF_SKIP_LOGOUT, RequestAttributes.SCOPE_REQUEST)).thenReturn(Boolean.FALSE);
+        when(requestAttributes.getAttribute(LogoutFilter.ASYNC_SKIP_LOGOUT, RequestAttributes.SCOPE_REQUEST)).thenReturn(Boolean.TRUE);
+        ExportParams exportParams = ExportParams.builder().build();
+        when(pdfConverter.convertToPdf(exportParams, null)).thenThrow(new ConcurrentModificationException());
+
+        String jobId = pdfConverterJobsService.startJob(exportParams, 60);
+
+        assertThat(jobId).isNotBlank();
+        // Poll until the .exceptionally stage has recorded the final reason (it may run after the stored future is done).
+        await().atMost(Durations.FIVE_SECONDS).untilAsserted(() -> {
+            JobState jobState = pdfConverterJobsService.getJobState(jobId);
+            assertThat(jobState.isDone()).isTrue();
+            assertThat(jobState.isCompletedExceptionally()).isTrue();
+            assertThat(jobState.errorMessage())
+                    .isNotNull()
+                    .contains("ConcurrentModificationException")
+                    .doesNotContain("NullPointerException");
+        });
         verify(securityService).logout(subject);
     }
 


### PR DESCRIPTION
### Proposed changes

We have to refactor `PdfConverterJobsService`'s code a bit to eliminate potential NPE because some exceptions may have `null` message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
