### PR TITLE
fix: reuse popup element to prevent detached node issues

### DIFF
--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
@@ -15,16 +15,23 @@ export default class ExportPopup {
     }
 
     initPopup() {
-        document.getElementById(POPUP_ID)?.remove();
-        const popup = document.createElement('div');
-        popup.classList.add("modal");
-        popup.classList.add("micromodal-slide");
-        popup.id = POPUP_ID;
+        // Reuse the popup element across opens. The shared generic micromodal caches one Modal per
+        // id bound to the element it first saw, so rebuilding the element would leave that cache
+        // pointing at a detached node and later opens (e.g. after editing/saving the document) would
+        // silently do nothing.
+        let popup = document.getElementById(POPUP_ID);
+        if (!popup) {
+            popup = document.createElement('div');
+            popup.classList.add("modal", "micromodal-slide");
+            popup.id = POPUP_ID;
+            document.body.appendChild(popup);
+        }
         popup.setAttribute("aria-hidden", "true");
         popup.innerHTML = POPUP_HTML;
-        document.body.appendChild(popup);
 
-        fetch('/polarion/pdf-exporter/html/popupForm.html')
+        // Derive the form URL from this module's own URL so it follows the same extension base as
+        // the toolbar import instead of a hardcoded /polarion/pdf-exporter/ context.
+        fetch(new URL('../../../html/popupForm.html', import.meta.url).href)
             .then(response => response.text())
             .then(content => {
                 this.renderPanel(content);


### PR DESCRIPTION
### Proposed changes

This pull request refactors the initialization logic for the export popup in `ExportPopup.js` to improve how the popup element is managed and how the form URL is constructed. The main focus is on ensuring the modal element is reused across multiple opens, preventing issues with detached DOM nodes, and making the form URL more robust.

**Popup management improvements:**
- Refactored the `initPopup` method to reuse the existing popup element if it exists, instead of always removing and recreating it. This change prevents issues where the modal library's cache points to a detached DOM node, which could cause the popup to fail to appear after the first open.

**Form URL construction:**
- Changed the fetch of the popup form HTML to derive the URL relative to the module's own location using `import.meta.url`, instead of relying on a hardcoded path. This makes the module more portable and consistent with how other resources are loaded.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
