### PR TITLE
feat: adopt generic 15.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.3.3</version>
+        <version>15.4.0</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.pdf-exporter</artifactId>

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
@@ -94,7 +94,13 @@ public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
         } else {
             String panelId = "bulk-%s".formatted(UUID.randomUUID().toString());
             HtmlTagBuilder wrap = builder.tag().div();
-            wrap.attributes().className("polarion-PdfExporter-BulkExportWidget").id(panelId);
+            // sbb-ui carries generic's --sbb-* design tokens (control-tokens.css) for this widget's
+            // subtree without opting into the form-field scopes: the token declarations live on
+            // .sbb-ui, while generic's inputs/checkboxes rules are scoped to .form-wrapper /
+            // .standard-admin-page / .modal__container. Post-#535 the tokens are gone from :root, so
+            // this wrapper is what makes the widget's checkbox tokens (below) resolve on a plain
+            // Polarion page.
+            wrap.attributes().className("polarion-PdfExporter-BulkExportWidget sbb-ui").id(panelId);
 
             HtmlTagBuilder header = wrap.append().tag().div();
             header.attributes().className("header");

--- a/src/main/resources/webapp/pdf-exporter-admin/css/tabs.css
+++ b/src/main/resources/webapp/pdf-exporter-admin/css/tabs.css
@@ -1,73 +1,19 @@
+/* pdf-exporter-specific tab layout. The shared tab LOOK now comes from generic tabs.css (linked
+   before this on each page). Kept here: the admin editor pages (css / cover-page / filename-template /
+   header-footer) are full-height, so the tab panel must fill the viewport below the tab bar — this is
+   layout specific to those pages, not part of the shared tab style. */
 .tabbed {
-    overflow-x: hidden; /* so we could easily hide the radio inputs */
-    position: relative;
     height: 100%;
 }
 
-.tabbed [type="radio"] {
-    /* hiding the inputs */
-    display: none;
-}
-
-.tabs {
-    display: flex;
-    align-items: stretch;
-    list-style: none;
-    padding: 0;
-    border-bottom: 1px solid #ccc;
-}
-
-.tab > label {
-    display: block;
-    margin-bottom: -1px;
-    padding: 12px 15px;
-    background: #eee;
-    color: #777;
-    font-size: 14px;
-    font-weight: 600;
-    cursor: pointer;
-    border-top-right-radius: 5px;
-    border-top-left-radius: 5px;
-    border-bottom: 1px solid #eee;
-    transition: all 0.3s;
-}
-
-.tab:hover label {
-    color: #555;
-}
-
-/* As we cannot replace the numbers with variables or calls to element properties, the number of this selector parts is our tab count limit */
-.tabbed [type="radio"]:nth-of-type(1):checked ~ .tabs .tab:nth-of-type(1) label,
-.tabbed [type="radio"]:nth-of-type(2):checked ~ .tabs .tab:nth-of-type(2) label,
-.tabbed [type="radio"]:nth-of-type(3):checked ~ .tabs .tab:nth-of-type(3) label,
-.tabbed [type="radio"]:nth-of-type(4):checked ~ .tabs .tab:nth-of-type(4) label {
-    border: 1px solid #ccc;
-    border-bottom-color: #fff;
-    background: #fff;
-    color: #333;
-}
-
-.tabbed [type="radio"]:nth-of-type(1):disabled ~ .tabs .tab:nth-of-type(1) label,
-.tabbed [type="radio"]:nth-of-type(2):disabled ~ .tabs .tab:nth-of-type(2) label,
-.tabbed [type="radio"]:nth-of-type(3):disabled ~ .tabs .tab:nth-of-type(3) label,
-.tabbed [type="radio"]:nth-of-type(4):disabled ~ .tabs .tab:nth-of-type(4) label {
-    color: #ccc;
-    cursor: default;
-}
-
 .tab-content {
-    opacity: 0;
-    -webkit-transition: opacity .4s;
-    -moz-transition: opacity .4s;
-    transition: opacity .4s;
     height: calc(100% - 108px);
-    display: none;
 }
 
-.tabbed [type="radio"]:nth-of-type(1):checked ~ .tab-content:nth-of-type(1),
-.tabbed [type="radio"]:nth-of-type(2):checked ~ .tab-content:nth-of-type(2),
-.tabbed [type="radio"]:nth-of-type(3):checked ~ .tab-content:nth-of-type(3),
-.tabbed [type="radio"]:nth-of-type(4):checked ~ .tab-content:nth-of-type(4) {
-    opacity: 1;
-    display: block;
+/* Uniform gap between the checkbox block above and the tab bar on every admin page: configurations.css
+   adds .input-group{margin-bottom:5px} only where the config UI is present (so filename-template, which
+   has none, sat tighter). Pin it here for the checkbox that directly precedes the tab bar; scoped via
+   :has(+ .tabbed) so other checkboxes are untouched. */
+.flex-container:has(+ .tabbed) .checkbox.input-group {
+    margin-bottom: 12px;
 }

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/cover-page.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/cover-page.jsp
@@ -98,7 +98,7 @@
     </div>
 
     <div class="tabbed">
-        <input type="radio" id="custom-template" name="cover-page-template" checked>
+        <input type="radio" id="custom-template" name="cover-page-template">
         <input type="radio" id="default-template" name="cover-page-template">
 
         <ul class="tabs">

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/filename-template.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/filename-template.jsp
@@ -89,7 +89,7 @@
     </div>
 
     <div class="tabbed">
-        <input type="radio" id="custom-templates" name="file-templates" checked>
+        <input type="radio" id="custom-templates" name="file-templates">
         <input type="radio" id="default-templates" name="file-templates">
 
         <ul class="tabs">

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/header-footer.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/header-footer.jsp
@@ -93,7 +93,7 @@
     </div>
 
     <div class="tabbed">
-        <input type="radio" id="custom-templates" name="cover-page-template" checked>
+        <input type="radio" id="custom-templates" name="cover-page-template">
         <input type="radio" id="default-templates" name="cover-page-template">
 
         <ul class="tabs">

--- a/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
+++ b/src/main/resources/webapp/pdf-exporter/css/pdf-exporter.css
@@ -267,9 +267,10 @@
 }
 
 /* The bulk export widget renders on a Polarion page, not inside a .form-wrapper / .modal__container,
-   so the shared 2606 checkbox styling (generic checkboxes.css) does not reach it. Re-apply it scoped
-   to the widget's own root — same tokens and images — rather than tagging the widget with the broad
-   .form-wrapper class, which would also opt it into unrelated form-field scopes. */
+   so the shared 2606 checkbox styling (generic checkboxes.css, scoped to those wrappers) does not
+   reach it. Re-apply it scoped to the widget's own root — same tokens and images. The widget root
+   carries .sbb-ui (see BulkPdfExportWidgetRenderer), which supplies the --sbb-* tokens these rules
+   consume without pulling in the unrelated form-field scopes. */
 .polarion-PdfExporter-BulkExportWidget input[type="checkbox"] {
     -webkit-appearance: none;
     appearance: none;
@@ -568,7 +569,7 @@
     height: 100%;
     padding: 0 10px;
     border-radius: 4px;
-    background-color: #007993;
+    background-color: var(--sbb-accent);
     overflow: hidden;
     line-height: 1.6em;
     text-align: center;


### PR DESCRIPTION
### Proposed changes

Bump generic to 15.4.0 (scope-only --sbb-* tokens, unified tabs, shared accent) and align the extension UI with it:
- tag the Bulk PDF Export widget root with .sbb-ui so its checkboxes and alerts keep resolving --sbb-* tokens after generic dropped :root (#535)
- align the admin tab pages with the shared tabs.css

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
