### PR TITLE
chore: enable hyphenation in default DLE export CSS

### DIFF
--- a/src/main/resources/default/dle-pdf-export.css
+++ b/src/main/resources/default/dle-pdf-export.css
@@ -75,6 +75,11 @@ html {
     }
 }
 
+.content {
+    hyphens: auto;
+    -webkit-hyphens: auto;
+}
+
 .content .title {
     font-size: 2em;
     font-weight: 600;


### PR DESCRIPTION
Refs: #983

### Proposed changes

Add `hyphens: auto` to the `.content` block of the default dle-pdf-export.css so language-aware hyphenation is on out of the box,  complementing the <html lang> injection from #983. Without this rule the injected language has no visible effect unless a style package's CSS enables hyphenation explicitly.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
