### PR TITLE
chore: pin node & npm versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,10 @@
         "cross-env": "10.1.0",
         "jsdom": "29.1.1",
         "mocha": "11.7.6"
+      },
+      "engines": {
+        "node": ">=20.9.0",
+        "npm": ">=11"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -166,6 +170,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -214,6 +219,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,10 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.3"
-  }
+  },
+  "engines": {
+    "node": ">=20.9.0",
+    "npm": ">=11"
+  },
+  "packageManager": "npm@11.6.1"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <swagger-maven-plugin.version>2.2.22</swagger-maven-plugin.version>
 
         <frontend-maven-plugin.version>2.0.1</frontend-maven-plugin.version>
+        <!-- When bumping nodeVersion/npmVersion, keep package.json ("engines" and "packageManager") in sync. -->
         <frontend-maven-plugin.nodeVersion>v24.11.0</frontend-maven-plugin.nodeVersion>
         <frontend-maven-plugin.npmVersion>11.6.1</frontend-maven-plugin.npmVersion>
 


### PR DESCRIPTION
### Proposed changes

Stop the build from rewriting `package-lock.json` on every run: pin `npm` in `package.json` (`engines` + `packageManager`) to match the version already pinned in `pom.xml`, and regenerate the lockfile with that npm so the committed file matches CI output.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
