### PR TITLE
feat: add single-tag dle-toolbar.js injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,22 +82,36 @@ ch.sbb.polarion.extension.pdf-exporter.weasyprint.service=http://localhost:9080
 
 ### PDF Exporter view to open via button in toolbar
 
-Alternatively you can configure PDF Exporter such a way that additional toolbar will appear in document's editor with a button to open a popup with PDF Exporter view.
+Alternatively you can configure PDF Exporter such a way that a button to open the PDF Exporter view appears in the document editor's toolbar.
 
 1. Open "Default Repository".
 2. On the top of its navigation pane click ⚙ (Actions) ➙ 🔧 Administration. Global administration page will be opened.
 3. On the administration's navigation pane select Configuration Properties.
 4. In editor of opened page add following line:
    ```properties
-   scriptInjection.dleEditorHead=<script src="/polarion/pdf-exporter/js/starter.js"></script><script>PdfExporterStarter.injectToolbar();</script>
+   scriptInjection.dleEditorHead=<script src="/polarion/pdf-exporter/js/dle-toolbar.js"></script>
    ```
-   There's an alternate approach adding the PDF Exporter button into Polarion's native document toolbar. Previously this
-   approach had a drawback — the button could disappear in some cases (for example when the document was saved); this has now
-   been fixed: the button is re-injected automatically when Polarion re-renders the toolbar, so it stays in place:
-   ```properties
-   scriptInjection.dleEditorHead=<script src="/polarion/pdf-exporter/js/starter.js"></script><script>PdfExporterStarter.injectToolbar({alternate: true});</script>
-   ```
+   This adds the button into Polarion's native document toolbar. The button is re-injected automatically when Polarion re-renders the toolbar (for example when the document is saved), so it stays in place.
 5. Save changes by clicking 💾 Save
+
+> [!TIP]
+> **Adding more than one toolbar button.** `scriptInjection.dleEditorHead` is a single Polarion-wide property that holds exactly one value. To show several buttons in the document editor (for example the PDF, DOCX and StrictDoc exporters together, or this button alongside any other injected script), do **not** add separate `scriptInjection.dleEditorHead=` lines — the last one overrides the rest. Concatenate all the `<script>` tags into that single value instead:
+> ```properties
+> scriptInjection.dleEditorHead=<script src="/polarion/pdf-exporter/js/dle-toolbar.js"></script><script src="/polarion/docx-exporter/js/dle-toolbar.js"></script><script src="/polarion/strictdoc-exporter/js/dle-toolbar.js"></script>
+> ```
+
+#### Deprecated configuration
+
+The explicit `PdfExporterStarter.injectToolbar(...)` configuration still works but is **deprecated** in favor of the single-tag `dle-toolbar.js` form above (removal is planned for a future major version):
+
+```properties
+# Button in Polarion's native document toolbar — equivalent to the recommended dle-toolbar.js form above.
+scriptInjection.dleEditorHead=<script src="/polarion/pdf-exporter/js/starter.js"></script><script>PdfExporterStarter.injectToolbar({alternate: true});</script>
+```
+```properties
+# A separate toolbar with the button placed above the document editing area.
+scriptInjection.dleEditorHead=<script src="/polarion/pdf-exporter/js/starter.js"></script><script>PdfExporterStarter.injectToolbar();</script>
+```
 
 ### PDF Exporter view to open in Live Reports
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,18 @@ First of all you need to inject appropriate JavaScript code into Polarion:
 3. On the administration's navigation pane select Configuration Properties.
 4. In editor of opened page add following line:
    ```properties
-   scriptInjection.mainHead=<script src="/polarion/pdf-exporter/js/starter.js"></script>
+   scriptInjection.mainHead=<script src="/polarion/pdf-exporter/js/live-reports.js"></script>
    ```
 5. Save changes by clicking 💾 Save
+
+> [!NOTE]
+> `scriptInjection.mainHead` is a single Polarion-wide property that holds exactly one value. If you also inject other scripts through it, concatenate all the `<script>` tags into that one value rather than adding separate `scriptInjection.mainHead=` lines — the last one overrides the rest.
+
+The explicit `starter.js` form still works but is **deprecated** in favor of the single-tag `live-reports.js` form above (removal is planned for a future major version):
+
+```properties
+scriptInjection.mainHead=<script src="/polarion/pdf-exporter/js/starter.js"></script>
+```
 
 Then open a project, its Live Report you wish to export, and click "Expand Tools" on top of the page.
 As a result report's toolbar will appear. Click "Edit" button in a toolbar, as a result the report will be switched into an edit mode. Add an empty region on top of the report, place cursor there, choose "PDF Export" tag on "Widgets" sidebar on right hand side of the page, find "Export to PDF Button" widget there and click it to add to the report. Then save a report clicking 💾 in a toolbar and then return to a view mode clicking "Back" button. When you click "Export to PDF" button just added to the report, PDF Exporter view will be opened in a popup and you will be able to proceed with exporting the report to PDF. Be aware that in report's context limited set of properties are available for configuration in PDF popup, the rest of them are relevant only in Live Document context.

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/DleToolbarStatusProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/DleToolbarStatusProvider.java
@@ -16,33 +16,42 @@ public class DleToolbarStatusProvider extends ConfigurationStatusProvider {
     // Recommended single-tag injector.
     public static final String DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/dle-toolbar.js[^\"]*\"></script>(.*)";
     // Deprecated explicit-injectToolbar config (still works).
-    public static final String DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/starter.js\"></script>(.*)<script>PdfExporterStarter.injectToolbar(.*);</script>(.*)";
+    public static final String DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/starter.js[^\"]*\"></script>(.*)<script>PdfExporterStarter.injectToolbar(.*);</script>(.*)";
     public static final String NOT_CONFIGURED = "Not configured";
     public static final String DEPRECATED_DETAILS = "Deprecated configuration. Replace it with the single tag "
             + "<script src=\"/polarion/pdf-exporter/js/dle-toolbar.js\"></script>";
 
+    // Ordered best-to-worst; when the two property sources disagree the lower ordinal wins.
+    private enum ConfigForm {
+        RECOMMENDED, DEPRECATED, MISSING
+    }
+
     @Override
     public @NotNull ConfigurationStatus getStatus(@NotNull Context context) {
-        ConfigurationStatus systemStatus = classify(ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().dleEditorHead());
-        ConfigurationStatus runtimeStatus = classify(ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().dleEditorHead());
-        // Prefer the better-configured of the two property sources (system wins on a tie).
-        return rank(systemStatus) >= rank(runtimeStatus) ? systemStatus : runtimeStatus;
+        ConfigForm system = evaluate(ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().dleEditorHead());
+        ConfigForm runtime = evaluate(ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().dleEditorHead());
+        // Prefer the better-configured source (system wins on a tie).
+        return toStatus(system.ordinal() <= runtime.ordinal() ? system : runtime);
     }
 
-    private @NotNull ConfigurationStatus classify(@Nullable String dleEditorHead) {
-        if (dleEditorHead != null && RegexMatcher.get(DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
-            return new ConfigurationStatus(DLE_TOOLBAR, Status.OK);
+    private @NotNull ConfigForm evaluate(@Nullable String dleEditorHead) {
+        if (dleEditorHead == null) {
+            return ConfigForm.MISSING;
         }
-        if (dleEditorHead != null && RegexMatcher.get(DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
-            return new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, DEPRECATED_DETAILS);
+        if (RegexMatcher.get(DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
+            return ConfigForm.RECOMMENDED;
         }
-        return new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, NOT_CONFIGURED);
+        if (RegexMatcher.get(DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
+            return ConfigForm.DEPRECATED;
+        }
+        return ConfigForm.MISSING;
     }
 
-    private int rank(@NotNull ConfigurationStatus status) {
-        if (status.getStatus() == Status.OK) {
-            return 2;
-        }
-        return DEPRECATED_DETAILS.equals(status.getDetails()) ? 1 : 0;
+    private @NotNull ConfigurationStatus toStatus(@NotNull ConfigForm form) {
+        return switch (form) {
+            case RECOMMENDED -> new ConfigurationStatus(DLE_TOOLBAR, Status.OK);
+            case DEPRECATED -> new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, DEPRECATED_DETAILS);
+            case MISSING -> new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, NOT_CONFIGURED);
+        };
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/DleToolbarStatusProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/DleToolbarStatusProvider.java
@@ -3,28 +3,46 @@ package ch.sbb.polarion.extension.pdf_exporter.util.configuration;
 import ch.sbb.polarion.extension.generic.configuration.ConfigurationStatus;
 import ch.sbb.polarion.extension.generic.configuration.ConfigurationStatusProvider;
 import ch.sbb.polarion.extension.generic.configuration.Status;
+import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.generic.util.Discoverable;
 import com.polarion.alm.projects.properties.internal.ScriptInjectionPropertiesProvider;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Discoverable
 public class DleToolbarStatusProvider extends ConfigurationStatusProvider {
 
     public static final String DLE_TOOLBAR = "DLE Toolbar";
-    public static final String DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/starter.js\"></script>(.*)<script>PdfExporterStarter.injectToolbar(.*);</script>(.*)";
+    // Recommended single-tag injector.
+    public static final String DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/dle-toolbar.js[^\"]*\"></script>(.*)";
+    // Deprecated explicit-injectToolbar config (still works).
+    public static final String DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/starter.js\"></script>(.*)<script>PdfExporterStarter.injectToolbar(.*);</script>(.*)";
+    public static final String NOT_CONFIGURED = "Not configured";
+    public static final String DEPRECATED_DETAILS = "Deprecated configuration. Replace it with the single tag "
+            + "<script src=\"/polarion/pdf-exporter/js/dle-toolbar.js\"></script>";
 
     @Override
     public @NotNull ConfigurationStatus getStatus(@NotNull Context context) {
-        String scriptInjectionSystemPropertiesDleEditorHead = ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().dleEditorHead();
-        String scriptInjectionRuntimePropertiesDleEditorHead = ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().dleEditorHead();
+        ConfigurationStatus systemStatus = classify(ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().dleEditorHead());
+        ConfigurationStatus runtimeStatus = classify(ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().dleEditorHead());
+        // Prefer the better-configured of the two property sources (system wins on a tie).
+        return rank(systemStatus) >= rank(runtimeStatus) ? systemStatus : runtimeStatus;
+    }
 
-        ConfigurationStatus configurationStatusSystemProperties = getConfigurationStatus(DLE_TOOLBAR, scriptInjectionSystemPropertiesDleEditorHead, DLE_TOOLBAR_SCRIPT_REGEX);
-        ConfigurationStatus configurationStatusRuntimeProperties = getConfigurationStatus(DLE_TOOLBAR, scriptInjectionRuntimePropertiesDleEditorHead, DLE_TOOLBAR_SCRIPT_REGEX);
-
-        if (configurationStatusSystemProperties.getStatus() == Status.OK) {
-            return configurationStatusSystemProperties;
-        } else {
-            return configurationStatusRuntimeProperties;
+    private @NotNull ConfigurationStatus classify(@Nullable String dleEditorHead) {
+        if (dleEditorHead != null && RegexMatcher.get(DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
+            return new ConfigurationStatus(DLE_TOOLBAR, Status.OK);
         }
+        if (dleEditorHead != null && RegexMatcher.get(DEPRECATED_DLE_TOOLBAR_SCRIPT_REGEX).anyMatch(dleEditorHead)) {
+            return new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, DEPRECATED_DETAILS);
+        }
+        return new ConfigurationStatus(DLE_TOOLBAR, Status.WARNING, NOT_CONFIGURED);
+    }
+
+    private int rank(@NotNull ConfigurationStatus status) {
+        if (status.getStatus() == Status.OK) {
+            return 2;
+        }
+        return DEPRECATED_DETAILS.equals(status.getDetails()) ? 1 : 0;
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/LiveReportMainHeadStatusProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/LiveReportMainHeadStatusProvider.java
@@ -3,28 +3,46 @@ package ch.sbb.polarion.extension.pdf_exporter.util.configuration;
 import ch.sbb.polarion.extension.generic.configuration.ConfigurationStatus;
 import ch.sbb.polarion.extension.generic.configuration.ConfigurationStatusProvider;
 import ch.sbb.polarion.extension.generic.configuration.Status;
+import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.generic.util.Discoverable;
 import com.polarion.alm.projects.properties.internal.ScriptInjectionPropertiesProvider;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Discoverable
 public class LiveReportMainHeadStatusProvider extends ConfigurationStatusProvider {
 
     public static final String LIVE_REPORT_BUTTON = "LiveReport Button";
-    public static final String LIVE_REPORT_BUTTON_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/starter.js\"></script>(.*)";
+    // Recommended single-tag Live Reports loader.
+    public static final String LIVE_REPORT_BUTTON_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/live-reports.js[^\"]*\"></script>(.*)";
+    // Deprecated form (loads starter.js, which also drags in the DLE toolbar engine).
+    public static final String DEPRECATED_LIVE_REPORT_BUTTON_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/starter.js\"></script>(.*)";
+    public static final String NOT_CONFIGURED = "Not configured";
+    public static final String DEPRECATED_DETAILS = "Deprecated configuration. Replace it with the single tag "
+            + "<script src=\"/polarion/pdf-exporter/js/live-reports.js\"></script>";
 
     @Override
     public @NotNull ConfigurationStatus getStatus(@NotNull Context context) {
-        String scriptInjectionSystemPropertiesMainHead = ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().mainHead();
-        String scriptInjectionRuntimePropertiesMainHead = ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().mainHead();
+        ConfigurationStatus systemStatus = classify(ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().mainHead());
+        ConfigurationStatus runtimeStatus = classify(ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().mainHead());
+        // Prefer the better-configured of the two property sources (system wins on a tie).
+        return rank(systemStatus) >= rank(runtimeStatus) ? systemStatus : runtimeStatus;
+    }
 
-        ConfigurationStatus configurationStatusSystemProperties = getConfigurationStatus(LIVE_REPORT_BUTTON, scriptInjectionSystemPropertiesMainHead, LIVE_REPORT_BUTTON_SCRIPT_REGEX);
-        ConfigurationStatus configurationStatusRuntimeProperties = getConfigurationStatus(LIVE_REPORT_BUTTON, scriptInjectionRuntimePropertiesMainHead, LIVE_REPORT_BUTTON_SCRIPT_REGEX);
-
-        if (configurationStatusSystemProperties.getStatus() == Status.OK) {
-            return configurationStatusSystemProperties;
-        } else {
-            return configurationStatusRuntimeProperties;
+    private @NotNull ConfigurationStatus classify(@Nullable String mainHead) {
+        if (mainHead != null && RegexMatcher.get(LIVE_REPORT_BUTTON_SCRIPT_REGEX).anyMatch(mainHead)) {
+            return new ConfigurationStatus(LIVE_REPORT_BUTTON, Status.OK);
         }
+        if (mainHead != null && RegexMatcher.get(DEPRECATED_LIVE_REPORT_BUTTON_SCRIPT_REGEX).anyMatch(mainHead)) {
+            return new ConfigurationStatus(LIVE_REPORT_BUTTON, Status.WARNING, DEPRECATED_DETAILS);
+        }
+        return new ConfigurationStatus(LIVE_REPORT_BUTTON, Status.WARNING, NOT_CONFIGURED);
+    }
+
+    private int rank(@NotNull ConfigurationStatus status) {
+        if (status.getStatus() == Status.OK) {
+            return 2;
+        }
+        return DEPRECATED_DETAILS.equals(status.getDetails()) ? 1 : 0;
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/LiveReportMainHeadStatusProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/LiveReportMainHeadStatusProvider.java
@@ -16,33 +16,42 @@ public class LiveReportMainHeadStatusProvider extends ConfigurationStatusProvide
     // Recommended single-tag Live Reports loader.
     public static final String LIVE_REPORT_BUTTON_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/live-reports.js[^\"]*\"></script>(.*)";
     // Deprecated form (loads starter.js, which also drags in the DLE toolbar engine).
-    public static final String DEPRECATED_LIVE_REPORT_BUTTON_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/starter.js\"></script>(.*)";
+    public static final String DEPRECATED_LIVE_REPORT_BUTTON_SCRIPT_REGEX = "(.*)<script src=\"/polarion/pdf-exporter/js/starter.js[^\"]*\"></script>(.*)";
     public static final String NOT_CONFIGURED = "Not configured";
     public static final String DEPRECATED_DETAILS = "Deprecated configuration. Replace it with the single tag "
             + "<script src=\"/polarion/pdf-exporter/js/live-reports.js\"></script>";
 
+    // Ordered best-to-worst; when the two property sources disagree the lower ordinal wins.
+    private enum ConfigForm {
+        RECOMMENDED, DEPRECATED, MISSING
+    }
+
     @Override
     public @NotNull ConfigurationStatus getStatus(@NotNull Context context) {
-        ConfigurationStatus systemStatus = classify(ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().mainHead());
-        ConfigurationStatus runtimeStatus = classify(ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().mainHead());
-        // Prefer the better-configured of the two property sources (system wins on a tie).
-        return rank(systemStatus) >= rank(runtimeStatus) ? systemStatus : runtimeStatus;
+        ConfigForm system = evaluate(ScriptInjectionPropertiesProvider.getScriptInjectionSystemProperties().mainHead());
+        ConfigForm runtime = evaluate(ScriptInjectionPropertiesProvider.getScripInjectionRuntimeProperties().mainHead());
+        // Prefer the better-configured source (system wins on a tie).
+        return toStatus(system.ordinal() <= runtime.ordinal() ? system : runtime);
     }
 
-    private @NotNull ConfigurationStatus classify(@Nullable String mainHead) {
-        if (mainHead != null && RegexMatcher.get(LIVE_REPORT_BUTTON_SCRIPT_REGEX).anyMatch(mainHead)) {
-            return new ConfigurationStatus(LIVE_REPORT_BUTTON, Status.OK);
+    private @NotNull ConfigForm evaluate(@Nullable String mainHead) {
+        if (mainHead == null) {
+            return ConfigForm.MISSING;
         }
-        if (mainHead != null && RegexMatcher.get(DEPRECATED_LIVE_REPORT_BUTTON_SCRIPT_REGEX).anyMatch(mainHead)) {
-            return new ConfigurationStatus(LIVE_REPORT_BUTTON, Status.WARNING, DEPRECATED_DETAILS);
+        if (RegexMatcher.get(LIVE_REPORT_BUTTON_SCRIPT_REGEX).anyMatch(mainHead)) {
+            return ConfigForm.RECOMMENDED;
         }
-        return new ConfigurationStatus(LIVE_REPORT_BUTTON, Status.WARNING, NOT_CONFIGURED);
+        if (RegexMatcher.get(DEPRECATED_LIVE_REPORT_BUTTON_SCRIPT_REGEX).anyMatch(mainHead)) {
+            return ConfigForm.DEPRECATED;
+        }
+        return ConfigForm.MISSING;
     }
 
-    private int rank(@NotNull ConfigurationStatus status) {
-        if (status.getStatus() == Status.OK) {
-            return 2;
-        }
-        return DEPRECATED_DETAILS.equals(status.getDetails()) ? 1 : 0;
+    private @NotNull ConfigurationStatus toStatus(@NotNull ConfigForm form) {
+        return switch (form) {
+            case RECOMMENDED -> new ConfigurationStatus(LIVE_REPORT_BUTTON, Status.OK);
+            case DEPRECATED -> new ConfigurationStatus(LIVE_REPORT_BUTTON, Status.WARNING, DEPRECATED_DETAILS);
+            case MISSING -> new ConfigurationStatus(LIVE_REPORT_BUTTON, Status.WARNING, NOT_CONFIGURED);
+        };
     }
 }

--- a/src/main/resources/webapp/pdf-exporter/js/dle-toolbar.js
+++ b/src/main/resources/webapp/pdf-exporter/js/dle-toolbar.js
@@ -1,0 +1,34 @@
+/*
+ * One-tag DLE toolbar injector — the simple, recommended way to add the PDF Exporter button to
+ * Polarion's native document editor toolbar. Configure a single script tag:
+ *
+ *   scriptInjection.dleEditorHead=<script src="/polarion/pdf-exporter/js/dle-toolbar.js"></script>
+ *
+ * It loads the thin starter (which pulls the shared self-healing engine) and injects the toolbar
+ * button, so no separate <script>PdfExporterStarter.injectToolbar({alternate: true});</script> tag
+ * is needed. The deprecated explicit-injectToolbar config keeps working; see starter.js.
+ */
+(function () {
+    function injectToolbar() {
+        window.PdfExporterStarter.injectToolbar({alternate: true});
+    }
+
+    // starter.js may already be loaded (e.g. also configured via scriptInjection.mainHead) —
+    // reuse it rather than loading it again.
+    if (window.PdfExporterStarter) {
+        injectToolbar();
+        return;
+    }
+
+    // Load starter.js relative to this script's own URL (…/polarion/<ext>/js/dle-toolbar.js),
+    // so nothing here hardcodes the /polarion/<ext>/ segment.
+    const starterSrc = (document.currentScript && document.currentScript.src || '')
+        .replace(/dle-toolbar\.js.*$/, 'starter.js') || '/polarion/pdf-exporter/js/starter.js';
+    const script = document.createElement('script');
+    script.src = starterSrc;
+    script.onload = injectToolbar;
+    script.onerror = function () {
+        console.error("pdf-exporter: failed to load starter.js — DLE toolbar button injection skipped.");
+    };
+    document.head.appendChild(script);
+})();

--- a/src/main/resources/webapp/pdf-exporter/js/dle-toolbar.js
+++ b/src/main/resources/webapp/pdf-exporter/js/dle-toolbar.js
@@ -26,7 +26,13 @@
         .replace(/dle-toolbar\.js.*$/, 'starter.js') || '/polarion/pdf-exporter/js/starter.js';
     const script = document.createElement('script');
     script.src = starterSrc;
-    script.onload = injectToolbar;
+    script.onload = function () {
+        if (window.PdfExporterStarter) {
+            injectToolbar();
+        } else {
+            console.error("pdf-exporter: starter.js loaded but PdfExporterStarter is not defined — DLE toolbar button injection skipped.");
+        }
+    };
     script.onerror = function () {
         console.error("pdf-exporter: failed to load starter.js — DLE toolbar button injection skipped.");
     };

--- a/src/main/resources/webapp/pdf-exporter/js/live-reports.js
+++ b/src/main/resources/webapp/pdf-exporter/js/live-reports.js
@@ -1,0 +1,50 @@
+/*
+ * Live Reports dependency loader — the recommended way to enable the "Export to PDF" button in
+ * Polarion Live Reports. Configure a single script tag (injected into every page):
+ *
+ *   scriptInjection.mainHead=<script src="/polarion/pdf-exporter/js/live-reports.js"></script>
+ *
+ * The "Export to PDF Button" report widget renders server-side and opens ExportPopup.js on click.
+ * That popup does not ship its own styling or the micromodal library, so this script injects the
+ * stylesheets and micromodal it needs. It adds NO toolbar button and does not load the DLE toolbar
+ * engine. It replaces loading starter.js via mainHead (deprecated).
+ *
+ * The element ids match the ones starter.js uses, so nothing is injected twice if both run.
+ */
+(function () {
+    const timestampParam = `?timestamp=${Date.now()}`;
+
+    // Extension web-context base, derived from this script's own URL (…/polarion/<ext>/js/live-reports.js)
+    // so nothing below hardcodes the /polarion/<ext>/ segment.
+    const EXT_BASE = (document.currentScript && document.currentScript.src || '').replace(/js\/live-reports\.js.*$/, '') || '/polarion/pdf-exporter/';
+
+    function injectStyle(id, href) {
+        if (!top.document.getElementById(id)) {
+            const link = top.document.createElement('link');
+            link.id = id;
+            link.rel = 'stylesheet';
+            link.type = 'text/css';
+            link.href = href;
+            top.document.head.appendChild(link);
+        }
+    }
+
+    function injectScript(id, src) {
+        if (!top.document.getElementById(id)) {
+            const script = top.document.createElement('script');
+            script.id = id;
+            script.setAttribute('src', src);
+            script.setAttribute('type', 'text/javascript');
+            top.document.head.appendChild(script);
+        }
+    }
+
+    injectStyle('pdf-exporter-styles', `${EXT_BASE}css/pdf-exporter.css${timestampParam}`);
+    injectStyle('pdf-micromodal-styles', `${EXT_BASE}ui/generic/css/micromodal.css${timestampParam}`);
+    injectStyle('generic-control-tokens', `${EXT_BASE}ui/generic/css/control-tokens.css${timestampParam}`);
+    injectStyle('generic-checkbox-styles', `${EXT_BASE}ui/generic/css/checkboxes.css${timestampParam}`);
+    injectStyle('generic-searchable-dropdown-styles', `${EXT_BASE}ui/generic/css/searchable-dropdown.css${timestampParam}`);
+    injectStyle('generic-inputs-styles', `${EXT_BASE}ui/generic/css/inputs.css${timestampParam}`);
+    injectStyle('generic-alerts-styles', `${EXT_BASE}ui/generic/css/alerts.css${timestampParam}`);
+    injectScript('pdf-micromodal-script', `${EXT_BASE}ui/generic/js/micromodal.min.js${timestampParam}`);
+})();

--- a/src/main/resources/webapp/pdf-exporter/js/starter.js
+++ b/src/main/resources/webapp/pdf-exporter/js/starter.js
@@ -6,6 +6,10 @@
  * The dleEditorHead config is unchanged: it still loads this script and calls
  * PdfExporterStarter.injectToolbar({...}); the bootstrap below pulls the engine and queues
  * the call until it is ready.
+ *
+ * DEPRECATED: the explicit PdfExporterStarter.injectToolbar(...) config is superseded by the
+ * single-tag /polarion/pdf-exporter/js/dle-toolbar.js injector (adds the toolbar button without a
+ * second script tag). It keeps working for backward compatibility; removal is a future major bump.
  */
 (function () {
     const timestampParam = `?timestamp=${Date.now()}`;
@@ -50,6 +54,12 @@
     let starter = null, myOrder;
     const pending = [];
     window.PdfExporterStarter = {
+        /**
+         * @deprecated Use the single-tag injector instead:
+         *   <script src="/polarion/pdf-exporter/js/dle-toolbar.js"></script>
+         * Kept for backward compatibility; removal is planned for a future major version.
+         * @param {{alternate: boolean}|undefined} params
+         */
         injectToolbar: function (params) {
             if (myOrder === undefined) {
                 // Capture config-execution order (this stub runs synchronously in dleEditorHead

--- a/src/main/resources/webapp/pdf-exporter/js/starter.js
+++ b/src/main/resources/webapp/pdf-exporter/js/starter.js
@@ -7,9 +7,11 @@
  * PdfExporterStarter.injectToolbar({...}); the bootstrap below pulls the engine and queues
  * the call until it is ready.
  *
- * DEPRECATED: the explicit PdfExporterStarter.injectToolbar(...) config is superseded by the
- * single-tag /polarion/pdf-exporter/js/dle-toolbar.js injector (adds the toolbar button without a
- * second script tag). It keeps working for backward compatibility; removal is a future major bump.
+ * DEPRECATED: this script is superseded by two dedicated single-tag injectors —
+ * /polarion/pdf-exporter/js/dle-toolbar.js for the document-editor toolbar button (replaces
+ * PdfExporterStarter.injectToolbar(...)), and /polarion/pdf-exporter/js/live-reports.js for the
+ * Live Reports export button (replaces loading starter.js via scriptInjection.mainHead). It keeps
+ * working for backward compatibility; removal is a future major bump.
  */
 (function () {
     const timestampParam = `?timestamp=${Date.now()}`;

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/DleToolbarStatusProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/DleToolbarStatusProviderTest.java
@@ -17,33 +17,48 @@ import static org.mockito.Mockito.mockStatic;
 
 class DleToolbarStatusProviderTest {
 
-    public static final String CONFIG = "<script src=\"/polarion/pdf-exporter/js/starter.js\"></script><script>PdfExporterStarter.injectToolbar();</script>";
-    public static final String CONFIG_WITH_ALTERNATE = "<script src=\"/polarion/pdf-exporter/js/starter.js\"></script><script>PdfExporterStarter.injectToolbar({alternate: true});</script>";
+    // Recommended single-tag injector.
+    public static final String CONFIG_NEW = "<script src=\"/polarion/pdf-exporter/js/dle-toolbar.js\"></script>";
+    // Deprecated explicit-injectToolbar forms (still supported).
+    public static final String CONFIG_DEPRECATED = "<script src=\"/polarion/pdf-exporter/js/starter.js\"></script><script>PdfExporterStarter.injectToolbar();</script>";
+    public static final String CONFIG_DEPRECATED_WITH_ALTERNATE = "<script src=\"/polarion/pdf-exporter/js/starter.js\"></script><script>PdfExporterStarter.injectToolbar({alternate: true});</script>";
 
     public static Stream<Arguments> provideConfigurationStatus() {
-        ConfigurationStatus configurationStatusNotConfigured = ConfigurationStatus.builder()
+        ConfigurationStatus notConfigured = ConfigurationStatus.builder()
                 .name(DleToolbarStatusProvider.DLE_TOOLBAR)
                 .status(Status.WARNING)
-                .details("Not configured")
+                .details(DleToolbarStatusProvider.NOT_CONFIGURED)
                 .build();
-        ConfigurationStatus configurationStatusOk = ConfigurationStatus.builder()
+        ConfigurationStatus ok = ConfigurationStatus.builder()
                 .name(DleToolbarStatusProvider.DLE_TOOLBAR)
                 .status(Status.OK)
                 .details("")
                 .build();
+        ConfigurationStatus deprecated = ConfigurationStatus.builder()
+                .name(DleToolbarStatusProvider.DLE_TOOLBAR)
+                .status(Status.WARNING)
+                .details(DleToolbarStatusProvider.DEPRECATED_DETAILS)
+                .build();
 
         return Stream.of(
-                Arguments.of("", "", configurationStatusNotConfigured),
+                Arguments.of("", "", notConfigured),
 
-                Arguments.of(CONFIG, "", configurationStatusOk),
-                Arguments.of("", CONFIG, configurationStatusOk),
-                Arguments.of(CONFIG, CONFIG, configurationStatusOk),
+                // Recommended single-tag form → OK.
+                Arguments.of(CONFIG_NEW, "", ok),
+                Arguments.of("", CONFIG_NEW, ok),
+                Arguments.of(CONFIG_NEW, CONFIG_NEW, ok),
+                Arguments.of("<script></script> <script src=\"/polarion/pdf-exporter/js/dle-toolbar.js\"></script> <script></script>", "", ok),
 
-                Arguments.of(CONFIG_WITH_ALTERNATE, "", configurationStatusOk),
-                Arguments.of("", CONFIG_WITH_ALTERNATE, configurationStatusOk),
-                Arguments.of(CONFIG_WITH_ALTERNATE, CONFIG_WITH_ALTERNATE, configurationStatusOk),
+                // Deprecated explicit-injectToolbar forms → WARNING with deprecation hint.
+                Arguments.of(CONFIG_DEPRECATED, "", deprecated),
+                Arguments.of("", CONFIG_DEPRECATED, deprecated),
+                Arguments.of(CONFIG_DEPRECATED_WITH_ALTERNATE, "", deprecated),
+                Arguments.of("", CONFIG_DEPRECATED_WITH_ALTERNATE, deprecated),
+                Arguments.of(CONFIG_DEPRECATED, CONFIG_DEPRECATED, deprecated),
 
-                Arguments.of("<script> </script> <script src=\"/polarion/pdf-exporter/js/starter.js\"></script> <script>PdfExporterStarter.injectToolbar();</script> <script></script>", "", configurationStatusOk)
+                // The recommended form on either source wins over a deprecated form.
+                Arguments.of(CONFIG_NEW, CONFIG_DEPRECATED, ok),
+                Arguments.of(CONFIG_DEPRECATED, CONFIG_NEW, ok)
         );
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/DleToolbarStatusProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/DleToolbarStatusProviderTest.java
@@ -42,6 +42,7 @@ class DleToolbarStatusProviderTest {
 
         return Stream.of(
                 Arguments.of("", "", notConfigured),
+                Arguments.of(null, null, notConfigured),
 
                 // Recommended single-tag form → OK.
                 Arguments.of(CONFIG_NEW, "", ok),

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/LiveReportMainHeadStatusProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/LiveReportMainHeadStatusProviderTest.java
@@ -41,6 +41,7 @@ class LiveReportMainHeadStatusProviderTest {
 
         return Stream.of(
                 Arguments.of("", "", notConfigured),
+                Arguments.of(null, null, notConfigured),
 
                 // Recommended single-tag form → OK.
                 Arguments.of(CONFIG_NEW, "", ok),

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/LiveReportMainHeadStatusProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/configuration/LiveReportMainHeadStatusProviderTest.java
@@ -17,28 +17,45 @@ import static org.mockito.Mockito.mockStatic;
 
 class LiveReportMainHeadStatusProviderTest {
 
-    public static final String CONFIG = "<script src=\"/polarion/pdf-exporter/js/starter.js\"></script>";
+    // Recommended single-tag Live Reports loader.
+    public static final String CONFIG_NEW = "<script src=\"/polarion/pdf-exporter/js/live-reports.js\"></script>";
+    // Deprecated form (loads starter.js).
+    public static final String CONFIG_DEPRECATED = "<script src=\"/polarion/pdf-exporter/js/starter.js\"></script>";
 
     public static Stream<Arguments> provideConfigurationStatus() {
-        ConfigurationStatus configurationStatusNotConfigured = ConfigurationStatus.builder()
+        ConfigurationStatus notConfigured = ConfigurationStatus.builder()
                 .name(LiveReportMainHeadStatusProvider.LIVE_REPORT_BUTTON)
                 .status(Status.WARNING)
-                .details("Not configured")
+                .details(LiveReportMainHeadStatusProvider.NOT_CONFIGURED)
                 .build();
-        ConfigurationStatus configurationStatusOk = ConfigurationStatus.builder()
+        ConfigurationStatus ok = ConfigurationStatus.builder()
                 .name(LiveReportMainHeadStatusProvider.LIVE_REPORT_BUTTON)
                 .status(Status.OK)
                 .details("")
                 .build();
+        ConfigurationStatus deprecated = ConfigurationStatus.builder()
+                .name(LiveReportMainHeadStatusProvider.LIVE_REPORT_BUTTON)
+                .status(Status.WARNING)
+                .details(LiveReportMainHeadStatusProvider.DEPRECATED_DETAILS)
+                .build();
 
         return Stream.of(
-                Arguments.of("", "", configurationStatusNotConfigured),
+                Arguments.of("", "", notConfigured),
 
-                Arguments.of(CONFIG, "", configurationStatusOk),
-                Arguments.of("", CONFIG, configurationStatusOk),
-                Arguments.of(CONFIG, CONFIG, configurationStatusOk),
+                // Recommended single-tag form → OK.
+                Arguments.of(CONFIG_NEW, "", ok),
+                Arguments.of("", CONFIG_NEW, ok),
+                Arguments.of(CONFIG_NEW, CONFIG_NEW, ok),
+                Arguments.of("<script></script> <script src=\"/polarion/pdf-exporter/js/live-reports.js\"></script> <script></script>", "", ok),
 
-                Arguments.of("<script> </script> <script src=\"/polarion/pdf-exporter/js/starter.js\"></script> <script></script>", "", configurationStatusOk)
+                // Deprecated starter.js form → WARNING with deprecation hint.
+                Arguments.of(CONFIG_DEPRECATED, "", deprecated),
+                Arguments.of("", CONFIG_DEPRECATED, deprecated),
+                Arguments.of(CONFIG_DEPRECATED, CONFIG_DEPRECATED, deprecated),
+
+                // The recommended form on either source wins over a deprecated form.
+                Arguments.of(CONFIG_NEW, CONFIG_DEPRECATED, ok),
+                Arguments.of(CONFIG_DEPRECATED, CONFIG_NEW, ok)
         );
     }
 


### PR DESCRIPTION
### Proposed changes

This pull request modernizes and simplifies the configuration and code for injecting the PDF Exporter button into Polarion, introducing new recommended single-tag injectors for both the document editor toolbar and Live Reports. It deprecates the older, more complex configuration in favor of these new approaches, updates status providers and documentation accordingly, and ensures backward compatibility for existing setups.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
