### PR TITLE
fix: roles multiselect sync

### DIFF
--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportPanel.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportPanel.js
@@ -148,7 +148,9 @@ export default class ExportPanel {
                 });
             }
         }
-        this.ctx.getElementById("roles-selector")?._searchableDropdown?.syncFromElement();
+        if (rolesProvided) {
+            this.ctx.getElementById("roles-selector")?._searchableDropdown?.syncFromElement();
+        }
         this.ctx.displayIf("roles-wrapper", rolesProvided, "flex");
         this.ctx.setValue("roles-direction-selector", stylePackage.linkRoleDirection || 'BOTH');
 

--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportPanel.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportPanel.js
@@ -148,6 +148,7 @@ export default class ExportPanel {
                 });
             }
         }
+        this.ctx.getElementById("roles-selector")?._searchableDropdown?.syncFromElement();
         this.ctx.displayIf("roles-wrapper", rolesProvided, "flex");
         this.ctx.setValue("roles-direction-selector", stylePackage.linkRoleDirection || 'BOTH');
 

--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
@@ -414,6 +414,9 @@ export default class ExportPopup {
                 });
             }
         }
+        // Roles were selected via raw option.selected; sync the multiselect widget so its chips
+        // reflect them (the widget only auto-syncs on option add/remove or a 'change' event).
+        this.ctx.getElementById("popup-roles-selector")?._searchableDropdown?.syncFromElement();
         this.ctx.displayIf("popup-roles-selector", this.ctx.getExportType() !== ExportParams.ExportType.BULK && rolesProvided, "block");
         this.ctx.setValue("popup-roles-direction-selector", stylePackage.linkRoleDirection || ExportParams.LinkRoleDirection.BOTH);
         this.ctx.displayIf("popup-roles-direction-selector", this.ctx.getExportType() !== ExportParams.ExportType.BULK && rolesProvided, "block");

--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
@@ -603,7 +603,10 @@ export default class ExportPopup {
         }
 
         const selectedRoles = [];
-        if (this.ctx.getElementById("popup-selected-roles").checked) {
+        // Only collect roles for export types that actually load them; the popup element is reused,
+        // so a report/test-run/bulk export must not serialize stale role options left checked and
+        // selected by a previous regular document export.
+        if (this.rolesSelectable() && this.ctx.getElementById("popup-selected-roles").checked) {
             const selectedOptions = Array.from(this.ctx.getElementById("popup-roles-selector").options).filter(opt => opt.selected);
             selectedRoles.push(...selectedOptions.map(opt => opt.value));
         }

--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
@@ -415,8 +415,12 @@ export default class ExportPopup {
             }
         }
         // Roles were selected via raw option.selected; sync the multiselect widget so its chips
-        // reflect them (the widget only auto-syncs on option add/remove or a 'change' event).
-        this.ctx.getElementById("popup-roles-selector")?._searchableDropdown?.syncFromElement();
+        // reflect them — but only when the selector is actually shown. Bulk (and report/test-run)
+        // exports skip loadLinkRoles, so syncing there would read stale/empty options into a
+        // hidden widget. The widget otherwise auto-syncs only on option add/remove.
+        if (this.ctx.getExportType() !== ExportParams.ExportType.BULK && rolesProvided) {
+            this.ctx.getElementById("popup-roles-selector")?._searchableDropdown?.syncFromElement();
+        }
         this.ctx.displayIf("popup-roles-selector", this.ctx.getExportType() !== ExportParams.ExportType.BULK && rolesProvided, "block");
         this.ctx.setValue("popup-roles-direction-selector", stylePackage.linkRoleDirection || ExportParams.LinkRoleDirection.BOTH);
         this.ctx.displayIf("popup-roles-direction-selector", this.ctx.getExportType() !== ExportParams.ExportType.BULK && rolesProvided, "block");

--- a/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
+++ b/src/main/resources/webapp/pdf-exporter/js/modules/ExportPopup.js
@@ -197,10 +197,16 @@ export default class ExportPopup {
         });
     }
 
+    // Roles can only be selected for regular document exports. Reports, test runs and bulk exports
+    // skip loading role options, so the roles selector has no data and must stay hidden.
+    rolesSelectable() {
+        return this.ctx.getDocumentType() !== ExportParams.DocumentType.LIVE_REPORT
+            && this.ctx.getDocumentType() !== ExportParams.DocumentType.TEST_RUN
+            && this.ctx.getExportType() !== ExportParams.ExportType.BULK;
+    }
+
     loadLinkRoles() {
-        if (this.ctx.getDocumentType() === ExportParams.DocumentType.LIVE_REPORT
-            || this.ctx.getDocumentType() === ExportParams.DocumentType.TEST_RUN
-            || this.ctx.getExportType() === ExportParams.ExportType.BULK) {
+        if (!this.rolesSelectable()) {
             return Promise.resolve(); // Skip loading link roles for reports, test runs and bulk export
         }
 
@@ -415,15 +421,16 @@ export default class ExportPopup {
             }
         }
         // Roles were selected via raw option.selected; sync the multiselect widget so its chips
-        // reflect them — but only when the selector is actually shown. Bulk (and report/test-run)
-        // exports skip loadLinkRoles, so syncing there would read stale/empty options into a
-        // hidden widget. The widget otherwise auto-syncs only on option add/remove.
-        if (this.ctx.getExportType() !== ExportParams.ExportType.BULK && rolesProvided) {
+        // reflect them — but only when the selector is actually shown. Reports, test runs and bulk
+        // exports skip loadLinkRoles, so the options aren't loaded and the selector stays hidden;
+        // syncing there would read stale/empty options into a hidden widget.
+        const showRoles = this.rolesSelectable() && rolesProvided;
+        if (showRoles) {
             this.ctx.getElementById("popup-roles-selector")?._searchableDropdown?.syncFromElement();
         }
-        this.ctx.displayIf("popup-roles-selector", this.ctx.getExportType() !== ExportParams.ExportType.BULK && rolesProvided, "block");
+        this.ctx.displayIf("popup-roles-selector", showRoles, "block");
         this.ctx.setValue("popup-roles-direction-selector", stylePackage.linkRoleDirection || ExportParams.LinkRoleDirection.BOTH);
-        this.ctx.displayIf("popup-roles-direction-selector", this.ctx.getExportType() !== ExportParams.ExportType.BULK && rolesProvided, "block");
+        this.ctx.displayIf("popup-roles-direction-selector", showRoles, "block");
 
         this.ctx.displayIf("popup-style-package-content",
             (!this.autoSelectStylePackageAvailable() || !this.ctx.getCheckboxValueById("popup-auto-select-style-package")) && stylePackage.exposeSettings);


### PR DESCRIPTION
### Proposed changes

This pull request improves the user interface consistency for role selection in the export panels by ensuring that the multiselect dropdown widgets accurately reflect the current selection state. The main updates synchronize the visual state of the dropdowns with the underlying data after programmatic changes.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
