### PR TITLE
fix: reassign tables and figures caption numbers following the visual…

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -1103,9 +1103,11 @@ public class HtmlProcessor {
      * (the editor numbers captions with CSS counters, i.e. in DOM order). We restore DOM-order numbering here.
      */
     @VisibleForTesting
+    @SuppressWarnings("java:S135") // several continue used to keep logic simple
     void renumberCaptions(@NotNull Document document) {
         Map<String, Integer> sequenceCounters = new HashMap<>();
-        for (Element captionSpan : document.select("span.polarion-rte-caption[data-sequence]")) {
+        // Scope must match generateTableOfFigures so the numbers stay consistent with the generated list.
+        for (Element captionSpan : document.select("p.polarion-rte-caption-paragraph span.polarion-rte-caption[data-sequence]")) {
             String sequence = captionSpan.dataset().get("sequence");
             if (StringUtils.isEmpty(sequence)) {
                 continue;

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -30,6 +30,7 @@ import org.jsoup.select.Elements;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -134,6 +135,8 @@ public class HtmlProcessor {
 
             // Localize enumeration values
             timedIfNotNull(generationLog, "Localize enums", () -> localizeEnums(document, exportParams));
+
+            timedIfNotNull(generationLog, "Renumber captions", () -> renumberCaptions(document));
 
             timedIfNotNull(generationLog, "Add table of figures", () -> addTableOfFigures(document));
         }
@@ -1087,6 +1090,35 @@ public class HtmlProcessor {
         // which may contain a lot of nbsp too. This may occasionally result in exceeding page width lines.
         // Replace them with thin spaces to prevent overflow while maintaining some visual spacing.
         return html.replaceAll("&nbsp;|\u00A0", "&thinsp;");
+    }
+
+    /**
+     * Reassigns caption numbers ("Table 1", "Figure 2", ...) following the visual (DOM) order of the captions.
+     * <p>
+     * Polarion generates caption numbers server-side via a single stateful counter that increments in render
+     * order (see {@code RichTextCaption.render} / {@code CaptionIdGenerator}). For PDF export Polarion renders
+     * all wiki/macro blocks first (see {@code ServerRichTextDocumentBase.renderImpl}) and only then the document's
+     * own parts. When a macro re-renders a work item's rich text that already contains a numbered caption, the
+     * macro copy grabs the lower number, so the numbering ends up reversed relative to what the editor shows
+     * (the editor numbers captions with CSS counters, i.e. in DOM order). We restore DOM-order numbering here.
+     */
+    @VisibleForTesting
+    void renumberCaptions(@NotNull Document document) {
+        Map<String, Integer> sequenceCounters = new HashMap<>();
+        for (Element captionSpan : document.select("span.polarion-rte-caption[data-sequence]")) {
+            String sequence = captionSpan.dataset().get("sequence");
+            if (StringUtils.isEmpty(sequence)) {
+                continue;
+            }
+            Node numberNode = captionSpan.childNodes().stream().filter(TextNode.class::isInstance).findFirst().orElse(null);
+            if (!(numberNode instanceof TextNode numberTextNode) || !numberTextNode.text().trim().matches("\\d+")) {
+                continue;
+            }
+            int nextNumber = sequenceCounters.merge(sequence, 1, Integer::sum);
+            if (!numberTextNode.text().trim().equals(String.valueOf(nextNumber))) {
+                numberTextNode.text(String.valueOf(nextNumber));
+            }
+        }
     }
 
     @VisibleForTesting

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -720,6 +720,26 @@ class HtmlProcessorTest {
     }
 
     @Test
+    void renumberCaptionsHandlesEdgeCasesTest() {
+        // - empty data-sequence: skipped, left untouched
+        // - caption without a text node (only an anchor): skipped, no exception
+        // - caption already carrying the correct number: left untouched (no needless rewrite)
+        String html = """
+                <p class="polarion-rte-caption-paragraph">Table <span data-sequence="" class="polarion-rte-caption">4</span> Empty sequence</p>
+                <p class="polarion-rte-caption-paragraph">Table <span data-sequence="Table" class="polarion-rte-caption"><a name="dlecaption_1"></a></span> No number</p>
+                <p class="polarion-rte-caption-paragraph">Table <span data-sequence="Table" class="polarion-rte-caption">1</span> Already correct</p>
+                """;
+        Document document = JSoupUtils.parseHtml(html);
+
+        processor.renumberCaptions(document);
+
+        Elements captions = document.select("span.polarion-rte-caption[data-sequence]");
+        assertEquals("4", captions.get(0).text());       // empty sequence untouched
+        assertEquals("", captions.get(1).text().trim()); // no text node, still no number
+        assertEquals("1", captions.get(2).text());       // first real "Table" caption, already 1
+    }
+
+    @Test
     @SneakyThrows
     void adjustReportedByTest() {
         String initialHtml = """

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -666,6 +666,60 @@ class HtmlProcessorTest {
     }
 
     @Test
+    void renumberCaptionsRestoresDomOrderTest() {
+        // Reproduces the Polarion numbering bug: a work item owns a table (rendered second, so numbered "2")
+        // followed by a macro that re-renders the same rich text (rendered first during the wiki phase, so
+        // numbered "1"). In DOM order the work item's own caption comes first but carries the higher number.
+        String html = """
+                <p class="polarion-rte-caption-paragraph">Table <span data-sequence="Table" class="polarion-rte-caption">2<a name="dlecaption_5"></a></span> Own table</p>
+                <p class="polarion-rte-caption-paragraph">Table <span data-sequence="Table" class="polarion-rte-caption">1<a name="dlecaption_6"></a></span> Macro copy</p>
+                """;
+        Document document = JSoupUtils.parseHtml(html);
+
+        processor.renumberCaptions(document);
+
+        Elements captions = document.select("span.polarion-rte-caption[data-sequence]");
+        assertEquals("1", captions.get(0).childNodes().stream().filter(org.jsoup.nodes.TextNode.class::isInstance).findFirst().map(n -> ((org.jsoup.nodes.TextNode) n).text()).orElse(null));
+        assertEquals("2", captions.get(1).childNodes().stream().filter(org.jsoup.nodes.TextNode.class::isInstance).findFirst().map(n -> ((org.jsoup.nodes.TextNode) n).text()).orElse(null));
+    }
+
+    @Test
+    void renumberCaptionsKeepsSequencesIndependentTest() {
+        // Each sequence (Table, Figure, ...) is numbered independently, following DOM order within the sequence.
+        String html = """
+                <p class="polarion-rte-caption-paragraph">Figure <span data-sequence="Figure" class="polarion-rte-caption">3</span> Fig A</p>
+                <p class="polarion-rte-caption-paragraph">Table <span data-sequence="Table" class="polarion-rte-caption">2</span> Tab A</p>
+                <p class="polarion-rte-caption-paragraph">Figure <span data-sequence="Figure" class="polarion-rte-caption">9</span> Fig B</p>
+                <p class="polarion-rte-caption-paragraph">Table <span data-sequence="Table" class="polarion-rte-caption">7</span> Tab B</p>
+                """;
+        Document document = JSoupUtils.parseHtml(html);
+
+        processor.renumberCaptions(document);
+
+        Elements captions = document.select("span.polarion-rte-caption[data-sequence]");
+        assertEquals("1", captions.get(0).text()); // Figure 1
+        assertEquals("1", captions.get(1).text()); // Table 1
+        assertEquals("2", captions.get(2).text()); // Figure 2
+        assertEquals("2", captions.get(3).text()); // Table 2
+    }
+
+    @Test
+    void renumberCaptionsLeavesNonNumericSpansUntouchedTest() {
+        // Captions without a resolved number (e.g. an editor placeholder) must not be rewritten.
+        String html = """
+                <p class="polarion-rte-caption-paragraph">Table <span data-sequence="Table" class="polarion-rte-caption">#</span> Placeholder</p>
+                <p class="polarion-rte-caption-paragraph">Table <span data-sequence="Table" class="polarion-rte-caption">5</span> Real</p>
+                """;
+        Document document = JSoupUtils.parseHtml(html);
+
+        processor.renumberCaptions(document);
+
+        Elements captions = document.select("span.polarion-rte-caption[data-sequence]");
+        assertEquals("#", captions.get(0).text());
+        assertEquals("1", captions.get(1).text());
+    }
+
+    @Test
     @SneakyThrows
     void adjustReportedByTest() {
         String initialHtml = """


### PR DESCRIPTION
… order

Refs: #833

### Proposed changes

We have to renumber tables & figures captions before sending html to weasyprint.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
