### PR TITLE
fix: remove @import rules from inline CSS in PDF export widget

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRenderer.java
@@ -31,8 +31,12 @@ import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.Iterator;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
+
+    private static final String CSS_IMPORT_RULE = "@import";
+
     private final @NotNull DataSet dataSet;
 
     private final @NotNull IterableWithSize<ModelObject> items;
@@ -127,14 +131,14 @@ public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
                         .then(module => new module.default('#%s', '%s' === 'true'))
                         .catch(console.error);""".formatted(panelId, exportPages.value()));
 
-            wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/css/micromodal.css"));
+            wrap.append().tag().style().append().html(inlineCss("/css/micromodal.css"));
             // The widget assembles its CSS inline and does not pull generic's common.css, so the shared
             // alert styling would be missing: control-tokens.css provides the --sbb-*-icon tokens and
             // alerts.css the notification boxes + warning/error triangle icons. Without these the export
             // dialog's warnings (e.g. the PDF/A sticky-notes notice) render as unstyled plain text.
-            wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/css/control-tokens.css"));
-            wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/css/alerts.css"));
-            wrap.append().tag().style().append().html(ScopeUtils.getFileContent("/webapp/pdf-exporter/css/pdf-exporter.css"));
+            wrap.append().tag().style().append().html(inlineCss("/css/control-tokens.css"));
+            wrap.append().tag().style().append().html(inlineCss("/css/alerts.css"));
+            wrap.append().tag().style().append().html(inlineCss("/webapp/pdf-exporter/css/pdf-exporter.css"));
 
             HtmlContentBuilder contentBuilder = mainTable.append();
             this.renderContentTable(contentBuilder.tag().tr().append().tag().td().append());
@@ -260,6 +264,36 @@ public class BulkPdfExportWidgetRenderer extends AbstractWidgetRenderer {
 
     private void renderFooter(@NotNull HtmlTagBuilder tagBuilder) {
         (new BottomQueryLinksBuilder(this.context, this.dataSet, this.topItems)).render(tagBuilder);
+    }
+
+    /**
+     * Reads a stylesheet to be embedded into an inline style tag, dropping its @import rules.
+     * <p>
+     * An inline style tag has no URL of its own, so a relative @import is resolved against the page URL instead of
+     * against the stylesheet. The result never exists (Polarion answers with an HTML error page, which the browser
+     * then refuses as a stylesheet because of its MIME type), while the very same @import works when the stylesheet
+     * is linked by href. Nothing is lost by dropping it here: every stylesheet the imports refer to is embedded
+     * explicitly by the caller anyway.
+     */
+    @NotNull
+    private String inlineCss(@NotNull String path) {
+        return stripCssImports(ScopeUtils.getFileContent(path));
+    }
+
+    @VisibleForTesting
+    @NotNull
+    static String stripCssImports(@NotNull String css) {
+        return css.lines()
+                .filter(line -> !startsWithImportRule(line.stripLeading()))
+                .collect(Collectors.joining("\n"));
+    }
+
+    /**
+     * Only rules starting a line are recognized: comments mention "@import" mid-sentence and must stay untouched.
+     * The comparison ignores case, as at-rule keywords are case-insensitive in CSS.
+     */
+    private static boolean startsWithImportRule(@NotNull String line) {
+        return line.regionMatches(true, 0, CSS_IMPORT_RULE, 0, CSS_IMPORT_RULE.length());
     }
 
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRendererTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/widgets/BulkPdfExportWidgetRendererTest.java
@@ -32,9 +32,12 @@ import com.polarion.alm.shared.api.utils.html.impl.HtmlFragmentBuilderImpl;
 import com.polarion.alm.tracker.model.IWorkItem;
 import com.polarion.platform.persistence.model.IPrototype;
 import com.polarion.subterra.base.data.identification.ILocalId;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -216,6 +219,55 @@ class BulkPdfExportWidgetRendererTest {
         try (MockedConstruction<BottomQueryLinksBuilder> ignored = mockConstruction(BottomQueryLinksBuilder.class)) {
             assertDoesNotThrow(() -> renderer.render(builder));
         }
+    }
+
+    @Test
+    @SneakyThrows
+    void stripCssImportsRemovesImportsFromBundledStylesheet() {
+        // The bundled file is used on purpose: should the import move to another stylesheet of the bundle,
+        // this test keeps guarding the widget instead of a hand-written sample.
+        String original;
+        try (InputStream is = getClass().getResourceAsStream("/css/micromodal.css")) {
+            assertNotNull(is, "bundled micromodal.css is expected on the classpath");
+            original = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        assertTrue(original.contains("@import url(\"control-tokens.css\");"), "bundled micromodal.css is expected to import control-tokens.css");
+
+        String stripped = BulkPdfExportWidgetRenderer.stripCssImports(original);
+
+        // A relative @import inside an inline style tag is resolved against the page URL and always 404s
+        assertFalse(stripped.contains("@import url("), "inlined stylesheet must not keep @import rules");
+        // ... while everything else must survive: exactly one line is expected to disappear
+        assertTrue(stripped.contains(".modal__container"), "inlined stylesheet must keep its own rules");
+        assertEquals(original.lines().count() - 1, stripped.lines().count());
+        assertEquals(original.lines().filter(line -> !line.contains("@import url(")).toList(), stripped.lines().toList());
+    }
+
+    @Test
+    void stripCssImportsHandlesIndentedAndUpperCaseRules() {
+        // Leading whitespace is allowed before an at-rule, and at-rule keywords are case-insensitive in CSS
+        String css = "    @import url(\"a.css\");\n\t@import url(\"b.css\");\n@IMPORT url(\"c.css\");\n@Import url(\"d.css\");\n.modal { color: red; }";
+
+        String stripped = BulkPdfExportWidgetRenderer.stripCssImports(css);
+
+        assertEquals(".modal { color: red; }", stripped);
+    }
+
+    @Test
+    void stripCssImportsKeepsImportsMentionedInComments() {
+        String css = """
+                /* common.css @imports this one; see the note about @import URLs
+                   being de-duped by the browser. */
+                @import url("control-tokens.css");
+                .modal { color: red; }""";
+
+        String stripped = BulkPdfExportWidgetRenderer.stripCssImports(css);
+
+        assertFalse(stripped.contains("@import url("), "the rule itself must be dropped");
+        // Matching the word inside the comment would swallow everything up to the next semicolon,
+        // including the comment terminator, turning the rest of the file into a comment
+        assertTrue(stripped.contains("*/"), "the comment must stay intact");
+        assertTrue(stripped.contains(".modal { color: red; }"), "rules must stay intact");
     }
 
     @Test


### PR DESCRIPTION
### Proposed changes

This change ensures that stylesheets embedded in the PDF export widget do not include @import rules, which can lead to 404 errors when resolved against the page URL. The following updates were made:

- Introduced inlineCss method to strip @import rules from stylesheets
- Updated CSS loading to use inlineCss for control-tokens.css, alerts.css, and pdf-exporter.css
- Added tests to verify that @import rules are removed correctly

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
