### PR TITLE
chore: remove stale renovate custom manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,18 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SchweizerischeBundesbahnen/casc-renovate-preset-polarion-java"
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/versions.properties$/"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "SchweizerischeBundesbahnen/weasyprint-service",
-      "matchStrings": [
-        "weasyprint-service.version=(?<currentValue>.*)"
-      ]
-    }
   ]
 }


### PR DESCRIPTION
Closes #951

The regex custom manager tracked `weasyprint-service.version=` in `versions.properties`, but that key was replaced by `weasyprint-service.api-version=1` when the compatibility check switched to API versions — the manager matches nothing and is dead config. It is also misleading: the API version is a manually maintained contract version and must not be bumped by renovate.

`renovate.json` is back to template form (`extends` only); the CI service-container image pin keeps being updated by the regular docker manager from the shared preset.

Same cleanup is part of docx-exporter's switch to `pandoc-service.api-version` (SchweizerischeBundesbahnen/ch.sbb.polarion.extension.docx-exporter#316).