### PR TITLE
style: update select dropdown styling and remove color input rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.3.1</version>
+        <version>15.3.2</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.pdf-exporter</artifactId>

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
@@ -71,33 +71,6 @@
             vertical-align: middle;
             cursor: pointer;
         }
-        /* Match the combo-styled color picker used in the export panel / popup (130 x 23,
-           bordered, with the same dropdown arrow) — admin doesn't load pdf-exporter.css. */
-        #headers-color {
-            appearance: none;
-            -webkit-appearance: none;
-            -moz-appearance: none;
-            width: 130px;
-            height: 23px;
-            box-sizing: border-box;
-            border: 1px solid #cccccc;
-            border-radius: 2px;
-            /* Fixed px (not rem) so the swatch width is identical across admin / side-panel / popup —
-               those contexts have different root font-sizes, which made 2rem render differently. */
-            padding: 2px 24px 2px 4px;
-            /* Same sharp SVG combobox chevron + full swatch as the export panel (pdf-exporter.css),
-               so the admin colour picker matches the document-properties one. */
-            background: transparent var(--sbb-combo-chevron) no-repeat;
-            background-position: calc(100% - 5px) 55%;
-            background-size: 16px 16px;
-        }
-        #headers-color::-webkit-color-swatch {
-            border: 1px solid var(--sbb-control-border);
-            border-radius: 1px;
-        }
-        #headers-color::-webkit-color-swatch-wrapper {
-            padding: 0;
-        }
     </style>
 </head>
 

--- a/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
+++ b/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
@@ -308,7 +308,7 @@
     border-radius: 2px;
 }
 
-.property-wrapper select, .property-wrapper input[type="color"] {
+.property-wrapper select {
     appearance: none !important;
     -webkit-appearance: none !important;
     -moz-appearance: none !important;
@@ -336,11 +336,6 @@
     width: 200px;
 }
 
-.property-wrapper input[type="color"] {
-    /* Fixed px (not rem) so the swatch width is identical in the side panel, the popup and the
-       admin picker — those contexts have different root font-sizes, so 2rem rendered differently. */
-    padding: 2px 24px 2px 4px;
-}
 
 /* Uniform control sizing in the export panel & popup so every combo-like control matches the
    admin comboboxes (130 x 23). The searchable-dropdown wraps a native <select>; its container
@@ -380,36 +375,6 @@
    .options rule in the editor / modal context can't flatten it back to the trigger width). */
 .property-wrapper .searchable-dropdown .options {
     min-width: calc(100% + 35px);
-}
-
-.property-wrapper input[type="color"] {
-    width: 130px;
-    height: 23px;
-    box-sizing: border-box;
-    border-radius: 2px;
-    /* Chevron in px (not the base rule's calc(100% - 1rem)) so it sits identically in the side panel,
-       popup and admin, regardless of each context's root font-size. */
-    background-position: calc(100% - 5px) 55% !important;
-}
-
-.property-wrapper input[type="color"]::-webkit-color-swatch {
-    border: 1px solid var(--sbb-control-border);
-    border-radius: 1px;
-}
-
-/* Swatch fills the field (drop the default wrapper inset) — matches the admin style-packages
-   picker so admin / side-panel / popup colour pickers look identical. */
-.property-wrapper input[type="color"]::-webkit-color-swatch-wrapper {
-    padding: 0;
-}
-
-/* The colour input is a native <input> — its chevron sits via background-position, unlike the
-   SearchableDropdown's ::after. Higher specificity (panel/popup id) so the sibling exporters'
-   global `.property-wrapper input[type=color]` rule can't clobber it; nudge it right to line up
-   with the SearchableDropdown chevrons. */
-#pdf-exporter-panel .property-wrapper input[type="color"],
-.modal__container.pdf-exporter .property-wrapper input[type="color"] {
-    background-position: calc(100% - 5px) 55% !important;
 }
 
 .buttons-wrapper {

--- a/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
+++ b/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
@@ -300,7 +300,11 @@
     cursor: help;
 }
 
-.property-wrapper select, .property-wrapper input {
+/* input[type="color"] is excluded: the colour picker's look is owned entirely by the shared control
+   system in generic inputs.css (scoped to .form-wrapper / .modal__container). Keeping the colour input
+   out of these baseline rules leaves generic in sole control, so admin, side panel and popup render
+   identically instead of the colour field being partly styled here. */
+.property-wrapper select, .property-wrapper input:not([type="color"]) {
     font-weight: 600;
     font-family: "Segoe UI", "Selawik", "Open Sans", Arial, sans-serif;
     font-size: 13px;
@@ -319,7 +323,7 @@
     background-size: 16px 16px;
 }
 
-.property-wrapper input {
+.property-wrapper input:not([type="color"]) {
     padding: 2px 4px 4px .4rem;
 }
 


### PR DESCRIPTION
### Proposed changes

This pull request simplifies and unifies the styling for color picker inputs across the admin, side panel, and popup in the PDF exporter webapp. The main change is the removal of custom CSS targeting color inputs, ensuring that color pickers now use default browser styles for consistency and maintainability.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
