### PR TITLE
fix: add wiki velocity tools to velocity evaluator context (#925)

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/velocity/VelocityEvaluator.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/velocity/VelocityEvaluator.java
@@ -22,7 +22,9 @@ import com.polarion.alm.tracker.model.IRichPage;
 import com.polarion.alm.tracker.model.ITestRun;
 import com.polarion.alm.tracker.model.IWikiPage;
 import com.polarion.alm.tracker.model.baselinecollection.IBaselineCollection;
+import com.polarion.alm.wiki.IWikiService;
 import com.polarion.core.util.StringUtils;
+import com.polarion.platform.core.PlatformContext;
 import com.polarion.portal.internal.shared.navigation.ProjectScope;
 import org.apache.velocity.VelocityContext;
 import org.jetbrains.annotations.NotNull;
@@ -36,9 +38,29 @@ public class VelocityEvaluator {
             richPageRenderingContext.setPageParameters(getPageParameters(documentData));
             RichPageScriptRenderer richPageScriptRenderer = new RichPageScriptRenderer(richPageRenderingContext, template, documentData.getId().getDocumentId());
             VelocityContext velocityContext = richPageScriptRenderer.velocityContext();
+            addWikiRenderingContext(velocityContext);
             updateVelocityContext(velocityContext, documentData);
             return richPageScriptRenderer.renderHtml();
         }));
+    }
+
+    /**
+     * Rich page velocity context, which is used here to evaluate expressions, doesn't contain wiki specific tools
+     * such as $calendarTool or $wikiService, they are contributed to the wiki rendering context only. Without them
+     * expressions which work fine in wiki content are left unevaluated in exported PDF, so we add them here.
+     * Values already present in the context take precedence and are not overwritten.
+     */
+    @VisibleForTesting
+    void addWikiRenderingContext(@NotNull VelocityContext velocityContext) {
+        IWikiService wikiService = PlatformContext.getPlatform().lookupService(IWikiService.class);
+        if (wikiService == null) {
+            return;
+        }
+        wikiService.getWikiRenderingContextMap().forEach((key, value) -> {
+            if (velocityContext.get(key) == null) {
+                velocityContext.put(key, value);
+            }
+        });
     }
 
     private void updateVelocityContext(@NotNull VelocityContext velocityContext, @NotNull DocumentData<? extends IUniqueObject> documentData) {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/velocity/VelocityEvaluatorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/velocity/VelocityEvaluatorTest.java
@@ -16,6 +16,9 @@ import com.polarion.alm.tracker.model.IRichPage;
 import com.polarion.alm.tracker.model.ITestRun;
 import com.polarion.alm.tracker.model.IWikiPage;
 import com.polarion.alm.tracker.model.baselinecollection.IBaselineCollection;
+import com.polarion.alm.wiki.IWikiService;
+import com.polarion.platform.core.IPlatform;
+import com.polarion.platform.core.PlatformContext;
 import org.apache.velocity.VelocityContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -211,6 +215,59 @@ class VelocityEvaluatorTest {
         assertNull(velocityContext.get("testrun"));
         assertNull(velocityContext.get("collection"));
         assertEquals("Test Project", velocityContext.get("projectName"));
+    }
+
+    @Test
+    void addWikiRenderingContextAddsWikiTools() {
+        IWikiService wikiService = mock(IWikiService.class);
+        Object calendarTool = new Object();
+        when(wikiService.getWikiRenderingContextMap()).thenReturn(Map.of("calendarTool", calendarTool));
+
+        VelocityContext velocityContext = new VelocityContext();
+        withWikiService(wikiService, () -> velocityEvaluator.addWikiRenderingContext(velocityContext));
+
+        assertEquals(calendarTool, velocityContext.get("calendarTool"));
+    }
+
+    @Test
+    void addWikiRenderingContextKeepsExistingValues() {
+        IWikiService wikiService = mock(IWikiService.class);
+        when(wikiService.getWikiRenderingContextMap()).thenReturn(Map.of("trackerService", new Object()));
+
+        Object richPageTrackerService = new Object();
+        VelocityContext velocityContext = new VelocityContext();
+        velocityContext.put("trackerService", richPageTrackerService);
+        withWikiService(wikiService, () -> velocityEvaluator.addWikiRenderingContext(velocityContext));
+
+        assertEquals(richPageTrackerService, velocityContext.get("trackerService"));
+    }
+
+    @Test
+    void addWikiRenderingContextSkippedWhenNoWikiService() {
+        VelocityContext velocityContext = new VelocityContext();
+        withWikiService(null, () -> velocityEvaluator.addWikiRenderingContext(velocityContext));
+
+        assertNull(velocityContext.get("calendarTool"));
+    }
+
+    @Test
+    void addWikiRenderingContextDoesNotUseContainsKey() {
+        IWikiService wikiService = mock(IWikiService.class);
+        when(wikiService.getWikiRenderingContextMap()).thenReturn(Map.of("calendarTool", new Object()));
+
+        VelocityContext velocityContext = spy(new VelocityContext());
+        withWikiService(wikiService, () -> velocityEvaluator.addWikiRenderingContext(velocityContext));
+
+        verify(velocityContext, never()).containsKey(any());
+    }
+
+    private void withWikiService(IWikiService wikiService, Runnable runnable) {
+        IPlatform platform = mock(IPlatform.class);
+        when(platform.lookupService(IWikiService.class)).thenReturn(wikiService);
+        try (MockedStatic<PlatformContext> platformContextMockedStatic = mockStatic(PlatformContext.class)) {
+            platformContextMockedStatic.when(PlatformContext::getPlatform).thenReturn(platform);
+            runnable.run();
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Proposed changes

Header/footer and cover page expressions are evaluated in the rich page velocity context, which has no wiki specific tools. Expressions like $calendarTool, working fine in wiki content, were therefore left unevaluated in exported PDF. Wiki rendering context is now merged in, without overwriting values already present.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
