### PR TITLE
test: pin where the generated help articles land

### DIFF
--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/GeneratedHelpArticlesTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/GeneratedHelpArticlesTest.java
@@ -1,0 +1,50 @@
+package ch.sbb.polarion.extension.pdf_exporter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Pins where the build-generated help articles land.
+ * <p>
+ * The three of them are written by markdown2html into the directory
+ * {@code markdown2html-maven-plugin.extensionContextAdminHtml} points at - a property whose name
+ * predates the React apps: as soon as {@code ui/} exists, the generic parent's {@code vite-ui} profile
+ * redefines it to the <em>app</em> webapp. Two things then depend on that, silently:
+ * <ul>
+ *   <li>generic's {@code /readme} and {@code /user-guide} endpoints read their article from the
+ *       classpath, searching {@code -app} before {@code -admin};</li>
+ *   <li>the Usage Disclaimer page has no endpoint to read from and fetches
+ *       {@code /polarion/pdf-exporter-app/ui/html/disclaimer.html} over HTTP, which only
+ *       {@code PdfExporterAppServlet} can serve - from the app webapp and nowhere else.</li>
+ * </ul>
+ * Should the destination ever move back under {@code -admin}, the REST endpoints keep working through
+ * their fallback and only the Disclaimer page breaks, showing its "not generated" message. This test
+ * is what turns that into a red build instead. It is deterministic: since markdown2html 1.7.x the
+ * markdown is rendered locally, with no GitHub API call and no token.
+ */
+class GeneratedHelpArticlesTest {
+
+    private void assertArticleGenerated(String fileName) {
+        String resource = "/webapp/pdf-exporter-app/html/" + fileName;
+        assertNotNull(getClass().getResource(resource),
+                resource + " is missing: markdown2html no longer writes the generated articles into the app webapp, "
+                        + "which breaks the Usage Disclaimer page (it fetches disclaimer.html from there over HTTP)");
+    }
+
+    @Test
+    void aboutArticleIsGeneratedIntoTheAppWebapp() {
+        assertArticleGenerated("about.html");
+    }
+
+    @Test
+    void userGuideArticleIsGeneratedIntoTheAppWebapp() {
+        assertArticleGenerated("user-guide.html");
+    }
+
+    @Test
+    void disclaimerArticleIsGeneratedIntoTheAppWebapp() {
+        assertArticleGenerated("disclaimer.html");
+    }
+
+}


### PR DESCRIPTION
### Proposed changes

The Usage Disclaimer page added by #973 fetches `/polarion/pdf-exporter-app/ui/html/disclaimer.html`, while the pom writes that article through a property called `markdown2html-maven-plugin.extensionContextAdminHtml` — a name that reads like the *admin* webapp and predates the React apps. It does resolve to the app webapp (the generic parent's `vite-ui` profile redefines it as soon as `ui/` exists), but nothing in the tree guarantees that stays true, and both reviewers of the equivalent docx-exporter PR stopped at exactly this point because it cannot be confirmed from a diff.

So this asserts it instead of explaining it: the three generated articles must be on the classpath under `webapp/pdf-exporter-app/html`.

Why it is worth a test rather than a comment: if the destination ever moves back under `-admin`, About and User Guide keep working — generic's endpoints search `-app` then `-admin` — and **only** the Disclaimer page breaks, showing its "not generated" fallback to an administrator. No other test would notice.

Verified both ways: green on a normal build, red when the article is removed from the classpath. Deterministic since markdown2html 1.7.x renders the markdown locally, with no GitHub API call and no token.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
