### PR TITLE
fix: point bulk widget indeterminate checkbox at generic image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -166,6 +166,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -214,6 +215,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.3.0</version>
+        <version>15.3.1</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.pdf-exporter</artifactId>

--- a/src/main/resources/webapp/pdf-exporter-admin/js/modules/localization.js
+++ b/src/main/resources/webapp/pdf-exporter-admin/js/modules/localization.js
@@ -178,8 +178,8 @@ function createActionColumn(row) {
     const td = row.insertCell();
     td.classList.add('action');
     td.setAttribute('title', 'Delete');
-    const image = document.createElement('img');
-    image.setAttribute('src', '/polarion/ria/images/control/tableMinus.png');
+    const image = document.createElement('span');
+    image.className = 'sbb-icon-table-minus';
     td.appendChild(image);
     td.addEventListener('click', function () {
         row.remove();

--- a/src/main/resources/webapp/pdf-exporter-admin/js/modules/webhooks.js
+++ b/src/main/resources/webapp/pdf-exporter-admin/js/modules/webhooks.js
@@ -111,8 +111,8 @@ function addWebhook(webhookConfig) {
         const removeButton = document.createElement('button');
         removeButton.classList.add('toolbar-button', 'webhook-button');
         removeButton.setAttribute('title', 'Delete this webhook');
-        const removeButtonImage = document.createElement('img');
-        removeButtonImage.setAttribute('src', '/polarion/ria/images/control/tableMinus.png');
+        const removeButtonImage = document.createElement('span');
+        removeButtonImage.className = 'sbb-icon-table-minus';
         removeButton.appendChild(removeButtonImage);
         removeButton.addEventListener('click', function () {
             // tear down the row's auth-type dropdown so its body-level portal isn't orphaned

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/cover-page.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/cover-page.jsp
@@ -155,7 +155,7 @@
         <div id="templates-select"></div>
         <div class="action-buttons">
             <button id="persist-selected-template" class="toolbar-button">
-                <img class="button-image" src="/polarion/ria/images/actions/save.gif?bundle=<%= bundleTimestamp %>" alt="">Persist
+                <span class="button-image sbb-icon-save" role="img" aria-label="Persist"></span>Persist
             </button>
         </div>
         <div class="action-alerts" style="display: inline-block">

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/localization.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/localization.jsp
@@ -113,7 +113,7 @@
 
             </div>
             <button style="display: table-cell;" id="create-empty-row" class="action" title="Add">
-                <img src="/polarion/ria/images/control/tablePlus.png" alt="">
+                <span class="sbb-icon-table-plus" role="img" aria-label="Add"></span>
             </button>
         </div>
     </div>

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
@@ -64,10 +64,11 @@
             flex-grow: 1;
         }
         .more-info {
-            background: url(/polarion/ria/images/msginfo.png) no-repeat;
+            background: var(--sbb-info-icon) no-repeat;
             display: inline-block;
             width: 17px;
             height: 17px;
+            vertical-align: middle;
             cursor: pointer;
         }
         /* Match the combo-styled color picker used in the export panel / popup (130 x 23,
@@ -81,9 +82,21 @@
             box-sizing: border-box;
             border: 1px solid #cccccc;
             border-radius: 2px;
-            padding: 2px 2rem 2px 2px;
-            background: transparent url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAOUlEQVR4nGNgwAOKGRgY/qNhkBgDCwMDw0UkwasMDAysMF22DAwM/6ASjuhGLmVgYFiCzS5JKAYDACJtDIY1VpdwAAAAAElFTkSuQmCC") no-repeat;
-            background-position: calc(100% - 1rem) 55%;
+            /* Fixed px (not rem) so the swatch width is identical across admin / side-panel / popup —
+               those contexts have different root font-sizes, which made 2rem render differently. */
+            padding: 2px 24px 2px 4px;
+            /* Same sharp SVG combobox chevron + full swatch as the export panel (pdf-exporter.css),
+               so the admin colour picker matches the document-properties one. */
+            background: transparent var(--sbb-combo-chevron) no-repeat;
+            background-position: calc(100% - 5px) 55%;
+            background-size: 16px 16px;
+        }
+        #headers-color::-webkit-color-swatch {
+            border: 1px solid var(--sbb-control-border);
+            border-radius: 1px;
+        }
+        #headers-color::-webkit-color-swatch-wrapper {
+            padding: 0;
         }
     </style>
 </head>

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/webhooks.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/webhooks.jsp
@@ -103,7 +103,7 @@
         <h2 class="align-left">List of webhooks</h2>
         <table id="webhooks-table"><!-- Filled by JS --></table>
         <button id="add-webhook-button" class="toolbar-button webhook-button" title="Add a webhook" style="margin-top: 10px; margin-left: 3px;">
-            <img src='/polarion/ria/images/control/tablePlus.png' alt="Plus">
+            <span class="sbb-icon-table-plus" role="img" aria-label="Add"></span>
         </button>
 
         <input id="scope" type="hidden" value="<%= request.getParameter("scope")%>"/>

--- a/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
+++ b/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
@@ -124,42 +124,17 @@
     padding: 0 0 10px;
 }
 
+/* Box padding only; alert colours (bg/border) come from generic .notifications .alert-*. */
 .modal__container.pdf-exporter .notifications .alert {
     margin-bottom: 10px;
     padding: 6px 12px;
     border-radius: 3px;
 }
 
-.modal__container.pdf-exporter .notifications .alert-error {
-    background-color: #f8d7da;
-    border: 1px solid #b3626a;
-}
-
-.modal__container.pdf-exporter .notifications .alert-warning {
-    background-color: #fff7cd;
-    border: 1px solid #ffc328;
-}
-
-.modal__container.pdf-exporter .notifications .alert-success {
-    background-color: #d1e7dd;
-    border: 1px solid #75b598;
-}
-
+/* Layout only; text colour + weight come from generic .validation-alerts .alert-*. */
 .modal__container.pdf-exporter .validation-alerts {
     display: inline-block;
     padding: 0 10px;
-}
-
-.modal__container.pdf-exporter .validation-alerts .alert {
-    font-weight: bold;
-}
-
-.modal__container.pdf-exporter .validation-alerts .alert-error {
-    color: red;
-}
-
-.modal__container.pdf-exporter .validation-alerts .alert-success {
-    color: green;
 }
 
 .modal__container.pdf-exporter .polarion-JSWizardButton-Primary.action-button:disabled,
@@ -298,29 +273,28 @@
 .polarion-PdfExporter-BulkExportWidget input[type="checkbox"] {
     -webkit-appearance: none;
     appearance: none;
-    width: var(--sbb-toggle-size, 15px);
-    height: var(--sbb-toggle-size, 15px);
+    width: var(--sbb-toggle-size);
+    height: var(--sbb-toggle-size);
     margin: 0 4px 0 0;
     vertical-align: middle;
     cursor: pointer;
-    background: var(--sbb-checkbox-unchecked, url(/polarion/ria/images/checkbox/unchecked.png)) no-repeat center;
-    background-size: var(--sbb-toggle-size, 15px) var(--sbb-toggle-size, 15px);
+    background: var(--sbb-checkbox-unchecked) no-repeat center;
+    background-size: var(--sbb-toggle-size) var(--sbb-toggle-size);
 }
 
 .polarion-PdfExporter-BulkExportWidget input[type="checkbox"]:checked {
-    background-image: var(--sbb-checkbox-checked, url(/polarion/ria/images/checkbox/checked.png));
+    background-image: var(--sbb-checkbox-checked);
 }
 
-/* Generic hosts the indeterminate checkbox image. This stylesheet is inlined into the bulk widget
-   (so a relative url() has no reliable base) and this widget already references /polarion/pdf-exporter/
-   paths, so point at the served generic image absolutely rather than via the relative
-   --sbb-checkbox-indeterminate token. */
+/* Indeterminate: the --sbb-checkbox-indeterminate token is a self-contained data-URI (inlined from
+   images/checkbox/indeterminate.svg at build, issue #528), so it resolves even where this stylesheet
+   is inlined into the widget — same single source as the checked/unchecked above. */
 .polarion-PdfExporter-BulkExportWidget input[type="checkbox"]:indeterminate {
-    background-image: url(/polarion/pdf-exporter/ui/generic/images/checkbox-indeterminate.png);
+    background-image: var(--sbb-checkbox-indeterminate);
 }
 
 .property-wrapper .more-info {
-    background: url(/polarion/ria/images/msginfo.png) no-repeat;
+    background: var(--sbb-info-icon) no-repeat;
     width: 16px;
     height: 16px;
     cursor: help;
@@ -338,8 +312,11 @@
     appearance: none !important;
     -webkit-appearance: none !important;
     -moz-appearance: none !important;
-    background: transparent url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAOUlEQVR4nGNgwAOKGRgY/qNhkBgDCwMDw0UkwasMDAysMF22DAwM/6ASjuhGLmVgYFiCzS5JKAYDACJtDIY1VpdwAAAAAElFTkSuQmCC") no-repeat;
+    /* Native-<select> dropdown arrow — the shared --sbb-combo-chevron token (single source in
+       control-tokens.css, which the side panel loads), matching the SearchableDropdown. */
+    background: transparent var(--sbb-combo-chevron) no-repeat;
     background-position: calc(100% - 1rem) 55% !important;
+    background-size: 16px 16px;
 }
 
 .property-wrapper input {
@@ -360,7 +337,9 @@
 }
 
 .property-wrapper input[type="color"] {
-    padding: 2px 2rem 2px 2px;
+    /* Fixed px (not rem) so the swatch width is identical in the side panel, the popup and the
+       admin picker — those contexts have different root font-sizes, so 2rem rendered differently. */
+    padding: 2px 24px 2px 4px;
 }
 
 /* Uniform control sizing in the export panel & popup so every combo-like control matches the
@@ -407,6 +386,30 @@
     width: 130px;
     height: 23px;
     box-sizing: border-box;
+    border-radius: 2px;
+    /* Chevron in px (not the base rule's calc(100% - 1rem)) so it sits identically in the side panel,
+       popup and admin, regardless of each context's root font-size. */
+    background-position: calc(100% - 5px) 55% !important;
+}
+
+.property-wrapper input[type="color"]::-webkit-color-swatch {
+    border: 1px solid var(--sbb-control-border);
+    border-radius: 1px;
+}
+
+/* Swatch fills the field (drop the default wrapper inset) — matches the admin style-packages
+   picker so admin / side-panel / popup colour pickers look identical. */
+.property-wrapper input[type="color"]::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+
+/* The colour input is a native <input> — its chevron sits via background-position, unlike the
+   SearchableDropdown's ::after. Higher specificity (panel/popup id) so the sibling exporters'
+   global `.property-wrapper input[type=color]` rule can't clobber it; nudge it right to line up
+   with the SearchableDropdown chevrons. */
+#pdf-exporter-panel .property-wrapper input[type="color"],
+.modal__container.pdf-exporter .property-wrapper input[type="color"] {
+    background-position: calc(100% - 5px) 55% !important;
 }
 
 .buttons-wrapper {

--- a/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
+++ b/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
@@ -311,8 +311,12 @@
     background-image: var(--sbb-checkbox-checked, url(/polarion/ria/images/checkbox/checked.png));
 }
 
+/* Generic hosts the indeterminate checkbox image. This stylesheet is inlined into the bulk widget
+   (so a relative url() has no reliable base) and this widget already references /polarion/pdf-exporter/
+   paths, so point at the served generic image absolutely rather than via the relative
+   --sbb-checkbox-indeterminate token. */
 .polarion-PdfExporter-BulkExportWidget input[type="checkbox"]:indeterminate {
-    background-image: var(--sbb-checkbox-indeterminate, url(/polarion/ria/images/checkbox/grayed.png));
+    background-image: url(/polarion/pdf-exporter/ui/generic/images/checkbox-indeterminate.png);
 }
 
 .property-wrapper .more-info {

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -1,5 +1,6 @@
 <!-- If we put javascript code just in inline 'script' block it won't be initialized,
   but the attribute 'onload' below allows to import our module.  -->
+<link href='/polarion/pdf-exporter/ui/generic/css/control-tokens.css' rel='stylesheet'>
 <link href='/polarion/pdf-exporter/ui/generic/css/checkboxes.css' rel='stylesheet'>
 <link href='/polarion/pdf-exporter/ui/generic/css/searchable-dropdown.css' rel='stylesheet'>
 <link href='/polarion/pdf-exporter/ui/generic/css/inputs.css' rel='stylesheet'>


### PR DESCRIPTION
### Proposed changes

The bulk widget's :indeterminate rule referenced a checkbox image that no longer ships in 2606. Point it at generic's indeterminate PNG instead (an absolute /polarion/pdf-exporter/ path, since this CSS is inlined into the widget and has no reliable relative base).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
