### PR TITLE
fix: render styled warnings in pdf export dialogs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.3.2</version>
+        <version>15.3.3</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.pdf-exporter</artifactId>

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
@@ -122,6 +122,12 @@ public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
                         .catch(console.error);""".formatted(panelId, exportPages.value()));
 
             wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/css/micromodal.css"));
+            // The widget assembles its CSS inline and does not pull generic's common.css, so the shared
+            // alert styling would be missing: control-tokens.css provides the --sbb-*-icon tokens and
+            // alerts.css the notification boxes + warning/error triangle icons. Without these the export
+            // dialog's warnings (e.g. the PDF/A sticky-notes notice) render as unstyled plain text.
+            wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/css/control-tokens.css"));
+            wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/css/alerts.css"));
             wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/webapp/pdf-exporter/css/pdf-exporter.css"));
 
             HtmlContentBuilder contentBuilder = mainTable.append();

--- a/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
+++ b/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
@@ -430,19 +430,25 @@
 }
 
 #export-error, #validate-error, #style-package-error {
-    display: inline-block;
+    display: block;
+    margin-top: 6px;
     color: red;
     font-weight: bold;
 }
 
 #export-warning {
-    display: inline-block;
+    display: block;
+    margin-top: 6px;
     color: orange;
     font-weight: bold;
 }
 
+/* Success message stays inline to the right of the Validate button (short text), vertically centred
+   against it. The error message, by contrast, is a full-width block below the button (long messages). */
 #validate-ok {
     display: inline-block;
+    vertical-align: middle;
+    margin-left: 8px;
     color: green;
     font-weight: bold;
 }

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -265,7 +265,6 @@
         </button>
         <div id='validate-ok'></div>
         <span id='validate-pdf-progress' class='sbb-spinner' role='img' aria-label='Loading'></span>
-        <br>
         <div id='validate-error'></div>
     </div>
 </div>

--- a/src/main/resources/webapp/pdf-exporter/js/starter.js
+++ b/src/main/resources/webapp/pdf-exporter/js/starter.js
@@ -76,6 +76,7 @@
         generic.injectStyles("generic-checkbox-styles", `${EXT_BASE}ui/generic/css/checkboxes.css${timestampParam}`);
         generic.injectStyles("generic-searchable-dropdown-styles", `${EXT_BASE}ui/generic/css/searchable-dropdown.css${timestampParam}`);
         generic.injectStyles("generic-inputs-styles", `${EXT_BASE}ui/generic/css/inputs.css${timestampParam}`);
+        generic.injectStyles("generic-alerts-styles", `${EXT_BASE}ui/generic/css/alerts.css${timestampParam}`);
         generic.injectScript("pdf-micromodal-script", `${EXT_BASE}ui/generic/js/micromodal.min.js${timestampParam}`);
         starter = generic.create({
             markerId: 'pdf-exporter-toolbar-injected',


### PR DESCRIPTION
### Proposed changes

The alert box + triangle styling lives in generic's common.css, which the export dialogs never load, so the PDF/A sticky-notes warning showed unstyled — plain text in bulk export, only a cross-extension colour leak in the toolbar dialog.

Inject the shared alerts.css into the toolbar/side-panel path via starter.js, and inline control-tokens.css + alerts.css in the Bulk PDF Export widget (which pulls neither) so its dialog resolves the alert box and the warning/error icon tokens.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
