### PR TITLE
fix: bulk export checkbox styling

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
@@ -94,7 +94,7 @@ public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
         } else {
             String panelId = "bulk-%s".formatted(UUID.randomUUID().toString());
             HtmlTagBuilder wrap = builder.tag().div();
-            wrap.attributes().className("polarion-PdfExporter-BulkExportWidget").id(panelId);
+            wrap.attributes().className("polarion-PdfExporter-BulkExportWidget form-wrapper").id(panelId);
 
             HtmlTagBuilder header = wrap.append().tag().div();
             header.attributes().className("header");
@@ -122,6 +122,7 @@ public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
                         .catch(console.error);""".formatted(panelId, exportPages.value()));
 
             wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/css/micromodal.css"));
+            wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/css/checkboxes.css"));
             wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/webapp/pdf-exporter/css/pdf-exporter.css"));
 
             HtmlContentBuilder contentBuilder = mainTable.append();

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
@@ -94,7 +94,7 @@ public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
         } else {
             String panelId = "bulk-%s".formatted(UUID.randomUUID().toString());
             HtmlTagBuilder wrap = builder.tag().div();
-            wrap.attributes().className("polarion-PdfExporter-BulkExportWidget form-wrapper").id(panelId);
+            wrap.attributes().className("polarion-PdfExporter-BulkExportWidget").id(panelId);
 
             HtmlTagBuilder header = wrap.append().tag().div();
             header.attributes().className("header");
@@ -122,7 +122,6 @@ public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
                         .catch(console.error);""".formatted(panelId, exportPages.value()));
 
             wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/css/micromodal.css"));
-            wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/css/checkboxes.css"));
             wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/webapp/pdf-exporter/css/pdf-exporter.css"));
 
             HtmlContentBuilder contentBuilder = mainTable.append();

--- a/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
+++ b/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
@@ -291,6 +291,30 @@
     vertical-align: middle;
 }
 
+/* The bulk export widget renders on a Polarion page, not inside a .form-wrapper / .modal__container,
+   so the shared 2606 checkbox styling (generic checkboxes.css) does not reach it. Re-apply it scoped
+   to the widget's own root — same tokens and images — rather than tagging the widget with the broad
+   .form-wrapper class, which would also opt it into unrelated form-field scopes. */
+.polarion-PdfExporter-BulkExportWidget input[type="checkbox"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: var(--sbb-toggle-size, 15px);
+    height: var(--sbb-toggle-size, 15px);
+    margin: 0 4px 0 0;
+    vertical-align: middle;
+    cursor: pointer;
+    background: var(--sbb-checkbox-unchecked, url(/polarion/ria/images/checkbox/unchecked.png)) no-repeat center;
+    background-size: var(--sbb-toggle-size, 15px) var(--sbb-toggle-size, 15px);
+}
+
+.polarion-PdfExporter-BulkExportWidget input[type="checkbox"]:checked {
+    background-image: var(--sbb-checkbox-checked, url(/polarion/ria/images/checkbox/checked.png));
+}
+
+.polarion-PdfExporter-BulkExportWidget input[type="checkbox"]:indeterminate {
+    background-image: var(--sbb-checkbox-indeterminate, url(/polarion/ria/images/checkbox/grayed.png));
+}
+
 .property-wrapper .more-info {
     background: url(/polarion/ria/images/msginfo.png) no-repeat;
     width: 16px;


### PR DESCRIPTION
### Proposed changes

This pull request makes minor improvements to the styling of the bulk PDF export widget. The changes focus on enhancing the widget's appearance by updating CSS classes and including an additional stylesheet.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
