### PR TITLE
refactor: localize enum label in place

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -1034,18 +1034,25 @@ public class HtmlProcessor {
     /**
      * Replaces the label text of an enum option in place while preserving child elements such as
      * the leading enum icon {@code <img>}. Using {@link Element#text(String)} directly would drop
-     * the icon, since it removes all child nodes. The localized text keeps the original label's
-     * position: the first text node is updated and any remaining text nodes are removed.
+     * the icon, since it removes all child nodes. The localized text replaces the first non-blank
+     * text node (the visible label) in its original position, so it stays after the icon even when
+     * the markup contains formatting whitespace; remaining non-blank text nodes are removed.
      */
     private void replaceEnumLabel(@NotNull Element enumElement, @NotNull String replacement) {
-        List<TextNode> textNodes = enumElement.textNodes();
-        if (textNodes.isEmpty()) {
-            enumElement.appendText(replacement);
-            return;
+        boolean replaced = false;
+        for (TextNode textNode : enumElement.textNodes()) {
+            if (textNode.isBlank()) {
+                continue;
+            }
+            if (replaced) {
+                textNode.remove();
+            } else {
+                textNode.text(replacement);
+                replaced = true;
+            }
         }
-        textNodes.get(0).text(replacement);
-        for (int i = 1; i < textNodes.size(); i++) {
-            textNodes.get(i).remove();
+        if (!replaced) {
+            enumElement.appendText(replacement);
         }
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -1032,13 +1032,21 @@ public class HtmlProcessor {
     }
 
     /**
-     * Replaces the label text of an enum option while preserving child elements such as the
-     * leading enum icon {@code <img>}. Using {@link Element#text(String)} directly would drop
-     * the icon, since it removes all child nodes.
+     * Replaces the label text of an enum option in place while preserving child elements such as
+     * the leading enum icon {@code <img>}. Using {@link Element#text(String)} directly would drop
+     * the icon, since it removes all child nodes. The localized text keeps the original label's
+     * position: the first text node is updated and any remaining text nodes are removed.
      */
     private void replaceEnumLabel(@NotNull Element enumElement, @NotNull String replacement) {
-        enumElement.textNodes().forEach(Node::remove);
-        enumElement.appendText(replacement);
+        List<TextNode> textNodes = enumElement.textNodes();
+        if (textNodes.isEmpty()) {
+            enumElement.appendText(replacement);
+            return;
+        }
+        textNodes.get(0).text(replacement);
+        for (int i = 1; i < textNodes.size(); i++) {
+            textNodes.get(i).remove();
+        }
     }
 
     public void adjustContentToFitPage(@NotNull Document document, @NotNull ConversionParams conversionParams) {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -325,6 +326,33 @@ class HtmlProcessorTest {
             // Spaces and new lines are removed to exclude difference in space characters
             assertEquals(TestStringUtils.removeNonsensicalSymbols(validHtml), TestStringUtils.removeNonsensicalSymbols(fixedHtml));
         }
+    }
+
+    @Test
+    void localizeEnumsPreservesIconForUncommonTextNodeShapesTest() {
+        Map<String, String> deTranslations = new HashMap<>();
+        deTranslations.put("draft", "Entwurf");
+        deTranslations.put("", "Empty"); // matches an enum option that has no visible label
+        when(localizationSettings.load(anyString(), any(SettingId.class)))
+                .thenReturn(new LocalizationModel(deTranslations, Map.of(), Map.of()));
+
+        // Label split into several text nodes around the icon: the localized value replaces the
+        // first non-blank node and the trailing label node is removed, while the icon is kept.
+        Document splitLabel = JSoupUtils.parseHtml("<span class=\"polarion-JSEnumOption\">dr<img src=\"/icon.gif\"/>aft</span>");
+        processor.localizeEnums(splitLabel, getExportParams());
+        Element splitSpan = splitLabel.selectFirst("span.polarion-JSEnumOption");
+        assertEquals(1, splitSpan.select("img").size());
+        assertEquals("Entwurf", splitSpan.text());
+        assertEquals(1, splitSpan.textNodes().size());
+
+        // Enum option that only carries an icon (no visible label): the localized value is
+        // appended after the icon instead of being dropped.
+        Document iconOnly = JSoupUtils.parseHtml("<span class=\"polarion-JSEnumOption\"><img src=\"/icon.gif\"/></span>");
+        processor.localizeEnums(iconOnly, getExportParams());
+        Element iconSpan = iconOnly.selectFirst("span.polarion-JSEnumOption");
+        assertEquals(1, iconSpan.select("img").size());
+        assertEquals("Empty", iconSpan.text());
+        assertEquals("img", iconSpan.child(0).nodeName());
     }
 
     @Test

--- a/src/test/resources/localizeEnumsAfterProcessing.html
+++ b/src/test/resources/localizeEnumsAfterProcessing.html
@@ -4,5 +4,6 @@
     <span class="polarion-JSEnumOption" id="sp2">Nicht überprüft</span>
     <span class="polarion-JSEnumOption" id="sp3">missing</span>
     <span class="polarion-JSEnumOption" id="sp4" title="Draft"><img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt=""/>Entwurf</span>
+    <span class="polarion-JSEnumOption" id="sp5" title="Draft"><img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt=""/>Entwurf</span>
 </p>
 <div>Some div</div>

--- a/src/test/resources/localizeEnumsBeforeProcessing.html
+++ b/src/test/resources/localizeEnumsBeforeProcessing.html
@@ -4,5 +4,9 @@
     <span class="polarion-JSEnumOption" id="sp2">not reviewed</span>
     <span class="polarion-JSEnumOption" id="sp3">missing</span>
     <span class="polarion-JSEnumOption" id="sp4" title="Draft"><img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt="">draft</span>
+    <span class="polarion-JSEnumOption" id="sp5" title="Draft">
+        <img style="vertical-align:bottom;border:0px;margin-right:2px;" src="/polarion/icons/default/enums/req_status_draft.gif" alt="">
+        draft
+    </span>
 </p>
 <div>Some div</div>


### PR DESCRIPTION
### Proposed changes

Follow-up to #894. `replaceEnumLabel` removed all direct text nodes and re-appended the localized label at the end, so an enum span holding elements after the label text would render the translated label after them instead of in place.

This updates the first text node in place and removes any remaining text nodes, keeping the localized label in its original position. It also brings the helper in line with the docx-exporter implementation (docx-exporter#285), where the same edge case was raised in review.

Real Polarion enum markup is always `<img/>label`, so behaviour is unchanged for actual data — this is a robustness/consistency cleanup. Existing `localizeEnumsTest` covers it.

### Checklist
- [x] I have read the `CONTRIBUTING` document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation