### PR TITLE
fix: reset modal instance on popup initialization

### DIFF
--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
@@ -15,6 +15,12 @@ export default class ExportPopup {
     }
 
     initPopup() {
+        // The shared generic micromodal caches one Modal instance per id and reuses it on show();
+        // since we rebuild the popup element below, drop that cached instance so show() re-binds to
+        // the new node — otherwise a 2nd+ open targets the detached old node and nothing appears.
+        if (typeof MicroModal !== "undefined") {
+            MicroModal.removeModal?.(POPUP_ID);
+        }
         document.getElementById(POPUP_ID)?.remove();
         const popup = document.createElement('div');
         popup.classList.add("modal");


### PR DESCRIPTION
### Proposed changes

Ensure the modal instance is removed before creating a new popup element to prevent issues with displaying the updated content.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
