### PR TITLE
chore: eslint & prettier pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,18 @@ repos:
         entry: \bDEV-\d{1,6}\b
         language: pygrep
         types: [text]
+      - id: ui-prettier
+        name: UI Prettier (format:check)
+        entry: npm --prefix ui run format:check
+        language: system
+        pass_filenames: false
+        files: ^ui/.*\.(ts|tsx|css|html)$
+      - id: ui-eslint
+        name: UI ESLint
+        entry: npm --prefix ui run lint
+        language: system
+        pass_filenames: false
+        files: ^ui/.*\.(ts|tsx|js|mjs)$
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.30.1
     hooks:

--- a/ui/README.md
+++ b/ui/README.md
@@ -204,7 +204,8 @@ ones.
 
 **One command, locally and in CI: `npm run test:coverage:docker`.** It runs the full suite (behavior +
 visual regression) plus the 80% istanbul coverage gate inside the pinned Playwright Docker image,
-which is what the Maven `test` phase and the pre-commit hook execute. Docker must be running.
+which is what the Maven `test` phase and CI execute. Docker must be running. It is not a pre-commit
+hook; see [Formatting, linting & typechecking](#formatting-linting--typechecking).
 
 The image's bundled npm is older than the `packageManager` pin, so the container installs the pinned
 npm through corepack before `npm ci`. That costs a few seconds and one download per run, and it is why
@@ -255,8 +256,12 @@ IDE showing one. `tsconfig.json` covers `src` **and** `test`: a test is code, an
 three tests kept passing a `hostSelector` prop that `BulkExportWidget` had stopped declaring. The config
 files themselves (`vite.config.js`, `vitest.config.ts`, `scripts/*.mjs`) are still outside the program.
 
-The repo's pre-commit hooks run `format:check`, `lint` and the dockerized coverage suite on any change
-under `ui/`. They are check-only and never modify your files.
+The repo's pre-commit hooks run `format:check` and `lint` on any change under `ui/`. They are
+check-only and never modify your files. Both use `language: system`, so run `npm ci` in `ui/` before
+`pre-commit run -a`. Without it they fail with an npm error rather than a lint finding.
+
+The dockerized coverage suite is deliberately **not** a hook: it needs Docker and adds 30-60s+ to every
+UI commit. The Maven `test` phase and CI already run it.
 
 ## Production build
 


### PR DESCRIPTION
Refs: #982

### Proposed changes

We have to add pre-commit hooks same way as we have in other extensions, except ui-test-coverage-docker: it needs Docker running and adds 30-60s+ to every UI commit, which is too slow for a pre-commit gate. The Vitest suite and the coverage gate already run in the Maven test phase and in CI.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
