### PR TITLE
fix: handle null spaceId in style package matching for Test Runs

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/settings/stylepackage/DocIdentifier.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/settings/stylepackage/DocIdentifier.java
@@ -28,7 +28,7 @@ public class DocIdentifier {
     private @Nullable String projectId;
 
     @Schema(description = "Space ID")
-    private @NotNull String spaceId;
+    private @Nullable String spaceId;
 
     @Schema(description = "Document name")
     private @NotNull String documentName;

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionService.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionService.java
@@ -135,7 +135,7 @@ public class PdfExporterPolarionService extends PolarionService {
     }
 
     @SuppressWarnings("unchecked")
-    private boolean isStylePackageSuitable(@Nullable String projectId, @NotNull String spaceId, @NotNull String documentName,
+    private boolean isStylePackageSuitable(@Nullable String projectId, @Nullable String spaceId, @NotNull String documentName,
                                            @NotNull StylePackageSettings stylePackageSettings, @NotNull String stylePackageScope, @NotNull SettingName stylePackageName) {
         StylePackageModel model = stylePackageSettings.read(stylePackageScope, SettingId.fromName(stylePackageName.getName()), null);
 
@@ -143,7 +143,7 @@ public class PdfExporterPolarionService extends PolarionService {
             return true;
         } else {
             IDataService dataService = getTrackerService().getDataService();
-            return Stream.of(IModule.PROTO, IRichPage.PROTO)
+            return Stream.of(IModule.PROTO, IRichPage.PROTO, ITestRun.PROTO)
                     .map(proto -> dataService.searchInstances(proto, model.getMatchingQuery(), "name"))
                     .flatMap(Collection::stream)
                     .filter(document -> !((IUniqueObject) document).isUnresolvable())
@@ -151,13 +151,14 @@ public class PdfExporterPolarionService extends PolarionService {
         }
     }
 
-    private boolean sameDocument(@Nullable String projectId, @NotNull String spaceId, @NotNull String documentName, @NotNull IUniqueObject document) {
+    private boolean sameDocument(@Nullable String projectId, @Nullable String spaceId, @NotNull String documentName, @NotNull IUniqueObject document) {
         if (!Objects.equals(projectId, document.getProjectId())) {
             return false;
         }
         return switch (document) {
-            case IModule module -> (spaceId + "/" + documentName).equals(module.getModuleLocation().getLocationPath());
-            case IRichPage page -> spaceId.equals(page.getSpaceId()) && documentName.equals(page.getPageName());
+            case IModule module -> spaceId != null && (spaceId + "/" + documentName).equals(module.getModuleLocation().getLocationPath());
+            case IRichPage page -> spaceId != null && spaceId.equals(page.getSpaceId()) && documentName.equals(page.getPageName());
+            case ITestRun testRun -> documentName.equals(testRun.getId());
             default -> false;
         };
     }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionService.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionService.java
@@ -144,10 +144,18 @@ public class PdfExporterPolarionService extends PolarionService {
         } else {
             IDataService dataService = getTrackerService().getDataService();
             return Stream.of(IModule.PROTO, IRichPage.PROTO, ITestRun.PROTO)
-                    .map(proto -> dataService.searchInstances(proto, model.getMatchingQuery(), "name"))
-                    .flatMap(Collection::stream)
+                    .flatMap(proto -> searchInstancesSafe(dataService, proto, model.getMatchingQuery()))
                     .filter(document -> !((IUniqueObject) document).isUnresolvable())
                     .anyMatch(suitableDocument -> sameDocument(projectId, spaceId, documentName, (IUniqueObject) suitableDocument));
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "java:S1166"})
+    private Stream<IUniqueObject> searchInstancesSafe(@NotNull IDataService dataService, @NotNull String proto, @NotNull String query) {
+        try {
+            return ((Collection<IUniqueObject>) dataService.searchInstances(proto, query, "name")).stream();
+        } catch (Exception e) {
+            return Stream.empty();
         }
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionService.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionService.java
@@ -145,8 +145,8 @@ public class PdfExporterPolarionService extends PolarionService {
             IDataService dataService = getTrackerService().getDataService();
             return Stream.of(IModule.PROTO, IRichPage.PROTO, ITestRun.PROTO)
                     .flatMap(proto -> searchInstancesSafe(dataService, proto, model.getMatchingQuery()))
-                    .filter(document -> !((IUniqueObject) document).isUnresolvable())
-                    .anyMatch(suitableDocument -> sameDocument(projectId, spaceId, documentName, (IUniqueObject) suitableDocument));
+                    .filter(document -> !document.isUnresolvable())
+                    .anyMatch(suitableDocument -> sameDocument(projectId, spaceId, documentName, suitableDocument));
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionServiceTest.java
@@ -425,6 +425,41 @@ class PdfExporterPolarionServiceTest {
     }
 
     @Test
+    @SuppressWarnings("rawtypes")
+    void testSearchInstancesSafeSwallowsExceptionForUnsupportedPrototype() {
+        IDataService dataService = mock(IDataService.class);
+        when(trackerService.getDataService()).thenReturn(dataService);
+
+        // Module search works normally
+        IModule module = mock(IModule.class);
+        when(module.isUnresolvable()).thenReturn(false);
+        when(module.getProjectId()).thenReturn("proj");
+        ILocation location = mock(ILocation.class);
+        when(module.getModuleLocation()).thenReturn(location);
+        when(location.getLocationPath()).thenReturn("space/Doc");
+        when(dataService.searchInstances(IModule.PROTO, "some_query", "name")).thenReturn(new PObjectList(dataService, List.of(module)));
+        when(dataService.searchInstances(IRichPage.PROTO, "some_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
+
+        // ITestRun search throws — query not compatible with this prototype
+        when(dataService.searchInstances(ITestRun.PROTO, "some_query", "name")).thenThrow(new RuntimeException("Unsupported field for TestRun"));
+
+        Collection<SettingName> settingNames = List.of(
+                SettingName.builder().id("id1").name("pkg").scope("project/proj/").build()
+        );
+        StylePackageModel modelWithQuery = StylePackageModel.builder().weight(10f).matchingQuery("some_query").build();
+
+        when(stylePackageSettings.readNames("")).thenReturn(List.of());
+        when(stylePackageSettings.readNames(ScopeUtils.getScopeFromProject("proj"))).thenReturn(settingNames);
+        when(stylePackageSettings.read(eq("project/proj/"), eq(SettingId.fromName("pkg")), isNull())).thenReturn(modelWithQuery);
+
+        // Should still find the package via Module match, despite TestRun search failing
+        DocIdentifier doc = new DocIdentifier("proj", "space", "Doc");
+        Collection<SettingName> result = service.getSuitableStylePackages(List.of(doc));
+        assertEquals(1, result.size());
+        assertEquals("pkg", result.iterator().next().getName());
+    }
+
+    @Test
     void testGetTestRun() {
         when(testManagementService.getTestRun("testProjectId", "testTestRunId", null)).thenReturn(mock(ITestRun.class));
         when(testManagementService.getTestRun("testProjectId", "testTestRunId", "1234")).thenReturn(mock(ITestRun.class));

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionServiceTest.java
@@ -335,10 +335,25 @@ class PdfExporterPolarionServiceTest {
         when(testRun.isUnresolvable()).thenReturn(false);
         when(testRun.getProjectId()).thenReturn("someProjectId");
         when(testRun.getId()).thenReturn("TestRun-123");
-        IPObjectList matchingTestRuns = new PObjectList(dataService, List.of(testRun));
-        when(dataService.searchInstances(ITestRun.PROTO, "testrun_query", "name")).thenReturn(matchingTestRuns);
-        when(dataService.searchInstances(IModule.PROTO, "testrun_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
-        when(dataService.searchInstances(IRichPage.PROTO, "testrun_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
+
+        // Also return a module and rich page from the same query — these should NOT match
+        // when spaceId is null (covers null-safe branches in sameDocument)
+        IModule module = mock(IModule.class);
+        when(module.isUnresolvable()).thenReturn(false);
+        when(module.getProjectId()).thenReturn("someProjectId");
+        ILocation location = mock(ILocation.class);
+        when(module.getModuleLocation()).thenReturn(location);
+        when(location.getLocationPath()).thenReturn("space/SomeDoc");
+
+        IRichPage page = mock(IRichPage.class);
+        when(page.isUnresolvable()).thenReturn(false);
+        when(page.getProjectId()).thenReturn("someProjectId");
+        when(page.getSpaceId()).thenReturn("space");
+        when(page.getPageName()).thenReturn("SomePage");
+
+        when(dataService.searchInstances(ITestRun.PROTO, "testrun_query", "name")).thenReturn(new PObjectList(dataService, List.of(testRun)));
+        when(dataService.searchInstances(IModule.PROTO, "testrun_query", "name")).thenReturn(new PObjectList(dataService, List.of(module)));
+        when(dataService.searchInstances(IRichPage.PROTO, "testrun_query", "name")).thenReturn(new PObjectList(dataService, List.of(page)));
 
         String projectId = "someProjectId";
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionServiceTest.java
@@ -12,6 +12,7 @@ import ch.sbb.polarion.extension.pdf_exporter.settings.StylePackageSettings;
 import com.polarion.alm.projects.IProjectService;
 import com.polarion.alm.tracker.ITestManagementService;
 import com.polarion.alm.tracker.ITrackerService;
+import com.polarion.alm.projects.model.IUniqueObject;
 import com.polarion.alm.tracker.model.IModule;
 import com.polarion.alm.tracker.model.IRichPage;
 import com.polarion.alm.tracker.model.ITestRecord;
@@ -430,30 +431,63 @@ class PdfExporterPolarionServiceTest {
         IDataService dataService = mock(IDataService.class);
         when(trackerService.getDataService()).thenReturn(dataService);
 
-        // Module search works normally
-        IModule module = mock(IModule.class);
-        when(module.isUnresolvable()).thenReturn(false);
-        when(module.getProjectId()).thenReturn("proj");
-        ILocation location = mock(ILocation.class);
-        when(module.getModuleLocation()).thenReturn(location);
-        when(location.getLocationPath()).thenReturn("space/Doc");
-        when(dataService.searchInstances(IModule.PROTO, "some_query", "name")).thenReturn(new PObjectList(dataService, List.of(module)));
-        when(dataService.searchInstances(IRichPage.PROTO, "some_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
+        // An unknown document type — covers the default branch in sameDocument
+        IUniqueObject unknownDoc = mock(IUniqueObject.class);
+        when(unknownDoc.isUnresolvable()).thenReturn(false);
+        when(unknownDoc.getProjectId()).thenReturn("proj");
+
+        // Module and RichPage return non-matching results, so stream must reach ITestRun
+        when(dataService.searchInstances(IModule.PROTO, "failing_query", "name")).thenReturn(new PObjectList(dataService, List.of(unknownDoc)));
+        when(dataService.searchInstances(IRichPage.PROTO, "failing_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
 
         // ITestRun search throws — query not compatible with this prototype
-        when(dataService.searchInstances(ITestRun.PROTO, "some_query", "name")).thenThrow(new RuntimeException("Unsupported field for TestRun"));
+        when(dataService.searchInstances(ITestRun.PROTO, "failing_query", "name")).thenThrow(new RuntimeException("Unsupported field for TestRun"));
 
         Collection<SettingName> settingNames = List.of(
                 SettingName.builder().id("id1").name("pkg").scope("project/proj/").build()
         );
-        StylePackageModel modelWithQuery = StylePackageModel.builder().weight(10f).matchingQuery("some_query").build();
+        StylePackageModel modelWithQuery = StylePackageModel.builder().weight(10f).matchingQuery("failing_query").build();
+
+        when(stylePackageSettings.readNames("")).thenReturn(List.of());
+        when(stylePackageSettings.readNames(ScopeUtils.getScopeFromProject("proj"))).thenReturn(settingNames);
+        when(stylePackageSettings.read(eq("project/proj/"), eq(SettingId.fromName("pkg")), isNull())).thenReturn(modelWithQuery);
+        when(stylePackageSettings.defaultValues()).thenReturn(StylePackageModel.builder().weight(0f).build());
+
+        // No documents match (unknownDoc hits default->false, RichPage empty, TestRun throws)
+        // but the exception should not propagate — package simply doesn't match
+        DocIdentifier doc = new DocIdentifier("proj", "space", "Doc");
+        Collection<SettingName> result = service.getSuitableStylePackages(List.of(doc));
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void testSearchInstancesSafeRecoversAndFindsMatch() {
+        IDataService dataService = mock(IDataService.class);
+        when(trackerService.getDataService()).thenReturn(dataService);
+
+        // IModule throws
+        when(dataService.searchInstances(IModule.PROTO, "mixed_fail_query", "name")).thenThrow(new RuntimeException("Bad query for Module"));
+        // IRichPage returns empty
+        when(dataService.searchInstances(IRichPage.PROTO, "mixed_fail_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
+        // ITestRun returns a match
+        ITestRun testRun = mock(ITestRun.class);
+        when(testRun.isUnresolvable()).thenReturn(false);
+        when(testRun.getProjectId()).thenReturn("proj");
+        when(testRun.getId()).thenReturn("TR-1");
+        when(dataService.searchInstances(ITestRun.PROTO, "mixed_fail_query", "name")).thenReturn(new PObjectList(dataService, List.of(testRun)));
+
+        Collection<SettingName> settingNames = List.of(
+                SettingName.builder().id("id1").name("pkg").scope("project/proj/").build()
+        );
+        StylePackageModel modelWithQuery = StylePackageModel.builder().weight(10f).matchingQuery("mixed_fail_query").build();
 
         when(stylePackageSettings.readNames("")).thenReturn(List.of());
         when(stylePackageSettings.readNames(ScopeUtils.getScopeFromProject("proj"))).thenReturn(settingNames);
         when(stylePackageSettings.read(eq("project/proj/"), eq(SettingId.fromName("pkg")), isNull())).thenReturn(modelWithQuery);
 
-        // Should still find the package via Module match, despite TestRun search failing
-        DocIdentifier doc = new DocIdentifier("proj", "space", "Doc");
+        // Module search fails, but TestRun match should still be found
+        DocIdentifier doc = new DocIdentifier("proj", null, "TR-1");
         Collection<SettingName> result = service.getSuitableStylePackages(List.of(doc));
         assertEquals(1, result.size());
         assertEquals("pkg", result.iterator().next().getName());

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/service/PdfExporterPolarionServiceTest.java
@@ -214,6 +214,10 @@ class PdfExporterPolarionServiceTest {
         IPObjectList notMatchingPages = new PObjectList(dataService, List.of());
         when(dataService.searchInstances(IRichPage.PROTO, "not_matching", "name")).thenReturn(notMatchingPages);
 
+        IPObjectList emptyTestRuns = new PObjectList(dataService, List.of());
+        when(dataService.searchInstances(ITestRun.PROTO, "matching", "name")).thenReturn(emptyTestRuns);
+        when(dataService.searchInstances(ITestRun.PROTO, "not_matching", "name")).thenReturn(emptyTestRuns);
+
         String projectId = "someProjectId";
         String spaceId = "someSpaceId";
         String documentName = "documentName";
@@ -282,11 +286,13 @@ class PdfExporterPolarionServiceTest {
         IPObjectList mixedDocuments = new PObjectList(dataService, List.of(unresolvableModule, resolvableModule));
         when(dataService.searchInstances(IModule.PROTO, "mixed_query", "name")).thenReturn(mixedDocuments);
         when(dataService.searchInstances(IRichPage.PROTO, "mixed_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
+        when(dataService.searchInstances(ITestRun.PROTO, "mixed_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
 
         // Search returns only unresolvable documents
         IPObjectList unresolvableOnly = new PObjectList(dataService, List.of(unresolvableModule));
         when(dataService.searchInstances(IModule.PROTO, "unresolvable_only", "name")).thenReturn(unresolvableOnly);
         when(dataService.searchInstances(IRichPage.PROTO, "unresolvable_only", "name")).thenReturn(new PObjectList(dataService, List.of()));
+        when(dataService.searchInstances(ITestRun.PROTO, "unresolvable_only", "name")).thenReturn(new PObjectList(dataService, List.of()));
 
         String projectId = "someProjectId";
         String spaceId = "someSpaceId";
@@ -316,6 +322,91 @@ class PdfExporterPolarionServiceTest {
         // has no resolvable matching documents
         assertEquals(10f, result.getWeight());
         assertEquals("mixed_query", result.getMatchingQuery());
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void testStylePackageSuitabilityForTestRunWithNullSpaceId() {
+        IDataService dataService = mock(IDataService.class);
+        when(trackerService.getDataService()).thenReturn(dataService);
+
+        // A matching test run
+        ITestRun testRun = mock(ITestRun.class);
+        when(testRun.isUnresolvable()).thenReturn(false);
+        when(testRun.getProjectId()).thenReturn("someProjectId");
+        when(testRun.getId()).thenReturn("TestRun-123");
+        IPObjectList matchingTestRuns = new PObjectList(dataService, List.of(testRun));
+        when(dataService.searchInstances(ITestRun.PROTO, "testrun_query", "name")).thenReturn(matchingTestRuns);
+        when(dataService.searchInstances(IModule.PROTO, "testrun_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
+        when(dataService.searchInstances(IRichPage.PROTO, "testrun_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
+
+        String projectId = "someProjectId";
+
+        Collection<SettingName> settingNames = List.of(
+                SettingName.builder().id("id1").name("withQuery").scope("project/someProjectId/").build(),
+                SettingName.builder().id("id2").name("noQuery").scope("project/someProjectId/").build()
+        );
+
+        StylePackageModel modelWithQuery = StylePackageModel.builder().weight(10f).matchingQuery("testrun_query").build();
+        StylePackageModel modelNoQuery = StylePackageModel.builder().weight(5f).build();
+
+        when(stylePackageSettings.readNames("")).thenReturn(List.of());
+        when(stylePackageSettings.readNames(ScopeUtils.getScopeFromProject(projectId))).thenReturn(settingNames);
+        when(stylePackageSettings.read(eq("project/someProjectId/"), eq(SettingId.fromName("withQuery")), isNull())).thenReturn(modelWithQuery);
+        when(stylePackageSettings.read(eq("project/someProjectId/"), eq(SettingId.fromName("noQuery")), isNull())).thenReturn(modelNoQuery);
+
+        // Test Run with null spaceId matching by ID — should find style package with matchingQuery
+        DocIdentifier testRunDoc = new DocIdentifier(projectId, null, "TestRun-123");
+        Collection<SettingName> result = service.getSuitableStylePackages(List.of(testRunDoc));
+        assertEquals(2, result.size());
+        assertEquals(List.of("withQuery", "noQuery"), result.stream().map(SettingName::getName).toList());
+
+        // Test Run with non-matching ID — style package with matchingQuery should be excluded
+        DocIdentifier nonMatchingTestRun = new DocIdentifier(projectId, null, "TestRun-999");
+        result = service.getSuitableStylePackages(List.of(nonMatchingTestRun));
+        assertEquals(1, result.size());
+        assertEquals("noQuery", result.iterator().next().getName());
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void testStylePackageSuitabilityMixedDocumentAndTestRun() {
+        IDataService dataService = mock(IDataService.class);
+        when(trackerService.getDataService()).thenReturn(dataService);
+
+        // Module matching query
+        IModule module = mock(IModule.class);
+        when(module.isUnresolvable()).thenReturn(false);
+        when(module.getProjectId()).thenReturn("someProjectId");
+        ILocation location = mock(ILocation.class);
+        when(module.getModuleLocation()).thenReturn(location);
+        when(location.getLocationPath()).thenReturn("space/Doc1");
+        when(dataService.searchInstances(IModule.PROTO, "doc_query", "name")).thenReturn(new PObjectList(dataService, List.of(module)));
+        when(dataService.searchInstances(IRichPage.PROTO, "doc_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
+        when(dataService.searchInstances(ITestRun.PROTO, "doc_query", "name")).thenReturn(new PObjectList(dataService, List.of()));
+
+        String projectId = "someProjectId";
+        Collection<SettingName> settingNames = List.of(
+                SettingName.builder().id("id1").name("docOnly").scope("project/someProjectId/").build(),
+                SettingName.builder().id("id2").name("generic").scope("project/someProjectId/").build()
+        );
+
+        StylePackageModel docOnlyModel = StylePackageModel.builder().weight(10f).matchingQuery("doc_query").build();
+        StylePackageModel genericModel = StylePackageModel.builder().weight(5f).build();
+
+        when(stylePackageSettings.readNames("")).thenReturn(List.of());
+        when(stylePackageSettings.readNames(ScopeUtils.getScopeFromProject(projectId))).thenReturn(settingNames);
+        when(stylePackageSettings.read(eq("project/someProjectId/"), eq(SettingId.fromName("docOnly")), isNull())).thenReturn(docOnlyModel);
+        when(stylePackageSettings.read(eq("project/someProjectId/"), eq(SettingId.fromName("generic")), isNull())).thenReturn(genericModel);
+
+        // Mix: Module (matches query) + TestRun (does NOT match query, spaceId=null)
+        // allMatch requires all docs to match → "docOnly" should be excluded
+        DocIdentifier moduleDoc = new DocIdentifier(projectId, "space", "Doc1");
+        DocIdentifier testRunDoc = new DocIdentifier(projectId, null, "TestRun-456");
+        Collection<SettingName> result = service.getSuitableStylePackages(List.of(moduleDoc, testRunDoc));
+
+        assertEquals(1, result.size());
+        assertEquals("generic", result.iterator().next().getName());
     }
 
     @Test


### PR DESCRIPTION
Refs: #935

### Proposed changes

Fix NullPointerException in style package matching when bulk export includes Test Runs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
