### PR TITLE
fix: preserve enum icon when localizing enum fields

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -1037,21 +1037,8 @@ public class HtmlProcessor {
      * the icon, since it removes all child nodes.
      */
     private void replaceEnumLabel(@NotNull Element enumElement, @NotNull String replacement) {
-        boolean applied = false;
-        for (TextNode textNode : enumElement.textNodes()) {
-            if (textNode.isBlank()) {
-                continue;
-            }
-            if (!applied) {
-                textNode.text(replacement);
-                applied = true;
-            } else {
-                textNode.text("");
-            }
-        }
-        if (!applied) {
-            enumElement.text(replacement);
-        }
+        enumElement.textNodes().forEach(Node::remove);
+        enumElement.appendText(replacement);
     }
 
     public void adjustContentToFitPage(@NotNull Document document, @NotNull ConversionParams conversionParams) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -1026,8 +1026,31 @@ public class HtmlProcessor {
         for (Element enumElement : enums) {
             String replacementString = localizationMap.get(enumElement.text());
             if (!StringUtils.isEmptyTrimmed(replacementString)) {
-                enumElement.text(replacementString);
+                replaceEnumLabel(enumElement, replacementString);
             }
+        }
+    }
+
+    /**
+     * Replaces the label text of an enum option while preserving child elements such as the
+     * leading enum icon {@code <img>}. Using {@link Element#text(String)} directly would drop
+     * the icon, since it removes all child nodes.
+     */
+    private void replaceEnumLabel(@NotNull Element enumElement, @NotNull String replacement) {
+        boolean applied = false;
+        for (TextNode textNode : enumElement.textNodes()) {
+            if (textNode.isBlank()) {
+                continue;
+            }
+            if (!applied) {
+                textNode.text(replacement);
+                applied = true;
+            } else {
+                textNode.text("");
+            }
+        }
+        if (!applied) {
+            enumElement.text(replacement);
         }
     }
 

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -22,7 +22,7 @@
     <div id='style-package-content' style='border-top: 1px solid #eee; padding-top: 10px;'>
         <p>Selected style package exposes its settings, so you can redefine them.</p>
         <div class='property-wrapper'>
-            <label for='cover-page-selector'>
+            <label for='cover-page-checkbox'>
                 <input id='cover-page-checkbox' onchange='document.querySelector("#pdf-exporter-panel #cover-page-selector").style.display = this.checked ? "inline-block" : "none"' type='checkbox' {COVER_PAGE_SELECTED}/>
                 Cover page:
             </label>
@@ -49,7 +49,7 @@
             </select>
         </div>
         <div class='property-wrapper {WEBHOOKS_DISPLAY}' style='border-top: 1px solid #eee; padding-top: 10px;'>
-            <label for='webhooks-selector'>
+            <label for='webhooks-checkbox'>
                 <input id='webhooks-checkbox' onchange='document.querySelector("#pdf-exporter-panel #webhooks-selector").style.display = this.checked ? "inline-block" : "none"' type='checkbox' {WEBHOOKS_SELECTED}/>
                 Webhooks:
             </label>

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -130,7 +130,7 @@
             </label>
         </div>
         <div class='property-wrapper'>
-            <label for='render-comments'>
+            <label>
                 <input id='render-comments' onchange='document.querySelector("#pdf-exporter-panel #render-comments-selector").style.display = this.checked ? "block" : "none";document.querySelector("#pdf-exporter-panel #render-comments-options").style.display = this.checked ? "flex" : "none"' type='checkbox'/>
                 Comments rendering
             </label>
@@ -140,7 +140,7 @@
             </select>
         </div>
         <div class='property-wrapper' id='render-comments-options' style='display: none; padding-left: 20px'>
-            <label for='include-unreferenced-comments' id='include-unreferenced-comments-container' title="Unreferenced comments will be rendered at the end of the document">
+            <label id='include-unreferenced-comments-container' title="Unreferenced comments will be rendered at the end of the document">
                 <input id='include-unreferenced-comments' type='checkbox' />
                 include unreferenced
             </label>

--- a/src/test/resources/localizeEnumsAfterProcessing.html
+++ b/src/test/resources/localizeEnumsAfterProcessing.html
@@ -3,5 +3,6 @@
     <span class="polarion-JSEnumOption" id="sp1">Entwurf</span>
     <span class="polarion-JSEnumOption" id="sp2">Nicht überprüft</span>
     <span class="polarion-JSEnumOption" id="sp3">missing</span>
+    <span class="polarion-JSEnumOption" id="sp4" title="Draft"><img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt=""/>Entwurf</span>
 </p>
 <div>Some div</div>

--- a/src/test/resources/localizeEnumsBeforeProcessing.html
+++ b/src/test/resources/localizeEnumsBeforeProcessing.html
@@ -3,5 +3,6 @@
     <span class="polarion-JSEnumOption" id="sp1">draft</span>
     <span class="polarion-JSEnumOption" id="sp2">not reviewed</span>
     <span class="polarion-JSEnumOption" id="sp3">missing</span>
+    <span class="polarion-JSEnumOption" id="sp4" title="Draft"><img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt="">draft</span>
 </p>
 <div>Some div</div>


### PR DESCRIPTION
### Proposed changes

This pull request improves the localization of enum labels in HTML documents by ensuring that any child elements, such as icons, are preserved during the localization process. Previously, replacing the label text would remove these child elements. The changes include a new helper method for safely updating the label and updated test resources to verify the correct handling of enum options with icons.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
