### PR TITLE
chore: stop shadowing the parent's plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,6 @@
         <markdown2html-maven-plugin.disclaimer.inputFile>${project.basedir}/DISCLAIMER.md</markdown2html-maven-plugin.disclaimer.inputFile>
         <markdown2html-maven-plugin.disclaimer.outputFileName>disclaimer.html</markdown2html-maven-plugin.disclaimer.outputFileName>
         <markdown2html-maven-plugin.disclaimer.outputFile>${markdown2html-maven-plugin.extensionContextAdminHtml}/${markdown2html-maven-plugin.disclaimer.outputFileName}</markdown2html-maven-plugin.disclaimer.outputFile>
-        <swagger-maven-plugin.version>2.2.22</swagger-maven-plugin.version>
 
         <frontend-maven-plugin.version>2.0.1</frontend-maven-plugin.version>
         <!-- When bumping nodeVersion/npmVersion, keep package.json ("engines" and "packageManager") in sync. -->

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
         <verapdf.version>1.30.2</verapdf.version>
         <rhino.version>1.9.1</rhino.version>
 
-        <exec-maven-plugin.version>3.3.0</exec-maven-plugin.version>
 
         <maven-jar-plugin.Extension-Context>pdf-exporter</maven-jar-plugin.Extension-Context>
         <maven-jar-plugin.Automatic-Module-Name>ch.sbb.polarion.extension.pdf_exporter</maven-jar-plugin.Automatic-Module-Name>

--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,6 @@
         <markdown2html-maven-plugin.disclaimer.outputFile>${markdown2html-maven-plugin.extensionContextAdminHtml}/${markdown2html-maven-plugin.disclaimer.outputFileName}</markdown2html-maven-plugin.disclaimer.outputFile>
 
         <frontend-maven-plugin.version>2.0.1</frontend-maven-plugin.version>
-        <!-- When bumping nodeVersion/npmVersion, keep package.json ("engines" and "packageManager") in sync. -->
-        <frontend-maven-plugin.nodeVersion>v24.11.0</frontend-maven-plugin.nodeVersion>
-        <frontend-maven-plugin.npmVersion>11.6.1</frontend-maven-plugin.npmVersion>
 
         <!--suppress UnresolvedMavenProperty -->
         <skipJavaScriptTests>${skipTests}</skipJavaScriptTests>


### PR DESCRIPTION
### Proposed changes

Three properties that only shadowed the generic parent's, none of them visible to renovate - a property with no version declaration of its own has nothing for the maven manager to attach an update to, so all three were frozen where someone last typed them.

1. **`swagger-maven-plugin.version`** - `swagger-maven-plugin-jakarta` is declared here without a `<version>`, so it takes the parent's `pluginManagement` value; the local property overrode that and pinned the build to **2.2.22** while the parent was on **2.2.52**. The generated `docs/openapi.json` comes out **unchanged** under the newer plugin.
2. **`exec-maven-plugin.version`** - `exec-maven-plugin` is declared in no pom at all, here or in the parent. The property never resolved anywhere.
3. **`frontend-maven-plugin.nodeVersion` / `.npmVersion`** - pinned node **v24.11.0** / npm **11.6.1** against the parent's **v24.18.0** / **12.0.1**, and contradicted this repo's own `package.json`, which declares `"packageManager": "npm@12.0.1"`. The comment asking to keep them in sync goes with them. It also matters the day this extension grows a React `ui/`: the parent's `vite-ui` profile would have built it with the pinned npm 11, below the `npm >=12` the shared UI library requires.

`frontend-maven-plugin.version` stays - this pom declares the plugin itself and uses the property in that declaration, which is exactly why renovate does see that one.

Verified: full `mvn install` on the inherited node/npm, 825 tests green.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
