### PR TITLE
fix: update fullFonts option description for clarity

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -145,6 +145,14 @@ This configuration property allows selecting the density (DPI) for PNG images co
 
 The default value is 96.
 
+### Embed full fonts (no subsetting)
+
+By default the fonts used in a document are subsetted: only the glyphs the document actually needs are embedded into the PDF, which keeps the file small. With this option enabled the fonts are embedded in their entirety instead.
+
+Turn it on when the exported PDF is processed further and its complete character set matters - for example when the file is edited in a layout tool afterwards, or handed over to a print shop. The price is the file size: the whole font is embedded even if the document uses a handful of its characters.
+
+This is not a robustness switch. Subsetting keeps a font whole whenever it cannot be applied, so a font that resists subsetting is exported correctly either way; skipping subsetting, on the contrary, can itself fail on a damaged font. The option is off by default.
+
 ### Fit images and tables to page width
 This option which is on by default tells PDF Exporter to fit images and tables into resulted page width even if their width in the Polarion document exceeds it. Elements exceeding Polarion document width:
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1764,7 +1764,7 @@
           },
           "fullFonts": {
             "default": false,
-            "description": "Embed full fonts instead of subsetting. When true, fonts are embedded completely without optimization. This can help avoid font subsetting errors but results in larger PDF files.",
+            "description": "Embed full fonts instead of subsetting. When true, fonts are embedded completely without optimization, which gives full glyph coverage and keeps the resulting PDF easier to edit downstream, at the cost of a larger file. This is not a robustness switch: subsetting already keeps a font whole when it cannot be applied, while skipping it can itself fail on a damaged font.",
             "type": "boolean"
           },
           "headerFooter": {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/conversion/ConversionParams.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/rest/model/conversion/ConversionParams.java
@@ -41,7 +41,10 @@ public class ConversionParams {
     protected ImageDensity imageDensity = ImageDensity.DPI_96;
 
     @Schema(description = "Embed full fonts instead of subsetting. When true, fonts are embedded completely " +
-            "without optimization. This can help avoid font subsetting errors but results in larger PDF files.", defaultValue = "false")
+            "without optimization, which gives full glyph coverage and keeps the resulting PDF easier to edit " +
+            "downstream, at the cost of a larger file. This is not a robustness switch: subsetting already keeps " +
+            "a font whole when it cannot be applied, while skipping it can itself fail on a damaged font.",
+            defaultValue = "false")
     @Builder.Default
     protected boolean fullFonts = false;
 }

--- a/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
+++ b/src/main/resources/webapp/pdf-exporter-admin/pages/style-packages.jsp
@@ -188,7 +188,7 @@
                         <input id='full-fonts' type='checkbox'/>
                         Embed full fonts (no subsetting)
                     </label>
-                    <div class='more-info' title="When enabled, fonts are embedded in their entirety without subsetting. This helps avoid font-related errors but increases PDF file size."></div>
+                    <div class='more-info' title="When enabled, fonts are embedded in their entirety without subsetting: full glyph coverage and better editability of the resulting PDF, at the cost of a larger file. This is not a robustness switch: subsetting already keeps a font whole when it cannot be applied, while skipping it can itself fail on a damaged font."></div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/webapp/pdf-exporter/html/popupForm.html
+++ b/src/main/resources/webapp/pdf-exporter/html/popupForm.html
@@ -126,7 +126,7 @@
                         <input id='popup-full-fonts' type='checkbox'/>
                         Embed full fonts (no subsetting)
                     </label>
-                    <div class='more-info' title="When enabled, fonts are embedded in their entirety without subsetting. This helps avoid font-related errors but increases PDF file size."></div>
+                    <div class='more-info' title="When enabled, fonts are embedded in their entirety without subsetting: full glyph coverage and better editability of the resulting PDF, at the cost of a larger file. This is not a robustness switch: subsetting already keeps a font whole when it cannot be applied, while skipping it can itself fail on a damaged font."></div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
+++ b/src/main/resources/webapp/pdf-exporter/html/sidePanelContent.html
@@ -116,7 +116,7 @@
                 <input id='full-fonts' type='checkbox'/>
                 Embed full fonts (no subsetting)
             </label>
-            <div class='more-info' title="When enabled, fonts are embedded in their entirety without subsetting. This helps avoid font-related errors but increases PDF file size."></div>
+            <div class='more-info' title="When enabled, fonts are embedded in their entirety without subsetting: full glyph coverage and better editability of the resulting PDF, at the cost of a larger file. This is not a robustness switch: subsetting already keeps a font whole when it cannot be applied, while skipping it can itself fail on a damaged font."></div>
         </div>
         <div class='property-wrapper'>
             <label for='fit-to-page'>

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/FullFontsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/weasyprint/FullFontsTest.java
@@ -9,13 +9,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Integration tests for the fullFonts parameter.
  * <p>
- * When fullFonts=true, fonts are embedded in their entirety without subsetting.
- * This helps avoid font subsetting errors (e.g., invalid OS/2 Unicode range bits)
- * but results in larger PDF files.
+ * When fullFonts=true, fonts are embedded in their entirety without subsetting: full glyph coverage and a PDF that
+ * is easier to edit downstream, at the cost of a larger file.
+ * <p>
+ * The option used to be a workaround for fonts that broke subsetting (e.g. invalid OS/2 Unicode range bits). That
+ * justification is gone: since WeasyPrint 69 subsetting no longer fails hard but logs and keeps the full font, so
+ * such a font converts fine with fullFonts=false as well. The risk has in fact inverted - skipping subsetting is
+ * what can fail on a damaged font - which is why the "bad font" case below is asserted for both values.
  * <p>
  * Tests cover the following scenarios:
  * <ul>
  *     <li>Bad font + fullFonts=true → should succeed</li>
+ *     <li>Bad font + fullFonts=false → should succeed as well (guards the claim above against engine bumps)</li>
  *     <li>Good font + fullFonts=false → should succeed</li>
  *     <li>Good font + fullFonts=true → should succeed</li>
  *     <li>fullFonts=true produces a larger PDF than fullFonts=false</li>
@@ -30,9 +35,8 @@ class FullFontsTest extends BaseWeasyPrintTest {
      * Tests that HTML with a font containing invalid OS/2 Unicode range bits succeeds
      * with fullFonts=true.
      * <p>
-     * This test verifies that disabling font subsetting (fullFonts=true) allows
-     * conversion of fonts with invalid Unicode range bits that would otherwise fail
-     * during subsetting.
+     * Such a font used to fail during subsetting, which is no longer the case (see the test below), so this only
+     * asserts that skipping subsetting still copes with it.
      */
     @Test
     @SneakyThrows
@@ -49,6 +53,36 @@ class FullFontsTest extends BaseWeasyPrintTest {
 
         assertThat(pdfBytes)
                 .as("PDF should be generated with fullFonts=true for bad font")
+                .isNotNull()
+                .isNotEmpty();
+
+        assertThat(new String(pdfBytes, 0, 4))
+                .as("Generated file should be a valid PDF")
+                .isEqualTo("%PDF");
+    }
+
+    /**
+     * Tests that a font which used to break subsetting converts fine with subsetting enabled as well.
+     * <p>
+     * This is what made the original justification of fullFonts obsolete: since WeasyPrint 69 a font that cannot be
+     * subset no longer fails the conversion, it is kept whole instead. Should a future engine bring the hard failure
+     * back, this test turns red and the option's description has to be revisited.
+     */
+    @Test
+    @SneakyThrows
+    void testBadFontSucceedsWithSubsetting() {
+        String html = readHtmlResource(BAD_FONT_HTML);
+
+        WeasyPrintOptions options = WeasyPrintOptions.builder()
+                .fullFonts(false)
+                .build();
+
+        byte[] pdfBytes = exportToPdf(html, options);
+
+        writeReportPdf(getCurrentMethodName(), "bad_font_subsetting", pdfBytes);
+
+        assertThat(pdfBytes)
+                .as("PDF should be generated with fullFonts=false for bad font, the engine keeps the font whole")
                 .isNotNull()
                 .isNotEmpty();
 


### PR DESCRIPTION
### Proposed changes

Clarify the purpose and implications of the fullFonts option in PDF export settings. The updated description emphasizes that while full glyph coverage is achieved, it may lead to larger PDF files. This change reflects the improved handling of font subsetting since WeasyPrint 69, ensuring users understand the trade-offs involved.

- Revise descriptions in ConversionParams, openapi.json, and HTML files
- Update integration tests to reflect new understanding of fullFonts

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
