### PR TITLE
fix: ensure resolvable location paths for reports in non-default spaces (#851)

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/DocumentCollectionHelper.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/DocumentCollectionHelper.java
@@ -75,15 +75,16 @@ public class DocumentCollectionHelper {
         }
 
         for (IRichPage page : collection.getRichPages()) {
+            String spaceId = page.getFolder().getName();
             ExportParams exportParams = ExportParams.builder()
                     .projectId(page.getProjectId())
                     .documentType(DocumentType.LIVE_REPORT)
-                    .locationPath(page.getPageNameWithSpace())
+                    .locationPath(spaceId + "/" + page.getPageName())
                     .revision(page.getRevision())
                     .build();
             DocumentCollectionEntry documentCollectionEntry = new DocumentCollectionEntry(
                     page.getProjectId(),
-                    page.getFolder().getName(),
+                    spaceId,
                     page.getPageName(),
                     DocumentType.LIVE_REPORT,
                     page.getRevision(),

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/DocumentCollectionHelperTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/DocumentCollectionHelperTest.java
@@ -15,6 +15,7 @@ import com.polarion.alm.tracker.model.baselinecollection.IBaselineCollectionElem
 import com.polarion.subterra.base.location.ILocation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 
@@ -117,13 +118,15 @@ class DocumentCollectionHelperTest {
         IRichPage mockPage2 = mock(IRichPage.class, RETURNS_DEEP_STUBS);
 
         when(mockPage1.getProjectId()).thenReturn(projectId);
-        when(mockPage1.getPageNameWithSpace()).thenReturn("Reports/TestReport");
+        // getPageNameWithSpace() returns a human-readable "<space> / <name>" string (note the spaces around
+        // the slash) which is NOT a resolvable location path - the helper must not rely on it (see issue #851).
+        when(mockPage1.getPageNameWithSpace()).thenReturn("Reports / TestReport");
         when(mockPage1.getPageName()).thenReturn("TestReport");
         when(mockPage1.getRevision()).thenReturn("10");
         when(mockPage1.getFolder().getName()).thenReturn("Reports");
 
         when(mockPage2.getProjectId()).thenReturn(secondProjectId);
-        when(mockPage2.getPageNameWithSpace()).thenReturn("_default/LiveReport");
+        when(mockPage2.getPageNameWithSpace()).thenReturn("LiveReport");
         when(mockPage2.getPageName()).thenReturn("LiveReport");
         when(mockPage2.getRevision()).thenReturn("5");
         when(mockPage2.getFolder().getName()).thenReturn("_default");
@@ -210,6 +213,59 @@ class DocumentCollectionHelperTest {
             assertEquals("LiveReport", resultWithRevision.get(4).getDocumentName());
             assertEquals(DocumentType.LIVE_REPORT, resultWithRevision.get(4).getDocumentType());
             assertEquals("5", resultWithRevision.get(4).getRevision());
+        }
+    }
+
+    /**
+     * Regression test for issue #851: a report page located in a space other than {@code _default} must produce a
+     * resolvable location path ({@code <space>/<pageId>}). The previously used {@link IRichPage#getPageNameWithSpace()}
+     * returns a human-readable {@code "<space> / <pageName>"} string (note the spaces around the slash) which, once
+     * split on the last slash by {@code RichPageReference.fromPath}, yields an unresolvable rich page URI and breaks
+     * the whole collection export.
+     */
+    @Test
+    void testReportInNonDefaultSpaceProducesResolvableLocationPath() {
+        DocumentFileNameHelper documentFileNameHelper = mock(DocumentFileNameHelper.class);
+        when(documentFileNameHelper.getDocumentFileName(any())).thenReturn("report.pdf");
+
+        DocumentCollectionHelper helper = new DocumentCollectionHelper(documentFileNameHelper);
+
+        IRichPage reportPage = mock(IRichPage.class, RETURNS_DEEP_STUBS);
+        when(reportPage.getProjectId()).thenReturn("drivepilot");
+        // The human-readable, NON-resolvable representation - the helper must not rely on it.
+        when(reportPage.getPageNameWithSpace()).thenReturn("Reports / Items By Status");
+        when(reportPage.getPageName()).thenReturn("Items By Status");
+        when(reportPage.getFolder().getName()).thenReturn("Reports");
+        when(reportPage.getRevision()).thenReturn("42");
+
+        IBaselineCollection mockCollection = mock(IBaselineCollection.class);
+        when(mockCollection.getElements()).thenReturn(List.of());
+        when(mockCollection.getUpstreamCollections()).thenReturn(List.of());
+        when(mockCollection.getRichPages()).thenReturn(List.of(reportPage));
+
+        BaselineCollection baselineCollection = mock(BaselineCollection.class);
+        when(baselineCollection.getOldApi()).thenReturn(mockCollection);
+
+        try (MockedConstruction<BaselineCollectionReference> ignored = mockConstruction(BaselineCollectionReference.class, (mock, context) -> {
+            when(mock.get(Mockito.any())).thenReturn(baselineCollection);
+            when(mock.getWithRevision(Mockito.anyString())).thenReturn(mock);
+        })) {
+            List<DocumentCollectionEntry> result = helper.getDocumentsFromCollection("drivepilot", "1", null, mock(ReadOnlyTransaction.class));
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertEquals("Reports", result.get(0).getSpaceId());
+            assertEquals("Items By Status", result.get(0).getDocumentName());
+            assertEquals(DocumentType.LIVE_REPORT, result.get(0).getDocumentType());
+
+            ArgumentCaptor<ExportParams> exportParamsCaptor = ArgumentCaptor.forClass(ExportParams.class);
+            verify(documentFileNameHelper).getDocumentFileName(exportParamsCaptor.capture());
+            ExportParams capturedParams = exportParamsCaptor.getValue();
+
+            assertEquals("Reports/Items By Status", capturedParams.getLocationPath());
+            assertEquals("drivepilot", capturedParams.getProjectId());
+            assertEquals(DocumentType.LIVE_REPORT, capturedParams.getDocumentType());
+            assertEquals("42", capturedParams.getRevision());
         }
     }
 }


### PR DESCRIPTION
Backport of #852 (commit d4f7897) to the **v12.x LTS line** (Polarion 2512).

## Problem
Reports contained in a Baseline Collection that live in a space other than `_default` produced an unresolvable location path, breaking the whole collection export. Issue #851.

## Fix
- Replace `getPageNameWithSpace()` (a human-readable `"<space> / <name>"` string) with `spaceId + "/" + pageName` for the location path, so `RichPageReference.fromPath` resolves the rich page URI correctly.
- Add a regression test validating that a report in a non-default space produces a resolvable `<space>/<pageId>` location path.

## Notes
- This PR also establishes the new `release-v12` LTS branch (created from tag `v12.5.0`), per `RELEASE.md`. On merge, release-please will open the LTS release PR (→ `v12.5.1`).
- Cherry-picked cleanly from `main`; `DocumentCollectionHelperTest` passes (2/2).

Refs: #851