### PR TITLE
fix: SSRF external resource policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,11 @@ A configured JVM proxy (`http.proxyHost` and friends) is used for these requests
 host name itself, so a request routed through one cannot be pinned to a checked address. Such a request
 is therefore only made for a host the configuration trusts as such: the Polarion server and the hosts
 listed above. Everything else is loaded directly, with the address check binding, or not at all. Hosts
-in `http.nonProxyHosts` are loaded directly and keep the address check. A SOCKS proxy is not a route the
-client takes, so a request under one stays direct and keeps the address check as well.
+in `http.nonProxyHosts` are loaded directly and keep the address check.
+
+A SOCKS proxy needs no such gate. It is no route the client plans, the JVM applies it at the socket, and
+the socket is connected to the address the check approved, not to a host name the proxy would resolve.
+So a request does traverse the SOCKS proxy, and its destination is still the vetted address.
 
 Blocked resources are reported in the Polarion log. The document is exported without them.
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ A configured JVM proxy (`http.proxyHost` and friends) is used for these requests
 host name itself, so a request routed through one cannot be pinned to a checked address. Such a request
 is therefore only made for a host the configuration trusts as such: the Polarion server and the hosts
 listed above. Everything else is loaded directly, with the address check binding, or not at all. Hosts
-in `http.nonProxyHosts` are loaded directly and keep the address check.
+in `http.nonProxyHosts` are loaded directly and keep the address check. A SOCKS proxy is not a route the
+client takes, so a request under one stays direct and keeps the address check as well.
 
 Blocked resources are reported in the Polarion log. The document is exported without them.
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ the size limit:
 ch.sbb.polarion.extension.pdf-exporter.externalResources.maxSizeMB=32
 ```
 
+A CSS `@import` of an absolute address is removed, whether the policy allows the address or not: an
+at-rule cannot be embedded, so WeasyPrint would have to load it itself, past every check above. Reference
+such a stylesheet with `<link rel="stylesheet">` instead, the extension loads and embeds that one.
+
+A configured JVM proxy (`http.proxyHost` and friends) is used for these requests. Behind a proxy the
+proxy resolves the host name, so the address checks decide whether the request is made at all, while
+the connection itself can no longer be pinned to a checked address.
+
 Blocked resources are reported in the Polarion log. The document is exported without them.
 
 ### Debug option

--- a/README.md
+++ b/README.md
@@ -200,6 +200,35 @@ To override this list, adjust the following property in the `polarion.properties
 ch.sbb.polarion.extension.pdf-exporter.renderable.image.extensions=png, jpg, jpeg, gif, bmp, svg, webp, avif, ico, cur, tif, tiff, vsdx
 ```
 
+### External resources
+
+A document can reference an image, a font or a stylesheet by an absolute URL. The extension loads such a
+resource and embeds it into the exported PDF. Because a document editor controls that URL, the request is
+restricted. By default the extension rejects every address which is not public: loopback, private ranges,
+link local addresses including the cloud metadata address `169.254.169.254`, and their IPv6 equivalents.
+The Polarion server itself, as configured by `base.url`, always stays reachable.
+
+To load resources from an internal host, list it explicitly:
+```properties
+ch.sbb.polarion.extension.pdf-exporter.externalResources.allowedHosts=cdn.intranet,images.intranet:8443
+```
+
+The policy itself can be changed:
+```properties
+# blockInternal (default) - public addresses, the Polarion server and the allowed hosts
+# allowlistOnly            - only the Polarion server and the allowed hosts
+# allowAll                 - no restriction, this exposes the server's network to document editors
+ch.sbb.polarion.extension.pdf-exporter.externalResources.policy=allowlistOnly
+```
+
+A loaded resource must be served as an image, a font or a stylesheet, and it may not exceed 16 MB. To change
+the size limit:
+```properties
+ch.sbb.polarion.extension.pdf-exporter.externalResources.maxSizeMB=32
+```
+
+Blocked resources are reported in the Polarion log. The document is exported without them.
+
 ### Debug option
 
 This extension makes intensive HTML processing to extend similar standard Polarion functionality. There is a possibility to log

--- a/README.md
+++ b/README.md
@@ -231,9 +231,11 @@ A CSS `@import` of an absolute address is removed, whether the policy allows the
 at-rule cannot be embedded, so WeasyPrint would have to load it itself, past every check above. Reference
 such a stylesheet with `<link rel="stylesheet">` instead, the extension loads and embeds that one.
 
-A configured JVM proxy (`http.proxyHost` and friends) is used for these requests. Behind a proxy the
-proxy resolves the host name, so the address checks decide whether the request is made at all, while
-the connection itself can no longer be pinned to a checked address.
+A configured JVM proxy (`http.proxyHost` and friends) is used for these requests. A proxy resolves the
+host name itself, so a request routed through one cannot be pinned to a checked address. Such a request
+is therefore only made for a host the configuration trusts as such: the Polarion server and the hosts
+listed above. Everything else is loaded directly, with the address check binding, or not at all. Hosts
+in `http.nonProxyHosts` are loaded directly and keep the address check.
 
 Blocked resources are reported in the Polarion log. The document is exported without them.
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ To load resources from an internal host, list it explicitly:
 ch.sbb.polarion.extension.pdf-exporter.externalResources.allowedHosts=cdn.intranet,images.intranet:8443
 ```
 
+An entry may carry a port, and then it names that port only: `cdn.intranet:443` allows the https spelling
+of that host, `cdn.intranet` allows both. A reference written `//host/path` takes the scheme of `base.url`
+first and the other one after, so it reaches the host under whichever scheme the entry names.
+
 The policy itself can be changed:
 ```properties
 # blockInternal (default) - public addresses, the Polarion server and the allowed hosts

--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,6 @@
         <maven-jar-plugin.Configuration-Properties-Prefix>ch.sbb.polarion.extension.pdf-exporter.</maven-jar-plugin.Configuration-Properties-Prefix>
         <web.app.name>${maven-jar-plugin.Extension-Context}</web.app.name>
 
-        <!-- Must stay equal to the versions of Polarion 2606's own httpcomponents bundles -->
-        <httpclient.version>4.5.14</httpclient.version>
-        <httpcore.version>4.4.16</httpcore.version>
 
         <!-- Extension-specific Require-Bundle (in addition to common ones from parent POM):
             com.polarion.alm.wiki
@@ -157,19 +154,18 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- Provided at runtime by Polarion 2606's org.apache.httpcomponents.httpclient_4.5.14 and
-             org.apache.httpcomponents.httpcore_4.4.16 OSGi bundles (resolved via Require-Bundle above).
-             Keep both versions equal to the ones Polarion ships, they are not bundled. -->
+        <!-- Polarion's own httpcomponents bundles, resolved at runtime via Require-Bundle above
+             and never packaged. Used by CustomResourceUrlResolver. -->
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpclient.version}</version>
+            <groupId>com.polarion.thirdparty</groupId>
+            <artifactId>org.apache.httpcomponents.httpclient_4.5.14</artifactId>
+            <version>${polarion.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>${httpcore.version}</version>
+            <groupId>com.polarion.thirdparty</groupId>
+            <artifactId>org.apache.httpcomponents.httpcore_4.4.16</artifactId>
+            <version>${polarion.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,14 +65,20 @@
         <maven-jar-plugin.Configuration-Properties-Prefix>ch.sbb.polarion.extension.pdf-exporter.</maven-jar-plugin.Configuration-Properties-Prefix>
         <web.app.name>${maven-jar-plugin.Extension-Context}</web.app.name>
 
+        <!-- Must stay equal to the versions of Polarion 2606's own httpcomponents bundles -->
+        <httpclient.version>4.5.14</httpclient.version>
+        <httpcore.version>4.4.16</httpcore.version>
+
         <!-- Extension-specific Require-Bundle (in addition to common ones from parent POM):
             com.polarion.alm.wiki
             org.jsoup
             net.bytebuddy.byte-buddy
             org.apache.tika.patched;resolution:=optional
             org.apache.tika;resolution:=optional
+            org.apache.httpcomponents.httpclient, org.apache.httpcomponents.httpcore (used by
+              CustomResourceUrlResolver to pin a request to the addresses ResourceUrlPolicy vetted)
         -->
-        <maven-jar-plugin.Require-Bundle.extension>com.polarion.alm.wiki,org.jsoup,net.bytebuddy.byte-buddy,org.apache.tika.patched;resolution:=optional,org.apache.tika;resolution:=optional</maven-jar-plugin.Require-Bundle.extension>
+        <maven-jar-plugin.Require-Bundle.extension>com.polarion.alm.wiki,org.jsoup,net.bytebuddy.byte-buddy,org.apache.tika.patched;resolution:=optional,org.apache.tika;resolution:=optional,org.apache.httpcomponents.httpclient,org.apache.httpcomponents.httpcore</maven-jar-plugin.Require-Bundle.extension>
         <maven-jar-plugin.Require-Bundle>${maven-jar-plugin.Require-Bundle.common},${maven-jar-plugin.Require-Bundle.extension}</maven-jar-plugin.Require-Bundle>
 
         <!-- A broken README.md -> about.html conversion fails the build instead of shipping an
@@ -151,6 +157,21 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Provided at runtime by Polarion 2606's org.apache.httpcomponents.httpclient_4.5.14 and
+             org.apache.httpcomponents.httpcore_4.4.16 OSGi bundles (resolved via Require-Bundle above).
+             Keep both versions equal to the ones Polarion ships, they are not bundled. -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcore.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>ch.sbb.polarion.extensions</groupId>
             <artifactId>ch.sbb.polarion.extension.generic.app</artifactId>

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessor.java
@@ -100,7 +100,7 @@ public class CoverPageProcessor {
         content = htmlProcessor.replaceResourcesAsBase64Encoded(content);
         String evaluatedContent = velocityEvaluator.evaluateVelocityExpressions(documentData, content);
         String css = coverPageSettings.processImagePlaceholders(settings.getTemplateCss());
-        css = htmlProcessor.replaceResourcesAsBase64Encoded(css);
+        css = htmlProcessor.replaceCssResourcesAsBase64Encoded(css);
         // Resolve the language the same way as the body (same resolver, same inputs) so the cover page hyphenates consistently
         String documentLanguage = DocumentLanguageResolver.resolve(documentData, exportParams);
         return pdfTemplateProcessor.processUsing(exportParams, documentData.getTitle(), css, evaluatedContent, "", documentLanguage);

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverter.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverter.java
@@ -376,7 +376,7 @@ public class PdfConverter {
         String processed = velocityEvaluator.evaluateVelocityExpressions(documentData, content);
 
         String cssContent = (exportParams.getDocumentType() != DocumentType.LIVE_DOC) ? appendWikiCss(processed) : processed;
-        return htmlProcessor.replaceResourcesAsBase64Encoded(cssContent);
+        return htmlProcessor.replaceCssResourcesAsBase64Encoded(cssContent);
     }
 
     @VisibleForTesting

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfiguration.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfiguration.java
@@ -132,7 +132,6 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
         return EXTERNAL_RESOURCES_POLICY_DEFAULT_VALUE;
     }
 
-    @NotNull
     @PropertyMapping(EXTERNAL_RESOURCES_ALLOWED_HOSTS)
     public String getExternalResourcesAllowedHosts() {
         return SystemValueReader.getInstance().readString(getPropertyPrefix() + EXTERNAL_RESOURCES_ALLOWED_HOSTS, EXTERNAL_RESOURCES_ALLOWED_HOSTS_DEFAULT_VALUE);

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfiguration.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfiguration.java
@@ -36,6 +36,18 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
             "png", "jpg", "jpeg", "gif", "bmp", "svg", "webp", "avif", "ico", "cur", "tif", "tiff", "vsdx"
     ));
 
+    public static final String EXTERNAL_RESOURCES_POLICY = "externalResources.policy";
+    public static final String EXTERNAL_RESOURCES_POLICY_DESCRIPTION = "Which hosts a document may load <a href='#external-resources'>images, fonts and stylesheets</a> from";
+    public static final String EXTERNAL_RESOURCES_POLICY_DEFAULT_VALUE = "blockInternal";
+
+    public static final String EXTERNAL_RESOURCES_ALLOWED_HOSTS = "externalResources.allowedHosts";
+    public static final String EXTERNAL_RESOURCES_ALLOWED_HOSTS_DESCRIPTION = "Comma separated hosts which are always allowed as a source of <a href='#external-resources'>external resources</a>";
+    public static final String EXTERNAL_RESOURCES_ALLOWED_HOSTS_DEFAULT_VALUE = "";
+
+    public static final String EXTERNAL_RESOURCES_MAX_SIZE_MB = "externalResources.maxSizeMB";
+    public static final String EXTERNAL_RESOURCES_MAX_SIZE_MB_DESCRIPTION = "Size in MB a single loaded <a href='#external-resources'>external resource</a> may reach";
+    public static final int EXTERNAL_RESOURCES_MAX_SIZE_MB_DEFAULT_VALUE = 16;
+
     @Override
     public String getDebugDescription() {
         return DEBUG_DESCRIPTION;
@@ -103,12 +115,67 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
         return String.join(", ", RENDERABLE_IMAGE_EXTENSIONS_DEFAULT_VALUE);
     }
 
+    @PropertyMapping(EXTERNAL_RESOURCES_POLICY)
+    public String getExternalResourcesPolicy() {
+        return SystemValueReader.getInstance().readString(getPropertyPrefix() + EXTERNAL_RESOURCES_POLICY, EXTERNAL_RESOURCES_POLICY_DEFAULT_VALUE);
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDescription(EXTERNAL_RESOURCES_POLICY)
+    public String getExternalResourcesPolicyDescription() {
+        return EXTERNAL_RESOURCES_POLICY_DESCRIPTION;
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDefaultValue(EXTERNAL_RESOURCES_POLICY)
+    public String getExternalResourcesPolicyDefaultValue() {
+        return EXTERNAL_RESOURCES_POLICY_DEFAULT_VALUE;
+    }
+
+    @NotNull
+    @PropertyMapping(EXTERNAL_RESOURCES_ALLOWED_HOSTS)
+    public String getExternalResourcesAllowedHosts() {
+        return SystemValueReader.getInstance().readString(getPropertyPrefix() + EXTERNAL_RESOURCES_ALLOWED_HOSTS, EXTERNAL_RESOURCES_ALLOWED_HOSTS_DEFAULT_VALUE);
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDescription(EXTERNAL_RESOURCES_ALLOWED_HOSTS)
+    public String getExternalResourcesAllowedHostsDescription() {
+        return EXTERNAL_RESOURCES_ALLOWED_HOSTS_DESCRIPTION;
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDefaultValue(EXTERNAL_RESOURCES_ALLOWED_HOSTS)
+    public String getExternalResourcesAllowedHostsDefaultValue() {
+        return EXTERNAL_RESOURCES_ALLOWED_HOSTS_DEFAULT_VALUE;
+    }
+
+    @PropertyMapping(EXTERNAL_RESOURCES_MAX_SIZE_MB)
+    public int getExternalResourcesMaxSizeMB() {
+        return SystemValueReader.getInstance().readInt(getPropertyPrefix() + EXTERNAL_RESOURCES_MAX_SIZE_MB, EXTERNAL_RESOURCES_MAX_SIZE_MB_DEFAULT_VALUE);
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDescription(EXTERNAL_RESOURCES_MAX_SIZE_MB)
+    public String getExternalResourcesMaxSizeMBDescription() {
+        return EXTERNAL_RESOURCES_MAX_SIZE_MB_DESCRIPTION;
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDefaultValue(EXTERNAL_RESOURCES_MAX_SIZE_MB)
+    public String getExternalResourcesMaxSizeMBDefaultValue() {
+        return String.valueOf(EXTERNAL_RESOURCES_MAX_SIZE_MB_DEFAULT_VALUE);
+    }
+
     @Override
     public @NotNull List<String> getSupportedProperties() {
         List<String> supportedProperties = new ArrayList<>(super.getSupportedProperties());
         supportedProperties.add(WEASYPRINT_SERVICE);
         supportedProperties.add(WEBHOOKS_ENABLED);
         supportedProperties.add(RENDERABLE_IMAGE_EXTENSIONS);
+        supportedProperties.add(EXTERNAL_RESOURCES_POLICY);
+        supportedProperties.add(EXTERNAL_RESOURCES_ALLOWED_HOSTS);
+        supportedProperties.add(EXTERNAL_RESOURCES_MAX_SIZE_MB);
         return supportedProperties;
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -163,6 +163,12 @@ public class CustomResourceUrlResolver implements IUrlResolver {
                         + " List the host in the allowed hosts property to fetch it anyway.");
                 return null;
             }
+            if (proxy.proxied() && proxy.host() == null) {
+                // the host is trusted, but the proxy to reach it through was not named, and a request
+                // sent past the configured route is not the request the configuration asked for
+                logger.warn(SKIPPED_RESOURCE + currentUrl + ": it goes through a proxy which could not be named.");
+                return null;
+            }
             InetAddress[] addresses = policy.vetAddresses(currentUrl);
             if (addresses == null) {
                 return null;

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -115,6 +115,10 @@ public class CustomResourceUrlResolver implements IUrlResolver {
                 .setRedirectsEnabled(false)
                 .build();
         return HttpClients.custom()
+                // the replaced HttpURLConnection honoured http.proxyHost and friends, keep doing that.
+                // Behind a proxy the socket goes to the proxy, so the proxy resolves the host name and
+                // the addresses below only decide whether the request is made at all.
+                .useSystemProperties()
                 .setDefaultRequestConfig(requestConfig)
                 .setDnsResolver(pinnedResolver)
                 .disableAutomaticRetries()

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -323,10 +323,14 @@ public class CustomResourceUrlResolver implements IUrlResolver {
             return new ProxyDecision(false, null);
         }
         try {
+            // the jvm takes the first entry it can use, direct or http, and reading the list the same way
+            // keeps the answer the one the configuration meant: 'DIRECT; PROXY host:port' means direct
             return selector.select(URI.create(url.toString())).stream()
-                    .filter(proxy -> proxy.type() == Proxy.Type.HTTP)
+                    .filter(proxy -> proxy.type() == Proxy.Type.DIRECT || proxy.type() == Proxy.Type.HTTP)
                     .findFirst()
-                    .map(proxy -> new ProxyDecision(true, hostOf(proxy)))
+                    .map(proxy -> proxy.type() == Proxy.Type.HTTP
+                            ? new ProxyDecision(true, hostOf(proxy))
+                            : new ProxyDecision(false, null))
                     .orElseGet(() -> new ProxyDecision(false, null));
         } catch (RuntimeException e) {
             // a selector which cannot answer is no reason to fetch anything past the check

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -129,7 +129,18 @@ public class CustomResourceUrlResolver implements IUrlResolver {
                 content.write(buffer, 0, read);
             }
         }
-        return new ByteArrayInputStream(content.toByteArray());
+
+        byte[] bytes = content.toByteArray();
+        if (policy.isSniffingRequired(contentType)) {
+            // A missing or generic content type passes the header check, so the content decides. This
+            // catches an internal service which answers with a document instead of an image.
+            String sniffedType = MediaUtils.getMimeTypeUsingTikaByContent(url.toString(), bytes);
+            if (policy.isRejectedSniffedType(sniffedType)) {
+                logger.warn("Skipped resource " + url + ": its content is '" + sniffedType + "', not an image, a font or a stylesheet");
+                return null;
+            }
+        }
+        return new ByteArrayInputStream(bytes);
     }
 
     private String ensureAbsoluteUrl(String url) {
@@ -141,7 +152,8 @@ public class CustomResourceUrlResolver implements IUrlResolver {
         return StringUtils.removeSuffix(baseUrl, "/");
     }
 
+    // delegates, so that the policy check and the request itself normalize a url identically
     private String normalizeUrl(String urlStr) {
-        return urlStr.replace(" ", "%20").replace("%5F", "_");
+        return MediaUtils.normalizeUrl(urlStr);
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -156,17 +156,7 @@ public class CustomResourceUrlResolver implements IUrlResolver {
         ProxySelector selector = ProxySelector.getDefault();
         for (int redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
             ProxyDecision proxy = decideProxy(selector, currentUrl);
-            if (proxy.proxied() && !policy.isExplicitlyTrusted(currentUrl)) {
-                // A proxy resolves the host name itself, so the vetted addresses would decide nothing.
-                // Only a host the configuration trusts as such may be fetched that way.
-                logger.warn(SKIPPED_RESOURCE + currentUrl + ": it would go through a proxy, which resolves the host name itself."
-                        + " List the host in the allowed hosts property to fetch it anyway.");
-                return null;
-            }
-            if (proxy.proxied() && proxy.host() == null) {
-                // the host is trusted, but the proxy to reach it through was not named, and a request
-                // sent past the configured route is not the request the configuration asked for
-                logger.warn(SKIPPED_RESOURCE + currentUrl + ": it goes through a proxy which could not be named.");
+            if (!mayBeFetched(currentUrl, proxy)) {
                 return null;
             }
             InetAddress[] addresses = policy.vetAddresses(currentUrl);
@@ -175,22 +165,57 @@ public class CustomResourceUrlResolver implements IUrlResolver {
             }
             try (CloseableHttpClient client = createClient(currentUrl, addresses, proxy);
                  CloseableHttpResponse response = client.execute(new HttpGet(URI.create(currentUrl.toString())))) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                if (statusCode == HTTP_OK) {
+                if (response.getStatusLine().getStatusCode() == HTTP_OK) {
                     return readContent(response, currentUrl);
                 }
-                if (!REDIRECT_STATUS_CODES.contains(statusCode)) {
+                URL target = redirectTarget(response, currentUrl);
+                if (target == null) {
                     return null;
                 }
-                Header location = response.getFirstHeader(HttpHeaders.LOCATION);
-                if (location == null || StringUtils.isEmptyTrimmed(location.getValue())) {
-                    return null;
-                }
-                currentUrl = URI.create(normalizeUrl(currentUrl.toString())).resolve(normalizeUrl(location.getValue().trim())).toURL();
+                currentUrl = target;
             }
         }
         logger.warn("Failed to load resource: " + url + ", more than " + MAX_REDIRECTS + " redirects");
         return null;
+    }
+
+    /**
+     * @return whether the request may be made at all, given where it would be routed
+     */
+    private boolean mayBeFetched(@NotNull URL url, @NotNull ProxyDecision proxy) {
+        if (!proxy.proxied()) {
+            return true;
+        }
+        if (!policy.isExplicitlyTrusted(url)) {
+            // A proxy resolves the host name itself, so the vetted addresses would decide nothing.
+            // Only a host the configuration trusts as such may be fetched that way.
+            logger.warn(SKIPPED_RESOURCE + url + ": it would go through a proxy, which resolves the host name itself."
+                    + " List the host in the allowed hosts property to fetch it anyway.");
+            return false;
+        }
+        if (proxy.host() == null) {
+            // the host is trusted, but the proxy to reach it through was not named, and a request
+            // sent past the configured route is not the request the configuration asked for
+            logger.warn(SKIPPED_RESOURCE + url + ": it goes through a proxy which could not be named.");
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return where the response sends the request next, null where it sends it nowhere
+     */
+    @SneakyThrows
+    @Nullable
+    private URL redirectTarget(@NotNull CloseableHttpResponse response, @NotNull URL currentUrl) {
+        if (!REDIRECT_STATUS_CODES.contains(response.getStatusLine().getStatusCode())) {
+            return null;
+        }
+        Header location = response.getFirstHeader(HttpHeaders.LOCATION);
+        if (location == null || StringUtils.isEmptyTrimmed(location.getValue())) {
+            return null;
+        }
+        return URI.create(normalizeUrl(currentUrl.toString())).resolve(normalizeUrl(location.getValue().trim())).toURL();
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -14,6 +14,7 @@ import org.apache.http.conn.DnsResolver;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -147,8 +148,11 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     @VisibleForTesting
     public InputStream resolveImpl(@NotNull URL url) {
         URL currentUrl = url;
+        // one selector answers both the check below and the routing of the client built from it, so the
+        // two cannot read a different proxy setup, whoever installed the one in place
+        ProxySelector selector = ProxySelector.getDefault();
         for (int redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
-            if (isProxied(currentUrl) && !policy.isExplicitlyTrusted(currentUrl)) {
+            if (isProxied(selector, currentUrl) && !policy.isExplicitlyTrusted(currentUrl)) {
                 // A proxy resolves the host name itself, so the vetted addresses would decide nothing.
                 // Only a host the configuration trusts as such may be fetched that way.
                 logger.warn(SKIPPED_RESOURCE + currentUrl + ": it would go through a proxy, which resolves the host name itself."
@@ -159,7 +163,7 @@ public class CustomResourceUrlResolver implements IUrlResolver {
             if (addresses == null) {
                 return null;
             }
-            try (CloseableHttpClient client = createClient(currentUrl, addresses);
+            try (CloseableHttpClient client = createClient(currentUrl, addresses, selector);
                  CloseableHttpResponse response = client.execute(new HttpGet(URI.create(currentUrl.toString())))) {
                 int statusCode = response.getStatusLine().getStatusCode();
                 if (statusCode == HTTP_OK) {
@@ -185,7 +189,7 @@ public class CustomResourceUrlResolver implements IUrlResolver {
      * approved. The host name stays in the request, so the Host header and the TLS host name verification
      * keep working. Any other name, a proxy host as a rule, is left to the system resolver.
      */
-    private CloseableHttpClient createClient(@NotNull URL url, @NotNull InetAddress[] addresses) {
+    private CloseableHttpClient createClient(@NotNull URL url, @NotNull InetAddress[] addresses, @Nullable ProxySelector selector) {
         String pinnedHost = url.getHost() == null ? "" : stripBrackets(url.getHost());
         DnsResolver pinnedResolver = host -> pinnedHost.equalsIgnoreCase(host)
                 ? addresses
@@ -202,6 +206,8 @@ public class CustomResourceUrlResolver implements IUrlResolver {
                 // Behind a proxy the socket goes to the proxy, so the proxy resolves the host name and
                 // the addresses below only decide whether the request is made at all.
                 .useSystemProperties()
+                // the routes come from the selector the check read, not from a second reading of it
+                .setRoutePlanner(new SystemDefaultRoutePlanner(selector))
                 .setDefaultRequestConfig(requestConfig)
                 .setDnsResolver(pinnedResolver)
                 .disableAutomaticRetries()
@@ -269,8 +275,7 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     }
 
     @VisibleForTesting
-    boolean isProxied(@NotNull URL url) {
-        ProxySelector selector = ProxySelector.getDefault();
+    boolean isProxied(@Nullable ProxySelector selector, @NotNull URL url) {
         if (selector == null) {
             return false;
         }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
-import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLPeerUnverifiedException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -28,6 +28,7 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URL;
+import java.security.cert.CertificateException;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -115,8 +116,8 @@ public class CustomResourceUrlResolver implements IUrlResolver {
             return new SchemeAttempt(stream, stream != null || !policy.isRefusalPortSpecific(url));
         } catch (Exception e) {
             logger.debug("Failed to load resource " + scheme + ":" + urlStr + ": " + e.getMessage());
-            // nothing was decided unless tls itself failed, and then the other scheme is not an answer
-            return new SchemeAttempt(null, isTlsFailure(e));
+            // nothing was decided unless the peer showed a certificate which was refused
+            return new SchemeAttempt(null, isCertificateFailure(e));
         }
     }
 
@@ -127,9 +128,15 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     private record SchemeAttempt(@Nullable InputStream stream, boolean conclusive) {
     }
 
-    private boolean isTlsFailure(@NotNull Throwable failure) {
+    /**
+     * A host which does not speak tls on that port answered nothing, and the other scheme of a network
+     * path reference is the question to ask next. A host which showed a certificate the client refused
+     * did answer, and the answer to a refused certificate is never the same resource in the clear.
+     */
+    @VisibleForTesting
+    boolean isCertificateFailure(@NotNull Throwable failure) {
         for (Throwable current = failure; current != null; current = current.getCause()) {
-            if (current instanceof SSLException) {
+            if (current instanceof CertificateException || current instanceof SSLPeerUnverifiedException) {
                 return true;
             }
         }
@@ -261,7 +268,8 @@ public class CustomResourceUrlResolver implements IUrlResolver {
         return host.startsWith("[") && host.endsWith("]") ? host.substring(1, host.length() - 1) : host;
     }
 
-    private boolean isProxied(@NotNull URL url) {
+    @VisibleForTesting
+    boolean isProxied(@NotNull URL url) {
         ProxySelector selector = ProxySelector.getDefault();
         if (selector == null) {
             return false;

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -4,24 +4,37 @@ import com.polarion.alm.tracker.internal.url.IUrlResolver;
 import com.polarion.core.util.StringUtils;
 import com.polarion.core.util.logging.Logger;
 import lombok.SneakyThrows;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.DnsResolver;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
 import java.util.stream.Stream;
 
-import static java.net.HttpURLConnection.*;
+import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
+import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
+import static java.net.HttpURLConnection.HTTP_OK;
 
 /**
  * Custom version of {@link com.polarion.alm.tracker.internal.url.GenericUrlResolver} with the redirect support.
  * <p>
  * Every request passes {@link ResourceUrlPolicy}, which keeps a document editor from making the server
- * fetch an arbitrary address and from getting the response body back in the exported document.
+ * fetch an arbitrary address and from getting the response body back in the exported document. The
+ * connection is pinned to the addresses the policy vetted, so a second name resolution cannot reach an
+ * address the policy never saw.
  * </p>
  */
 public class CustomResourceUrlResolver implements IUrlResolver {
@@ -32,6 +45,7 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     private static final int READ_TIMEOUT_MS = 3_000;
     private static final int MAX_REDIRECTS = 5;
     private static final int BUFFER_SIZE = 8192;
+    private static final String SKIPPED_RESOURCE = "Skipped resource ";
 
     private final ResourceUrlPolicy policy;
 
@@ -39,7 +53,6 @@ public class CustomResourceUrlResolver implements IUrlResolver {
         this(ResourceUrlPolicy.getInstance());
     }
 
-    @VisibleForTesting
     public CustomResourceUrlResolver(@NotNull ResourceUrlPolicy policy) {
         this.policy = policy;
     }
@@ -63,67 +76,84 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     public InputStream resolveImpl(@NotNull URL url) {
         URL currentUrl = url;
         for (int redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
-            if (!policy.isAllowed(currentUrl)) {
+            InetAddress[] addresses = policy.vetAddresses(currentUrl);
+            if (addresses == null) {
                 return null;
             }
-            HttpURLConnection connection = openConnection(currentUrl);
-            try {
-                int responseCode = connection.getResponseCode();
-                if (responseCode == HTTP_OK) {
-                    return readContent(connection, currentUrl);
+            try (CloseableHttpClient client = createClient(addresses);
+                 CloseableHttpResponse response = client.execute(new HttpGet(URI.create(currentUrl.toString())))) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == HTTP_OK) {
+                    return readContent(response, currentUrl);
                 }
-                if (responseCode != HTTP_MOVED_PERM && responseCode != HTTP_MOVED_TEMP) {
+                if (statusCode != HTTP_MOVED_PERM && statusCode != HTTP_MOVED_TEMP) {
                     return null;
                 }
-                String location = connection.getHeaderField("Location");
-                if (StringUtils.isEmptyTrimmed(location)) {
+                Header location = response.getFirstHeader(HttpHeaders.LOCATION);
+                if (location == null || StringUtils.isEmptyTrimmed(location.getValue())) {
                     return null;
                 }
-                currentUrl = URI.create(normalizeUrl(currentUrl.toString())).resolve(normalizeUrl(location.trim())).toURL();
-            } finally {
-                connection.disconnect();
+                currentUrl = URI.create(normalizeUrl(currentUrl.toString())).resolve(normalizeUrl(location.getValue().trim())).toURL();
             }
         }
         logger.warn("Failed to load resource: " + url + ", more than " + MAX_REDIRECTS + " redirects");
         return null;
     }
 
-    @SneakyThrows
-    private HttpURLConnection openConnection(@NotNull URL url) {
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        connection.setConnectTimeout(CONNECTION_TIMEOUT_MS);
-        connection.setReadTimeout(READ_TIMEOUT_MS);
-        // redirects are followed by this class, so that the policy sees every single hop
-        connection.setInstanceFollowRedirects(false);
-        connection.connect();
-        return connection;
+    /**
+     * Builds a client for a single request. Its name resolution answers with the vetted addresses only,
+     * which binds the request to what {@link ResourceUrlPolicy#vetAddresses} approved. The host name stays
+     * in the request, so the Host header and the TLS host name verification keep working.
+     */
+    private CloseableHttpClient createClient(@NotNull InetAddress[] addresses) {
+        DnsResolver pinnedResolver = host -> addresses;
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(CONNECTION_TIMEOUT_MS)
+                .setConnectionRequestTimeout(CONNECTION_TIMEOUT_MS)
+                .setSocketTimeout(READ_TIMEOUT_MS)
+                // redirects are followed by this class, so that the policy sees every single hop
+                .setRedirectsEnabled(false)
+                .build();
+        return HttpClients.custom()
+                .setDefaultRequestConfig(requestConfig)
+                .setDnsResolver(pinnedResolver)
+                .disableAutomaticRetries()
+                .disableCookieManagement()
+                .disableAuthCaching()
+                .build();
     }
 
     /**
      * Reads at most {@link ResourceUrlPolicy#getMaxResourceBytes()} bytes. The content is fully read here
-     * because the connection is closed as soon as this method returns.
+     * because the response is closed as soon as this method returns.
      */
     @SneakyThrows
-    private InputStream readContent(@NotNull HttpURLConnection connection, @NotNull URL url) {
-        String contentType = connection.getContentType();
+    private InputStream readContent(@NotNull CloseableHttpResponse response, @NotNull URL url) {
+        HttpEntity entity = response.getEntity();
+        if (entity == null) {
+            return null;
+        }
+
+        Header contentTypeHeader = entity.getContentType();
+        String contentType = contentTypeHeader == null ? null : contentTypeHeader.getValue();
         if (!policy.isAllowedContentType(contentType)) {
-            logger.warn("Skipped resource " + url + ": the content type '" + contentType + "' is not an image, a font or a stylesheet");
+            logger.warn(SKIPPED_RESOURCE + url + ": the content type '" + contentType + "' is not an image, a font or a stylesheet");
             return null;
         }
 
         long maxBytes = policy.getMaxResourceBytes();
-        if (connection.getContentLengthLong() > maxBytes) {
-            logger.warn("Skipped resource " + url + ": it is larger than " + maxBytes + " bytes");
+        if (entity.getContentLength() > maxBytes) {
+            logger.warn(SKIPPED_RESOURCE + url + ": it is larger than " + maxBytes + " bytes");
             return null;
         }
 
         ByteArrayOutputStream content = new ByteArrayOutputStream();
         byte[] buffer = new byte[BUFFER_SIZE];
-        try (InputStream inputStream = connection.getInputStream()) {
+        try (InputStream inputStream = entity.getContent()) {
             int read;
             while ((read = inputStream.read(buffer)) != -1) {
                 if (content.size() + read > maxBytes) {
-                    logger.warn("Skipped resource " + url + ": it is larger than " + maxBytes + " bytes");
+                    logger.warn(SKIPPED_RESOURCE + url + ": it is larger than " + maxBytes + " bytes");
                     return null;
                 }
                 content.write(buffer, 0, read);
@@ -136,7 +166,7 @@ public class CustomResourceUrlResolver implements IUrlResolver {
             // catches an internal service which answers with a document instead of an image.
             String sniffedType = MediaUtils.getMimeTypeUsingTikaByContent(url.toString(), bytes);
             if (policy.isRejectedSniffedType(sniffedType)) {
-                logger.warn("Skipped resource " + url + ": its content is '" + sniffedType + "', not an image, a font or a stylesheet");
+                logger.warn(SKIPPED_RESOURCE + url + ": its content is '" + sniffedType + "', not an image, a font or a stylesheet");
                 return null;
             }
         }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -14,6 +14,7 @@ import org.apache.http.conn.DnsResolver;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
+import javax.net.ssl.SSLException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -28,6 +29,7 @@ import java.net.URL;
 import java.util.stream.Stream;
 
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
 import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
@@ -90,21 +92,33 @@ public class CustomResourceUrlResolver implements IUrlResolver {
      */
     private InputStream resolveNetworkPathReference(@NotNull String urlStr) {
         String preferredScheme = policy.getBaseUrlScheme();
-        InputStream stream = resolveWithScheme(preferredScheme, urlStr);
-        if (stream != null) {
+        AtomicBoolean tlsFailure = new AtomicBoolean();
+        InputStream stream = resolveWithScheme(preferredScheme, urlStr, tlsFailure);
+        if (stream != null || tlsFailure.get()) {
+            // a host which speaks tls badly is not a reason to ask it for the same resource in the clear
             return stream;
         }
-        return resolveWithScheme(HTTPS_SCHEME.equals(preferredScheme) ? HTTP_SCHEME : HTTPS_SCHEME, urlStr);
+        return resolveWithScheme(HTTPS_SCHEME.equals(preferredScheme) ? HTTP_SCHEME : HTTPS_SCHEME, urlStr, new AtomicBoolean());
     }
 
-    private InputStream resolveWithScheme(@NotNull String scheme, @NotNull String urlStr) {
+    private InputStream resolveWithScheme(@NotNull String scheme, @NotNull String urlStr, @NotNull AtomicBoolean tlsFailure) {
         try {
             return resolveImpl(URI.create(normalizeUrl(scheme + ":" + urlStr)).toURL());
         } catch (Exception e) {
+            tlsFailure.set(isTlsFailure(e));
             // the other scheme is tried next, a failure here is not the end of it
             logger.debug("Failed to load resource " + scheme + ":" + urlStr + ": " + e.getMessage());
             return null;
         }
+    }
+
+    private boolean isTlsFailure(@NotNull Throwable failure) {
+        for (Throwable current = failure; current != null; current = current.getCause()) {
+            if (current instanceof SSLException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @SneakyThrows

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -13,6 +13,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.conn.DnsResolver;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -20,6 +21,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.InetAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URL;
 import java.util.stream.Stream;
@@ -80,7 +83,14 @@ public class CustomResourceUrlResolver implements IUrlResolver {
             if (addresses == null) {
                 return null;
             }
-            try (CloseableHttpClient client = createClient(addresses);
+            if (isProxied(currentUrl) && !policy.isExplicitlyTrusted(currentUrl)) {
+                // A proxy resolves the host name itself, so the vetted addresses would decide nothing.
+                // Only a host the configuration trusts as such may be fetched that way.
+                logger.warn(SKIPPED_RESOURCE + currentUrl + ": it would go through a proxy, which resolves the host name itself."
+                        + " List the host in the allowed hosts property to fetch it anyway.");
+                return null;
+            }
+            try (CloseableHttpClient client = createClient(currentUrl, addresses);
                  CloseableHttpResponse response = client.execute(new HttpGet(URI.create(currentUrl.toString())))) {
                 int statusCode = response.getStatusLine().getStatusCode();
                 if (statusCode == HTTP_OK) {
@@ -101,12 +111,16 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     }
 
     /**
-     * Builds a client for a single request. Its name resolution answers with the vetted addresses only,
-     * which binds the request to what {@link ResourceUrlPolicy#vetAddresses} approved. The host name stays
-     * in the request, so the Host header and the TLS host name verification keep working.
+     * Builds a client for a single request. Its name resolution answers with the vetted addresses for the
+     * host of that request, which binds the request to what {@link ResourceUrlPolicy#vetAddresses}
+     * approved. The host name stays in the request, so the Host header and the TLS host name verification
+     * keep working. Any other name, a proxy host as a rule, is left to the system resolver.
      */
-    private CloseableHttpClient createClient(@NotNull InetAddress[] addresses) {
-        DnsResolver pinnedResolver = host -> addresses;
+    private CloseableHttpClient createClient(@NotNull URL url, @NotNull InetAddress[] addresses) {
+        String pinnedHost = url.getHost() == null ? "" : stripBrackets(url.getHost());
+        DnsResolver pinnedResolver = host -> pinnedHost.equalsIgnoreCase(host)
+                ? addresses
+                : SystemDefaultDnsResolver.INSTANCE.resolve(host);
         RequestConfig requestConfig = RequestConfig.custom()
                 .setConnectTimeout(CONNECTION_TIMEOUT_MS)
                 .setConnectionRequestTimeout(CONNECTION_TIMEOUT_MS)
@@ -178,7 +192,28 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     }
 
     private String ensureAbsoluteUrl(String url) {
+        if (MediaUtils.isNetworkPathReference(url)) {
+            // '//host/path' names its own host, only the scheme comes from the Polarion base url
+            return policy.getBaseUrlScheme() + ":" + url;
+        }
         return url.startsWith("/") ? getBaseUrl() + url : url;
+    }
+
+    private static String stripBrackets(@NotNull String host) {
+        return host.startsWith("[") && host.endsWith("]") ? host.substring(1, host.length() - 1) : host;
+    }
+
+    private boolean isProxied(@NotNull URL url) {
+        ProxySelector selector = ProxySelector.getDefault();
+        if (selector == null) {
+            return false;
+        }
+        try {
+            return selector.select(URI.create(url.toString())).stream().anyMatch(proxy -> proxy.type() != Proxy.Type.DIRECT);
+        } catch (RuntimeException e) {
+            logger.warn("Cannot tell whether '" + url + "' goes through a proxy, it is treated as direct", e);
+            return false;
+        }
     }
 
     private String getBaseUrl() {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -14,9 +14,11 @@ import org.apache.http.conn.DnsResolver;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
-import javax.net.ssl.SSLException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
+
+import javax.net.ssl.SSLException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -26,10 +28,8 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URL;
-import java.util.stream.Stream;
-
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
 import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
@@ -92,24 +92,36 @@ public class CustomResourceUrlResolver implements IUrlResolver {
      */
     private InputStream resolveNetworkPathReference(@NotNull String urlStr) {
         String preferredScheme = policy.getBaseUrlScheme();
-        AtomicBoolean tlsFailure = new AtomicBoolean();
-        InputStream stream = resolveWithScheme(preferredScheme, urlStr, tlsFailure);
-        if (stream != null || tlsFailure.get()) {
-            // a host which speaks tls badly is not a reason to ask it for the same resource in the clear
-            return stream;
+        String otherScheme = HTTPS_SCHEME.equals(preferredScheme) ? HTTP_SCHEME : HTTPS_SCHEME;
+        SchemeAttempt preferred = resolveWithScheme(preferredScheme, urlStr);
+        if (preferred.conclusive()) {
+            // the host answered, and what it answered was read or refused: the other scheme adds nothing,
+            // and a host which speaks tls badly is not asked for the same resource in the clear either
+            return preferred.stream();
         }
-        return resolveWithScheme(HTTPS_SCHEME.equals(preferredScheme) ? HTTP_SCHEME : HTTPS_SCHEME, urlStr, new AtomicBoolean());
+        SchemeAttempt other = resolveWithScheme(otherScheme, urlStr);
+        if (other.stream() == null) {
+            logger.warn(SKIPPED_RESOURCE + urlStr + ": neither " + preferredScheme + " nor " + otherScheme + " could read it");
+        }
+        return other.stream();
     }
 
-    private InputStream resolveWithScheme(@NotNull String scheme, @NotNull String urlStr, @NotNull AtomicBoolean tlsFailure) {
+    private SchemeAttempt resolveWithScheme(@NotNull String scheme, @NotNull String urlStr) {
         try {
-            return resolveImpl(URI.create(normalizeUrl(scheme + ":" + urlStr)).toURL());
+            // a decision was taken, whether it produced a resource or refused one
+            return new SchemeAttempt(resolveImpl(URI.create(normalizeUrl(scheme + ":" + urlStr)).toURL()), true);
         } catch (Exception e) {
-            tlsFailure.set(isTlsFailure(e));
-            // the other scheme is tried next, a failure here is not the end of it
             logger.debug("Failed to load resource " + scheme + ":" + urlStr + ": " + e.getMessage());
-            return null;
+            // nothing was decided unless tls itself failed, and then the other scheme is not an answer
+            return new SchemeAttempt(null, isTlsFailure(e));
         }
+    }
+
+    /**
+     * @param stream     what the scheme produced, null if it produced nothing
+     * @param conclusive whether trying the other scheme would still answer the question
+     */
+    private record SchemeAttempt(@Nullable InputStream stream, boolean conclusive) {
     }
 
     private boolean isTlsFailure(@NotNull Throwable failure) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -6,6 +6,7 @@ import com.polarion.core.util.logging.Logger;
 import lombok.SneakyThrows;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -14,7 +15,8 @@ import org.apache.http.conn.DnsResolver;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
-import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.apache.http.impl.conn.DefaultRoutePlanner;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -25,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.URI;
@@ -148,11 +151,12 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     @VisibleForTesting
     public InputStream resolveImpl(@NotNull URL url) {
         URL currentUrl = url;
-        // one selector answers both the check below and the routing of the client built from it, so the
-        // two cannot read a different proxy setup, whoever installed the one in place
+        // the selector is asked once per hop, and the answer both decides and routes: what the check
+        // let through cannot be routed anywhere else
         ProxySelector selector = ProxySelector.getDefault();
         for (int redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
-            if (isProxied(selector, currentUrl) && !policy.isExplicitlyTrusted(currentUrl)) {
+            ProxyDecision proxy = decideProxy(selector, currentUrl);
+            if (proxy.proxied() && !policy.isExplicitlyTrusted(currentUrl)) {
                 // A proxy resolves the host name itself, so the vetted addresses would decide nothing.
                 // Only a host the configuration trusts as such may be fetched that way.
                 logger.warn(SKIPPED_RESOURCE + currentUrl + ": it would go through a proxy, which resolves the host name itself."
@@ -163,7 +167,7 @@ public class CustomResourceUrlResolver implements IUrlResolver {
             if (addresses == null) {
                 return null;
             }
-            try (CloseableHttpClient client = createClient(currentUrl, addresses, selector);
+            try (CloseableHttpClient client = createClient(currentUrl, addresses, proxy);
                  CloseableHttpResponse response = client.execute(new HttpGet(URI.create(currentUrl.toString())))) {
                 int statusCode = response.getStatusLine().getStatusCode();
                 if (statusCode == HTTP_OK) {
@@ -189,7 +193,7 @@ public class CustomResourceUrlResolver implements IUrlResolver {
      * approved. The host name stays in the request, so the Host header and the TLS host name verification
      * keep working. Any other name, a proxy host as a rule, is left to the system resolver.
      */
-    private CloseableHttpClient createClient(@NotNull URL url, @NotNull InetAddress[] addresses, @Nullable ProxySelector selector) {
+    private CloseableHttpClient createClient(@NotNull URL url, @NotNull InetAddress[] addresses, @NotNull ProxyDecision proxy) {
         String pinnedHost = url.getHost() == null ? "" : stripBrackets(url.getHost());
         DnsResolver pinnedResolver = host -> pinnedHost.equalsIgnoreCase(host)
                 ? addresses
@@ -206,8 +210,8 @@ public class CustomResourceUrlResolver implements IUrlResolver {
                 // Behind a proxy the socket goes to the proxy, so the proxy resolves the host name and
                 // the addresses below only decide whether the request is made at all.
                 .useSystemProperties()
-                // the routes come from the selector the check read, not from a second reading of it
-                .setRoutePlanner(new SystemDefaultRoutePlanner(selector))
+                // the route is the answer the check already got, so the selector is asked no second time
+                .setRoutePlanner(proxy.host() == null ? new DefaultRoutePlanner(null) : new DefaultProxyRoutePlanner(proxy.host()))
                 .setDefaultRequestConfig(requestConfig)
                 .setDnsResolver(pinnedResolver)
                 .disableAutomaticRetries()
@@ -274,19 +278,46 @@ public class CustomResourceUrlResolver implements IUrlResolver {
         return host.startsWith("[") && host.endsWith("]") ? host.substring(1, host.length() - 1) : host;
     }
 
+    /**
+     * Asks the selector once and keeps the answer. The request is routed by this answer and by nothing
+     * else, so a selector which answers differently the next time it is asked cannot route a request the
+     * check let through. Only an http proxy is a route: a socks one the jvm applies at the socket, after
+     * the connection has been bound to a vetted address.
+     *
+     * @return what to do with the url, and where to route it if that is through a proxy
+     */
     @VisibleForTesting
-    boolean isProxied(@Nullable ProxySelector selector, @NotNull URL url) {
+    ProxyDecision decideProxy(@Nullable ProxySelector selector, @NotNull URL url) {
         if (selector == null) {
-            return false;
+            return new ProxyDecision(false, null);
         }
         try {
-            // only an http proxy counts: the route planner of the client ignores a socks one, which the
-            // jvm applies at the socket, and the connection is pinned to the vetted address as ever
-            return selector.select(URI.create(url.toString())).stream().anyMatch(proxy -> proxy.type() == Proxy.Type.HTTP);
+            return selector.select(URI.create(url.toString())).stream()
+                    .filter(proxy -> proxy.type() == Proxy.Type.HTTP)
+                    .findFirst()
+                    .map(proxy -> new ProxyDecision(true, hostOf(proxy)))
+                    .orElseGet(() -> new ProxyDecision(false, null));
         } catch (RuntimeException e) {
-            logger.warn("Cannot tell whether '" + url + "' goes through a proxy, it is treated as direct", e);
-            return false;
+            // a selector which cannot answer is no reason to fetch anything past the check
+            logger.warn("Cannot tell whether '" + url + "' goes through a proxy, it is treated as proxied", e);
+            return new ProxyDecision(true, null);
         }
+    }
+
+    @Nullable
+    private HttpHost hostOf(@NotNull Proxy proxy) {
+        if (proxy.address() instanceof InetSocketAddress address) {
+            return new HttpHost(address.getHostString(), address.getPort());
+        }
+        return null;
+    }
+
+    /**
+     * @param proxied whether the url would be requested through an http proxy
+     * @param host    the proxy to route to, null where there is nothing to route to or nothing was told
+     */
+    @VisibleForTesting
+    record ProxyDecision(boolean proxied, @Nullable HttpHost host) {
     }
 
     private String getBaseUrl() {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -108,8 +108,11 @@ public class CustomResourceUrlResolver implements IUrlResolver {
 
     private SchemeAttempt resolveWithScheme(@NotNull String scheme, @NotNull String urlStr) {
         try {
-            // a decision was taken, whether it produced a resource or refused one
-            return new SchemeAttempt(resolveImpl(URI.create(normalizeUrl(scheme + ":" + urlStr)).toURL()), true);
+            URL url = URI.create(normalizeUrl(scheme + ":" + urlStr)).toURL();
+            InputStream stream = resolveImpl(url);
+            // a decision was taken, whether it produced a resource or refused one, unless the refusal
+            // itself turned on the scheme: an allowed host carrying a port is allowed under that port only
+            return new SchemeAttempt(stream, stream != null || !policy.isRefusalPortSpecific(url));
         } catch (Exception e) {
             logger.debug("Failed to load resource " + scheme + ":" + urlStr + ": " + e.getMessage());
             // nothing was decided unless tls itself failed, and then the other scheme is not an answer

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -233,7 +233,9 @@ public class CustomResourceUrlResolver implements IUrlResolver {
             return false;
         }
         try {
-            return selector.select(URI.create(url.toString())).stream().anyMatch(proxy -> proxy.type() != Proxy.Type.DIRECT);
+            // only an http proxy counts: the route planner of the client ignores a socks one, which the
+            // jvm applies at the socket, and the connection is pinned to the vetted address as ever
+            return selector.select(URI.create(url.toString())).stream().anyMatch(proxy -> proxy.type() == Proxy.Type.HTTP);
         } catch (RuntimeException e) {
             logger.warn("Cannot tell whether '" + url + "' goes through a proxy, it is treated as direct", e);
             return false;

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -49,6 +49,8 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     private static final int MAX_REDIRECTS = 5;
     private static final int BUFFER_SIZE = 8192;
     private static final String SKIPPED_RESOURCE = "Skipped resource ";
+    private static final String HTTP_SCHEME = "http";
+    private static final String HTTPS_SCHEME = "https";
 
     private final ResourceUrlPolicy policy;
 
@@ -66,12 +68,38 @@ public class CustomResourceUrlResolver implements IUrlResolver {
 
     public InputStream resolve(@NotNull String urlStr) {
         try {
-            URL url = URI.create(normalizeUrl(ensureAbsoluteUrl(urlStr))).toURL();
-            return resolveImpl(url);
+            if (MediaUtils.isNetworkPathReference(urlStr)) {
+                return resolveNetworkPathReference(urlStr);
+            }
+            return resolveImpl(URI.create(normalizeUrl(ensureAbsoluteUrl(urlStr))).toURL());
         } catch (Exception e) {
             logger.warn("Failed to load resource: " + urlStr, e);
         }
         return null;
+    }
+
+    /**
+     * A reference like {@code //host/path} takes the scheme of the base url the document carries, and
+     * that base is built elsewhere, from the cluster host among other things. Rather than guessing which
+     * one it ends up with, both are tried, each one checked by the policy on its own.
+     */
+    private InputStream resolveNetworkPathReference(@NotNull String urlStr) {
+        String preferredScheme = policy.getBaseUrlScheme();
+        InputStream stream = resolveWithScheme(preferredScheme, urlStr);
+        if (stream != null) {
+            return stream;
+        }
+        return resolveWithScheme(HTTPS_SCHEME.equals(preferredScheme) ? HTTP_SCHEME : HTTPS_SCHEME, urlStr);
+    }
+
+    private InputStream resolveWithScheme(@NotNull String scheme, @NotNull String urlStr) {
+        try {
+            return resolveImpl(URI.create(normalizeUrl(scheme + ":" + urlStr)).toURL());
+        } catch (Exception e) {
+            // the other scheme is tried next, a failure here is not the end of it
+            logger.debug("Failed to load resource " + scheme + ":" + urlStr + ": " + e.getMessage());
+            return null;
+        }
     }
 
     @SneakyThrows
@@ -192,10 +220,6 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     }
 
     private String ensureAbsoluteUrl(String url) {
-        if (MediaUtils.isNetworkPathReference(url)) {
-            // '//host/path' names its own host, only the scheme comes from the Polarion base url
-            return policy.getBaseUrlScheme() + ":" + url;
-        }
         return url.startsWith("/") ? getBaseUrl() + url : url;
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -27,9 +27,12 @@ import java.net.URI;
 import java.net.URL;
 import java.util.stream.Stream;
 
+import java.util.Set;
+
 import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
 import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_SEE_OTHER;
 
 /**
  * Custom version of {@link com.polarion.alm.tracker.internal.url.GenericUrlResolver} with the redirect support.
@@ -49,6 +52,8 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     private static final int MAX_REDIRECTS = 5;
     private static final int BUFFER_SIZE = 8192;
     private static final String SKIPPED_RESOURCE = "Skipped resource ";
+    // every redirect a client follows, the permanent and the temporary ones of both generations
+    private static final Set<Integer> REDIRECT_STATUS_CODES = Set.of(HTTP_MOVED_PERM, HTTP_MOVED_TEMP, HTTP_SEE_OTHER, 307, 308);
     private static final String HTTP_SCHEME = "http";
     private static final String HTTPS_SCHEME = "https";
 
@@ -107,15 +112,15 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     public InputStream resolveImpl(@NotNull URL url) {
         URL currentUrl = url;
         for (int redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
-            InetAddress[] addresses = policy.vetAddresses(currentUrl);
-            if (addresses == null) {
-                return null;
-            }
             if (isProxied(currentUrl) && !policy.isExplicitlyTrusted(currentUrl)) {
                 // A proxy resolves the host name itself, so the vetted addresses would decide nothing.
                 // Only a host the configuration trusts as such may be fetched that way.
                 logger.warn(SKIPPED_RESOURCE + currentUrl + ": it would go through a proxy, which resolves the host name itself."
                         + " List the host in the allowed hosts property to fetch it anyway.");
+                return null;
+            }
+            InetAddress[] addresses = policy.vetAddresses(currentUrl);
+            if (addresses == null) {
                 return null;
             }
             try (CloseableHttpClient client = createClient(currentUrl, addresses);
@@ -124,7 +129,7 @@ public class CustomResourceUrlResolver implements IUrlResolver {
                 if (statusCode == HTTP_OK) {
                     return readContent(response, currentUrl);
                 }
-                if (statusCode != HTTP_MOVED_PERM && statusCode != HTTP_MOVED_TEMP) {
+                if (!REDIRECT_STATUS_CODES.contains(statusCode)) {
                     return null;
                 }
                 Header location = response.getFirstHeader(HttpHeaders.LOCATION);

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -7,6 +7,8 @@ import lombok.SneakyThrows;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -17,11 +19,30 @@ import static java.net.HttpURLConnection.*;
 
 /**
  * Custom version of {@link com.polarion.alm.tracker.internal.url.GenericUrlResolver} with the redirect support.
+ * <p>
+ * Every request passes {@link ResourceUrlPolicy}, which keeps a document editor from making the server
+ * fetch an arbitrary address and from getting the response body back in the exported document.
+ * </p>
  */
 public class CustomResourceUrlResolver implements IUrlResolver {
 
+    private static final Logger logger = Logger.getLogger(CustomResourceUrlResolver.class);
+
     private static final int CONNECTION_TIMEOUT_MS = 3_000;
     private static final int READ_TIMEOUT_MS = 3_000;
+    private static final int MAX_REDIRECTS = 5;
+    private static final int BUFFER_SIZE = 8192;
+
+    private final ResourceUrlPolicy policy;
+
+    public CustomResourceUrlResolver() {
+        this(ResourceUrlPolicy.getInstance());
+    }
+
+    @VisibleForTesting
+    public CustomResourceUrlResolver(@NotNull ResourceUrlPolicy policy) {
+        this.policy = policy;
+    }
 
     public boolean canResolve(@NotNull String url) {
         return Stream.of("/", "http:", "https:").anyMatch(url::startsWith);
@@ -29,10 +50,10 @@ public class CustomResourceUrlResolver implements IUrlResolver {
 
     public InputStream resolve(@NotNull String urlStr) {
         try {
-            URI uri = URI.create(normalizeUrl(ensureAbsoluteUrl(urlStr)));
-            return resolveImpl(uri.toURL());
+            URL url = URI.create(normalizeUrl(ensureAbsoluteUrl(urlStr))).toURL();
+            return resolveImpl(url);
         } catch (Exception e) {
-            Logger.getLogger(this).warn("Failed to load resource: " + urlStr, e);
+            logger.warn("Failed to load resource: " + urlStr, e);
         }
         return null;
     }
@@ -40,20 +61,75 @@ public class CustomResourceUrlResolver implements IUrlResolver {
     @SneakyThrows
     @VisibleForTesting
     public InputStream resolveImpl(@NotNull URL url) {
+        URL currentUrl = url;
+        for (int redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
+            if (!policy.isAllowed(currentUrl)) {
+                return null;
+            }
+            HttpURLConnection connection = openConnection(currentUrl);
+            try {
+                int responseCode = connection.getResponseCode();
+                if (responseCode == HTTP_OK) {
+                    return readContent(connection, currentUrl);
+                }
+                if (responseCode != HTTP_MOVED_PERM && responseCode != HTTP_MOVED_TEMP) {
+                    return null;
+                }
+                String location = connection.getHeaderField("Location");
+                if (StringUtils.isEmptyTrimmed(location)) {
+                    return null;
+                }
+                currentUrl = URI.create(normalizeUrl(currentUrl.toString())).resolve(normalizeUrl(location.trim())).toURL();
+            } finally {
+                connection.disconnect();
+            }
+        }
+        logger.warn("Failed to load resource: " + url + ", more than " + MAX_REDIRECTS + " redirects");
+        return null;
+    }
+
+    @SneakyThrows
+    private HttpURLConnection openConnection(@NotNull URL url) {
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setConnectTimeout(CONNECTION_TIMEOUT_MS);
         connection.setReadTimeout(READ_TIMEOUT_MS);
+        // redirects are followed by this class, so that the policy sees every single hop
+        connection.setInstanceFollowRedirects(false);
         connection.connect();
-        int responseCode = connection.getResponseCode();
-        if (responseCode == HTTP_OK) {
-            return connection.getInputStream();
-        } else if (responseCode == HTTP_MOVED_PERM || responseCode == HTTP_MOVED_TEMP) {
-            String location = connection.getHeaderField("Location");
-            if (location != null && canResolve(location)) {
-                return resolve(location);
+        return connection;
+    }
+
+    /**
+     * Reads at most {@link ResourceUrlPolicy#getMaxResourceBytes()} bytes. The content is fully read here
+     * because the connection is closed as soon as this method returns.
+     */
+    @SneakyThrows
+    private InputStream readContent(@NotNull HttpURLConnection connection, @NotNull URL url) {
+        String contentType = connection.getContentType();
+        if (!policy.isAllowedContentType(contentType)) {
+            logger.warn("Skipped resource " + url + ": the content type '" + contentType + "' is not an image, a font or a stylesheet");
+            return null;
+        }
+
+        long maxBytes = policy.getMaxResourceBytes();
+        if (connection.getContentLengthLong() > maxBytes) {
+            logger.warn("Skipped resource " + url + ": it is larger than " + maxBytes + " bytes");
+            return null;
+        }
+
+        ByteArrayOutputStream content = new ByteArrayOutputStream();
+        byte[] buffer = new byte[BUFFER_SIZE];
+        try (InputStream inputStream = connection.getInputStream()) {
+            int read;
+            while ((read = inputStream.read(buffer)) != -1) {
+                if (content.size() + read > maxBytes) {
+                    logger.warn("Skipped resource " + url + ": it is larger than " + maxBytes + " bytes");
+                    return null;
+                }
+                content.write(buffer, 0, read);
             }
         }
-        return null;
+        return new ByteArrayInputStream(content.toByteArray());
     }
 
     private String ensureAbsoluteUrl(String url) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/FileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/FileResourceProvider.java
@@ -10,4 +10,12 @@ public interface FileResourceProvider {
 
     byte[] getResourceAsBytes(@NotNull String resource);
 
+    /**
+     * Tells whether the resource policy forbids requesting this URL. Such a URL must not be left in the
+     * HTML either: WeasyPrint would then load it from its own network position.
+     */
+    default boolean isForbidden(@NotNull String resource) {
+        return false;
+    }
+
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -1430,6 +1430,13 @@ public class HtmlProcessor {
         return MediaUtils.inlineBase64Resources(html, fileResourceProvider);
     }
 
+    /**
+     * The same for a value which is a stylesheet rather than a document, a cover page style for one.
+     */
+    public String replaceCssResourcesAsBase64Encoded(String css) {
+        return MediaUtils.inlineCssResources(css, fileResourceProvider);
+    }
+
     public String internalizeLinks(String html) {
         return httpLinksHelper.internalizeLinks(html);
     }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -42,6 +42,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.function.BiFunction;
 
 import static ch.sbb.polarion.extension.pdf_exporter.util.TikaMimeTypeResolver.PARAM_RESULT;
@@ -67,6 +69,7 @@ public class MediaUtils {
     public static final String CSS_IMPORT_URL_REGEX = "(?i)@import" + CSS_AT_RULE_SEPARATOR + "url\\((?<url>[^)]*)\\)[^;]*;?";
     public static final String DATA_URL_PREFIX = "data:";
     private static final String NETWORK_PATH_PREFIX = "//";
+    private static final Pattern CSS_ESCAPE_PATTERN = Pattern.compile("\\\\(?:([0-9a-fA-F]{1,6})[ \\t\\r\\n\\f]?|(.))", Pattern.DOTALL);
     private static final String COMMENT_START = "/*";
     private static final String COMMENT_END = "*/";
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
@@ -283,6 +286,25 @@ public class MediaUtils {
     /**
      * Check whether particular string is a <a href="https://www.rfc-editor.org/rfc/rfc2397">'data' URL</a>-encoded entry.
      */
+    /**
+     * Resolves the CSS escapes of a value, {@code http\\3a //host} and the like. A stylesheet reaches
+     * WeasyPrint as text, and WeasyPrint resolves them, so the check has to see the same value.
+     */
+    public String decodeCssEscapes(@NotNull String value) {
+        if (value.indexOf('\\') < 0) {
+            return value;
+        }
+        Matcher matcher = CSS_ESCAPE_PATTERN.matcher(value);
+        StringBuilder decoded = new StringBuilder();
+        while (matcher.find()) {
+            String hex = matcher.group(1);
+            String replacement = hex != null ? Character.toString(Integer.parseInt(hex, 16)) : matcher.group(2);
+            matcher.appendReplacement(decoded, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(decoded);
+        return decoded.toString();
+    }
+
     public boolean isDataUrl(@Nullable String resourceUrl) {
         return resourceUrl != null && resourceUrl.startsWith(DATA_URL_PREFIX);
     }
@@ -343,7 +365,7 @@ public class MediaUtils {
      */
     @NotNull
     public String unwrapCssUrl(@NotNull String url) {
-        String unwrapped = url.trim();
+        String unwrapped = decodeCssEscapes(url).trim();
         while (unwrapped.startsWith(COMMENT_START) && unwrapped.contains(COMMENT_END)) {
             unwrapped = unwrapped.substring(unwrapped.indexOf(COMMENT_END) + COMMENT_END.length()).trim();
         }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -518,12 +518,9 @@ public class MediaUtils {
 
     private boolean mayReferenceAResource(@NotNull String css) {
         String probe = decodeCssEscapes(css).toLowerCase(Locale.ROOT);
-        if (probe.contains("url(") || probe.contains("@import")) {
-            return true;
-        }
-        // an address of its own still has to reach the backstop, but the payload of a data url is the
-        // resource itself and an SVG in one names the namespace of SVG: that is no address to check
-        return namesAnAbsoluteAddress(probe.replaceAll("(?is)url\\([^)]*\\)", ""));
+        // an address of its own still has to reach the backstop, which is what judges whether anything
+        // accounted for it: the payload of a data url is exempted there, by the range of the url() term
+        return probe.contains("url(") || probe.contains("@import") || namesAnAbsoluteAddress(probe);
     }
 
     /**
@@ -560,34 +557,32 @@ public class MediaUtils {
                 .filter(Objects::nonNull)
                 .map(range -> selectorOf(css, range))
                 .forEach(ranges::add);
+        ranges.addAll(readStringRangesOf(css, stylesheet, lineStarts));
 
-        StringBuilder probe = new StringBuilder(css);
-        ranges.stream()
-                .sorted((left, right) -> Integer.compare(right.start(), left.start()))
-                .forEach(range -> probe.replace(range.start(), range.end(), " "));
-        String text = stripCssComments(probe.toString());
-        for (String readString : readStringsOf(stylesheet)) {
-            text = text.replace(readString, "");
-        }
-        return namesAnAbsoluteAddress(text);
+        // each range keeps its length, so one range never moves another and an overlap changes nothing
+        char[] probe = css.toCharArray();
+        ranges.forEach(range -> Arrays.fill(probe, range.start(), range.end(), ' '));
+        return namesAnAbsoluteAddress(stripCssComments(new String(probe)));
     }
 
     /**
-     * @return the string values the parser read, which are text: css fetches nothing from a string
+     * @return where the parser read a string, which is text: css fetches nothing from a string
      */
-    private List<String> readStringsOf(@NotNull CascadingStyleSheet stylesheet) {
-        List<String> readStrings = new ArrayList<>();
+    private List<CssRange> readStringRangesOf(@NotNull String css, @NotNull CascadingStyleSheet stylesheet, int[] lineStarts) {
+        List<CssRange> ranges = new ArrayList<>();
         CSSVisitor.visitCSS(stylesheet, new DefaultCSSVisitor() {
             @Override
             public void onDeclaration(@NotNull CSSDeclaration declaration) {
                 declaration.getExpression().getAllMembers().stream()
                         .filter(CSSExpressionMemberTermSimple.class::isInstance)
-                        .map(member -> ((CSSExpressionMemberTermSimple) member).getValue())
-                        .filter(value -> value.startsWith("\"") || value.startsWith("'"))
-                        .forEach(readStrings::add);
+                        .map(CSSExpressionMemberTermSimple.class::cast)
+                        .filter(member -> member.getValue().startsWith("\"") || member.getValue().startsWith("'"))
+                        .map(member -> rangeOf(lineStarts, css, member.getSourceLocation()))
+                        .filter(Objects::nonNull)
+                        .forEach(ranges::add);
             }
         });
-        return readStrings;
+        return ranges;
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -357,7 +357,9 @@ public class MediaUtils {
      * @return what the url of a resource has to be replaced with, null when it may stay as it is
      */
     @Nullable
-    private String replacementFor(@NotNull FileResourceProvider fileResourceProvider, @NotNull String url) {
+    private String replacementFor(@NotNull FileResourceProvider fileResourceProvider, @NotNull String rawUrl) {
+        // the document may write a url with whitespace around it, every step below has to see the same one
+        String url = rawUrl.trim();
         if (isDataUrl(url)) {
             return null;
         }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -510,25 +510,13 @@ public class MediaUtils {
      */
     private String stripCssComments(@NotNull String css) {
         StringBuilder result = new StringBuilder(css.length());
-        char quote = 0;
         int i = 0;
         while (i < css.length()) {
             char current = css.charAt(i);
-            if (quote != 0) {
-                result.append(current);
-                if (current == '\\' && i + 1 < css.length()) {
-                    result.append(css.charAt(++i));
-                } else if (current == quote) {
-                    quote = 0;
-                }
-                i++;
-            } else if (current == '"' || current == '\'') {
-                quote = current;
-                result.append(current);
-                i++;
-            } else if (current == '/' && i + 1 < css.length() && css.charAt(i + 1) == '*') {
-                int end = css.indexOf("*/", i + 2);
-                i = end < 0 ? css.length() : end + 2;
+            if (current == '"' || current == '\'') {
+                i = appendString(css, i, result);
+            } else if (isCommentStart(css, i)) {
+                i = endOfComment(css, i);
             } else {
                 result.append(current);
                 i++;
@@ -536,6 +524,32 @@ public class MediaUtils {
         }
         return result.toString();
     }
+
+    private boolean isCommentStart(@NotNull String css, int index) {
+        return css.charAt(index) == '/' && index + 1 < css.length() && css.charAt(index + 1) == '*';
+    }
+
+    private int endOfComment(@NotNull String css, int index) {
+        int end = css.indexOf("*/", index + 2);
+        return end < 0 ? css.length() : end + 2;
+    }
+
+    private int appendString(@NotNull String css, int index, @NotNull StringBuilder result) {
+        char quote = css.charAt(index);
+        result.append(quote);
+        int i = index + 1;
+        while (i < css.length()) {
+            char current = css.charAt(i++);
+            result.append(current);
+            if (current == '\\' && i < css.length()) {
+                result.append(css.charAt(i++));
+            } else if (current == quote) {
+                break;
+            }
+        }
+        return i;
+    }
+
 
     /**
      * Hands the parts of an HTML document which are CSS, a style element and a style attribute, to the

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -5,6 +5,7 @@ import ch.sbb.polarion.extension.generic.util.BundleJarsPrioritizingRunnable;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
 import com.helger.css.CSSSourceLocation;
 import com.helger.css.ICSSSourceLocationAware;
+import com.helger.css.decl.CSSStyleRule;
 import com.helger.css.decl.CSSUnknownRule;
 import com.helger.css.decl.ICSSExpressionMember;
 import com.helger.css.decl.CSSDeclaration;
@@ -557,7 +558,7 @@ public class MediaUtils {
                 .filter(Objects::nonNull)
                 .map(range -> selectorOf(css, range))
                 .forEach(ranges::add);
-        ranges.addAll(readStringRangesOf(css, stylesheet, lineStarts));
+        ranges.addAll(textRangesOf(css, stylesheet, lineStarts));
 
         // each range keeps its length, so one range never moves another and an overlap changes nothing
         char[] probe = css.toCharArray();
@@ -566,11 +567,20 @@ public class MediaUtils {
     }
 
     /**
-     * @return where the parser read a string, which is text: css fetches nothing from a string
+     * @return where the parser read something which fetches nothing: a string, and the selector of a
+     * style rule at any depth, which the top-level pass does not reach inside a grouping at-rule
      */
-    private List<CssRange> readStringRangesOf(@NotNull String css, @NotNull CascadingStyleSheet stylesheet, int[] lineStarts) {
+    private List<CssRange> textRangesOf(@NotNull String css, @NotNull CascadingStyleSheet stylesheet, int[] lineStarts) {
         List<CssRange> ranges = new ArrayList<>();
         CSSVisitor.visitCSS(stylesheet, new DefaultCSSVisitor() {
+            @Override
+            public void onBeginStyleRule(@NotNull CSSStyleRule styleRule) {
+                CssRange range = rangeOf(lineStarts, css, styleRule.getSourceLocation());
+                if (range != null) {
+                    ranges.add(selectorOf(css, range));
+                }
+            }
+
             @Override
             public void onDeclaration(@NotNull CSSDeclaration declaration) {
                 declaration.getExpression().getAllMembers().stream()

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -3,6 +3,18 @@ package ch.sbb.polarion.extension.pdf_exporter.util;
 import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.generic.util.BundleJarsPrioritizingRunnable;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
+import com.helger.css.decl.CSSDeclaration;
+import com.helger.css.decl.CSSExpressionMemberTermURI;
+import com.helger.css.decl.CascadingStyleSheet;
+import com.helger.css.decl.ICSSTopLevelRule;
+import com.helger.css.decl.visit.CSSVisitor;
+import com.helger.css.decl.visit.DefaultCSSUrlVisitor;
+import com.helger.css.handler.DoNothingCSSParseExceptionCallback;
+import com.helger.css.reader.CSSReader;
+import com.helger.css.reader.CSSReaderSettings;
+import com.helger.css.reader.errorhandler.DoNothingCSSParseErrorHandler;
+import com.helger.css.writer.CSSWriter;
+import com.helger.css.writer.CSSWriterSettings;
 import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.PdfVariant;
 import ch.sbb.polarion.extension.pdf_exporter.service.PdfExporterPolarionService;
@@ -44,7 +56,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
 
 import static ch.sbb.polarion.extension.pdf_exporter.util.TikaMimeTypeResolver.PARAM_RESULT;
 import static ch.sbb.polarion.extension.pdf_exporter.util.TikaMimeTypeResolver.PARAM_VALUE;
@@ -53,27 +67,10 @@ import static ch.sbb.polarion.extension.pdf_exporter.util.TikaMimeTypeResolver.P
 public class MediaUtils {
     public static final String IMG_SRC_REGEX = "<img[^<>]*src=(\"|')(?<url>[^(\"|')]*)(\"|')";
     public static final String URL_REGEX = "(?i)url\\(\\s*([\"'])?(?<url>.*?)\\1?\\s*\\)";
-    /**
-     * What CSS allows between {@code @import} and its target: nothing, whitespace or a comment.
-     */
-    private static final String CSS_AT_RULE_SEPARATOR = "(?:\\s|/\\*[\\s\\S]*?\\*/)*";
-    /**
-     * {@code @import "..."} without the {@code url(...)} wrapper, which {@link #URL_REGEX} does not match.
-     * The trailing {@code [^;]*} swallows a media condition, so the whole at-rule goes when it is dropped.
-     */
-    public static final String CSS_IMPORT_REGEX = "(?i)@import" + CSS_AT_RULE_SEPARATOR + "([\"'])(?<url>[^\"']+)\\1[^;]*;?";
-    /**
-     * {@code @import url(...)}. {@link #URL_REGEX} matches its url as well, but only this one can drop
-     * the whole at-rule, media condition included.
-     */
-    public static final String CSS_IMPORT_URL_REGEX = "(?i)@import" + CSS_AT_RULE_SEPARATOR + "url\\((?<url>[^)]*)\\)[^;]*;?";
     public static final String DATA_URL_PREFIX = "data:";
     private static final String NETWORK_PATH_PREFIX = "//";
-    private static final Pattern STYLE_ELEMENT_PATTERN = Pattern.compile("(?is)(<style[^>]*>)(.*?)(</style>)");
-    private static final Pattern STYLE_ATTRIBUTE_PATTERN = Pattern.compile("(?i)style=([\"'])([^\"']*)\\1");
+    private static final String STYLE_ATTRIBUTE = "style=";
     private static final Pattern CSS_ESCAPE_PATTERN = Pattern.compile("\\\\(?:([0-9a-fA-F]{1,6})[ \\t\\r\\n\\f]?|(.))", Pattern.DOTALL);
-    private static final String COMMENT_START = "/*";
-    private static final String COMMENT_END = "*/";
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
     /**
      * A 1x1 transparent PNG which replaces a resource the {@link ResourceUrlPolicy} rejected.
@@ -286,9 +283,6 @@ public class MediaUtils {
     }
 
     /**
-     * Check whether particular string is a <a href="https://www.rfc-editor.org/rfc/rfc2397">'data' URL</a>-encoded entry.
-     */
-    /**
      * Resolves the CSS escapes of a value, {@code http\\3a //host} and the like. A stylesheet reaches
      * WeasyPrint as text, and WeasyPrint resolves them, so the check has to see the same value.
      */
@@ -328,134 +322,167 @@ public class MediaUtils {
         return valid ? Character.toString(value) : "\uFFFD";
     }
 
+    /**
+     * Check whether particular string is a <a href="https://www.rfc-editor.org/rfc/rfc2397">'data' URL</a>-encoded entry.
+     */
     public boolean isDataUrl(@Nullable String resourceUrl) {
         return resourceUrl != null && resourceUrl.startsWith(DATA_URL_PREFIX);
     }
 
     public String inlineBase64Resources(String content, FileResourceProvider fileResourceProvider) {
-        // A comment may sit anywhere in CSS, a ')' or a quote inside one would derail every pattern
-        // below. They carry no meaning for the conversion, so they go first.
-        content = stripCommentsInCssRegions(content);
         // replace tags like <img src="...
-        String result = RegexMatcher.get(IMG_SRC_REGEX).replace(content, replacement(fileResourceProvider, false));
-        // An at-rule is never inlined, so any absolute target has to go: a forbidden one because the
-        // policy rejected it, an allowed one because WeasyPrint would then load it from its own network
-        // position, with none of the checks this class applies. A relative target stays.
-        RegexMatcher.IReplacementCalculator importReplacement = engine ->
-                isAbsoluteHttpUrl(unwrapCssUrl(engine.group("url"))) ? "" : null;
-        result = RegexMatcher.get(CSS_IMPORT_URL_REGEX).useJavaUtil().replace(result, importReplacement);
-        result = RegexMatcher.get(CSS_IMPORT_REGEX).useJavaUtil().replace(result, importReplacement);
-        // replace CSS parameters like background: src('/polarion/...
-        return RegexMatcher.get(URL_REGEX).useJavaUtil().replace(result, replacement(fileResourceProvider, true));
+        String result = RegexMatcher.get(IMG_SRC_REGEX).replace(content, imageReplacement(fileResourceProvider));
+        // the css of the document is read by a parser, see inlineCssResources
+        return processCssRegions(result, css -> inlineCssResources(css, fileResourceProvider));
     }
 
-    private RegexMatcher.IReplacementCalculator replacement(FileResourceProvider fileResourceProvider, boolean css) {
+    private RegexMatcher.IReplacementCalculator imageReplacement(FileResourceProvider fileResourceProvider) {
         return engine -> {
-            String rawUrl = engine.group("url");
-            if (rawUrl == null || rawUrl.isEmpty()) {
+            String url = engine.group("url");
+            if (url == null || url.isEmpty() || MediaUtils.isDataUrl(url)) {
                 return null;
             }
-            return inlineOrBlock(fileResourceProvider, engine.group(), rawUrl, css ? unwrapCssUrl(rawUrl) : rawUrl);
+            String replacement = replacementFor(fileResourceProvider, url);
+            return replacement == null ? null : engine.group().replace(url, replacement);
         };
     }
 
-    private String inlineOrBlock(@NotNull FileResourceProvider fileResourceProvider, @NotNull String match, @NotNull String rawUrl, @NotNull String url) {
-        if (MediaUtils.isDataUrl(url)) {
-            return null;
-        }
-        String base64String = inline(fileResourceProvider, url);
-        if (base64String != null) {
-            return match.replace(rawUrl, base64String);
-        }
-        // An absolute url which was not inlined, whatever the reason, must not stay in the HTML:
-        // WeasyPrint would load it from its own network position. A relative url is left untouched,
-        // WeasyPrint cannot resolve it.
-        return isAbsoluteHttpUrl(url) ? match.replace(rawUrl, BLOCKED_RESOURCE_PLACEHOLDER) : null;
-    }
-
+    /**
+     * @return what the url of a resource has to be replaced with, null when it may stay as it is
+     */
     @Nullable
-    private String inline(@NotNull FileResourceProvider fileResourceProvider, @NotNull String url) {
-        if (fileResourceProvider.isForbidden(url)) {
+    private String replacementFor(@NotNull FileResourceProvider fileResourceProvider, @NotNull String url) {
+        if (isDataUrl(url)) {
             return null;
         }
-        // For renderable images (e.g. .png, .svg) strip 'thumbnail' to fetch full-size content.
-        // For everything else (spreadsheets, documents, unknown formats) keep 'thumbnail' so Polarion returns an icon preview.
-        String resourceUrl = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
-        return fileResourceProvider.getResourceAsBase64String(resourceUrl);
-    }
-
-    /**
-     * Takes the target out of a CSS url value. A comment is allowed on either side of it, and a quote
-     * stays in the value whenever a comment kept the pattern from capturing it separately. Only the
-     * leading and the trailing comment go, a url may well carry the very same characters in its path.
-     */
-    @NotNull
-    public String unwrapCssUrl(@NotNull String url) {
-        String unwrapped = decodeCssEscapes(url).trim();
-        while (unwrapped.startsWith(COMMENT_START) && unwrapped.contains(COMMENT_END)) {
-            unwrapped = unwrapped.substring(unwrapped.indexOf(COMMENT_END) + COMMENT_END.length()).trim();
-        }
-        while (unwrapped.endsWith(COMMENT_END) && unwrapped.lastIndexOf(COMMENT_START) > 0) {
-            unwrapped = unwrapped.substring(0, unwrapped.lastIndexOf(COMMENT_START)).trim();
-        }
-        if (unwrapped.length() > 1 && (unwrapped.startsWith("\"") && unwrapped.endsWith("\"")
-                || unwrapped.startsWith("'") && unwrapped.endsWith("'"))) {
-            unwrapped = unwrapped.substring(1, unwrapped.length() - 1).trim();
-        }
-        return unwrapped;
-    }
-
-    /**
-     * Removes CSS comments from a stylesheet. A quoted string keeps what it holds, CSS starts no comment
-     * in there, and an unterminated comment runs to the end, as CSS says it does.
-     */
-    public String stripCssComments(@NotNull String css) {
-        if (!css.contains(COMMENT_START)) {
-            return css;
-        }
-        StringBuilder result = new StringBuilder(css.length());
-        char quote = 0;
-        for (int i = 0; i < css.length(); i++) {
-            char current = css.charAt(i);
-            if (quote != 0) {
-                result.append(current);
-                if (current == '\\' && i + 1 < css.length()) {
-                    result.append(css.charAt(++i));
-                } else if (current == quote) {
-                    quote = 0;
-                }
-            } else if (current == '"' || current == '\'') {
-                quote = current;
-                result.append(current);
-            } else if (current == '/' && i + 1 < css.length() && css.charAt(i + 1) == '*') {
-                int end = css.indexOf(COMMENT_END, i + 2);
-                i = end < 0 ? css.length() : end + 1;
-            } else {
-                result.append(current);
+        if (!fileResourceProvider.isForbidden(url)) {
+            // For renderable images (e.g. .png, .svg) strip 'thumbnail' to fetch full-size content.
+            // For everything else (spreadsheets, documents, unknown formats) keep 'thumbnail' so Polarion returns an icon preview.
+            String resourceUrl = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
+            String base64String = fileResourceProvider.getResourceAsBase64String(resourceUrl);
+            if (base64String != null) {
+                return base64String;
             }
         }
-        return result.toString();
+        // An absolute url which was not inlined, whatever the reason, must not stay in the document:
+        // WeasyPrint would load it from its own network position. A relative url is left
+        // untouched, the service cannot resolve it.
+        return isAbsoluteHttpUrl(url) ? BLOCKED_RESOURCE_PLACEHOLDER : null;
     }
 
     /**
-     * Removes CSS comments from the parts of an HTML document which are CSS, a style element and a style
-     * attribute. Everything else, a script or the text of the document, keeps what it has.
+     * Rewrites the resources a stylesheet points at: every url is inlined, replaced by the placeholder or
+     * left alone, and an {@code @import} of an absolute address is removed, since an at-rule is never
+     * inlined and WeasyPrint would load it itself.
+     * <p>
+     * The stylesheet is parsed rather than matched. A comment, an escape or a media condition may sit
+     * almost anywhere in CSS, and a pattern that survives all of them does not exist.
+     * </p>
      */
-    private String stripCommentsInCssRegions(@NotNull String html) {
-        String result = replaceGroup(STYLE_ELEMENT_PATTERN, html, 2);
-        return replaceGroup(STYLE_ATTRIBUTE_PATTERN, result, 2);
+    public String inlineCssResources(@NotNull String css, @NotNull FileResourceProvider fileResourceProvider) {
+        CSSReaderSettings settings = new CSSReaderSettings()
+                // a browser keeps what it understands and skips the rest, and so does the conversion service
+                .setBrowserCompliantMode(true)
+                .setCustomErrorHandler(new DoNothingCSSParseErrorHandler())
+                .setCustomExceptionHandler(new DoNothingCSSParseExceptionCallback());
+        CascadingStyleSheet stylesheet = CSSReader.readFromStringReader(css, settings);
+        if (stylesheet == null) {
+            logger.warn("Dropped a stylesheet which cannot be parsed, the resources it points at cannot be checked");
+            return "";
+        }
+        AtomicBoolean changed = new AtomicBoolean(false);
+        for (int i = stylesheet.getImportRuleCount() - 1; i >= 0; i--) {
+            if (isAbsoluteHttpUrl(stylesheet.getImportRuleAtIndex(i).getLocationString())) {
+                stylesheet.removeImportRule(i);
+                changed.set(true);
+            }
+        }
+        CSSVisitor.visitCSSUrl(stylesheet, new DefaultCSSUrlVisitor() {
+            @Override
+            public void onUrlDeclaration(@Nullable ICSSTopLevelRule topLevelRule, @NotNull CSSDeclaration declaration, @NotNull CSSExpressionMemberTermURI uri) {
+                String replacement = replacementFor(fileResourceProvider, uri.getURIString());
+                if (replacement != null && !replacement.equals(uri.getURIString())) {
+                    uri.setURIString(replacement);
+                    changed.set(true);
+                }
+            }
+        });
+        String result = changed.get() ? new CSSWriter(new CSSWriterSettings()).setWriteHeaderText(false).getCSSAsString(stylesheet) : css;
+        if (pointsAtAnAbsoluteAddress(result)) {
+            // The parser did not surface this address, so nothing checked it. Whatever syntax hid it from
+            // the parser, WeasyPrint may well understand, so the stylesheet does not go on.
+            logger.warn("Dropped a stylesheet: it points at an absolute address which could not be read as a resource");
+            return "";
+        }
+        return result;
     }
 
-    private String replaceGroup(@NotNull Pattern pattern, @NotNull String content, int group) {
-        Matcher matcher = pattern.matcher(content);
-        StringBuilder result = new StringBuilder();
-        while (matcher.find()) {
-            String css = matcher.group(group);
-            String replacement = matcher.group().replace(css, stripCssComments(css));
-            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+    /**
+     * Tells whether a stylesheet still names an absolute address after every url of it was rewritten.
+     * Nothing may: an allowed one is embedded as a data url by then, a rejected one is the placeholder,
+     * and an import of one is removed. So one that is left is one nothing understood.
+     */
+    private boolean pointsAtAnAbsoluteAddress(@NotNull String css) {
+        String probe = decodeCssEscapes(css).toLowerCase(Locale.ROOT).replaceAll("data:[^)\"';\\s]*", "");
+        return probe.contains("http:") || probe.contains("https:") || probe.contains(NETWORK_PATH_PREFIX);
+    }
+
+    /**
+     * Hands the parts of an HTML document which are CSS, a style element and a style attribute, to the
+     * given rewriting. Everything else, a script or the text of the document, stays as it is. The regions
+     * are found by scanning: a pattern over a whole document is one more thing an editor could make slow.
+     */
+    private String processCssRegions(@NotNull String html, @NotNull UnaryOperator<String> rewrite) {
+        return processStyleAttributes(processStyleElements(html, rewrite), rewrite);
+    }
+
+    private String processStyleElements(@NotNull String html, @NotNull UnaryOperator<String> rewrite) {
+        String lowerCased = html.toLowerCase(Locale.ROOT);
+        StringBuilder result = new StringBuilder(html.length());
+        int index = 0;
+        int start;
+        while ((start = lowerCased.indexOf("<style", index)) >= 0) {
+            int contentStart = html.indexOf('>', start);
+            int contentEnd = contentStart < 0 ? -1 : lowerCased.indexOf("</style", contentStart);
+            if (contentEnd < 0) {
+                break;
+            }
+            result.append(html, index, contentStart + 1).append(rewrite.apply(html.substring(contentStart + 1, contentEnd)));
+            index = contentEnd;
         }
-        matcher.appendTail(result);
-        return result.toString();
+        return result.append(html, index, html.length()).toString();
+    }
+
+    private String processStyleAttributes(@NotNull String html, @NotNull UnaryOperator<String> rewrite) {
+        String lowerCased = html.toLowerCase(Locale.ROOT);
+        StringBuilder result = new StringBuilder(html.length());
+        int index = 0;
+        int start;
+        while ((start = lowerCased.indexOf(STYLE_ATTRIBUTE, index)) >= 0) {
+            int quoteAt = start + STYLE_ATTRIBUTE.length();
+            char quote = quoteAt < html.length() ? html.charAt(quoteAt) : 0;
+            int valueEnd = quote == '"' || quote == '\'' ? html.indexOf(quote, quoteAt + 1) : -1;
+            if (valueEnd < 0) {
+                result.append(html, index, quoteAt);
+                index = quoteAt;
+                continue;
+            }
+            result.append(html, index, quoteAt + 1).append(rewriteDeclarations(html.substring(quoteAt + 1, valueEnd), rewrite));
+            index = valueEnd;
+        }
+        return result.append(html, index, html.length()).toString();
+    }
+
+    /**
+     * The value of a style attribute is a declaration list, not a stylesheet, so it is wrapped into a rule
+     * for the parser and unwrapped afterwards.
+     */
+    private String rewriteDeclarations(@NotNull String declarations, @NotNull UnaryOperator<String> rewrite) {
+        String rewritten = rewrite.apply("a{" + declarations + "}").trim();
+        int open = rewritten.indexOf('{');
+        int close = rewritten.lastIndexOf('}');
+        // an empty or unexpected result means the declarations were dropped, they do not come back
+        return open < 0 || close < open ? "" : rewritten.substring(open + 1, close).trim();
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -298,12 +298,23 @@ public class MediaUtils {
         StringBuilder decoded = new StringBuilder();
         while (matcher.find()) {
             String hex = matcher.group(1);
-            // the pattern caps the escape at six hex digits, so the value always fits into an int
-            String replacement = hex != null ? codePointOf(Integer.parseInt(hex, 16)) : matcher.group(2);
+            String replacement = hex != null ? codePointOf(hexValueOf(hex)) : matcher.group(2);
             matcher.appendReplacement(decoded, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(decoded);
         return decoded.toString();
+    }
+
+    /**
+     * Reads the hex digits of a CSS escape. The pattern caps them at six, so the value fits into an int,
+     * and every character it captured is a hex digit, so there is nothing here that could fail.
+     */
+    private int hexValueOf(@NotNull String hex) {
+        int value = 0;
+        for (int i = 0; i < hex.length(); i++) {
+            value = (value << 4) + Character.digit(hex.charAt(i), 16);
+        }
+        return value;
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -52,15 +52,19 @@ public class MediaUtils {
     public static final String IMG_SRC_REGEX = "<img[^<>]*src=(\"|')(?<url>[^(\"|')]*)(\"|')";
     public static final String URL_REGEX = "(?i)url\\(\\s*([\"'])?(?<url>.*?)\\1?\\s*\\)";
     /**
+     * What CSS allows between {@code @import} and its target: nothing, whitespace or a comment.
+     */
+    private static final String CSS_AT_RULE_SEPARATOR = "(?:\\s|/\\*[\\s\\S]*?\\*/)*";
+    /**
      * {@code @import "..."} without the {@code url(...)} wrapper, which {@link #URL_REGEX} does not match.
      * The trailing {@code [^;]*} swallows a media condition, so the whole at-rule goes when it is dropped.
      */
-    public static final String CSS_IMPORT_REGEX = "(?i)@import\\s+([\"'])(?<url>[^\"']+)\\1[^;]*;?";
+    public static final String CSS_IMPORT_REGEX = "(?i)@import" + CSS_AT_RULE_SEPARATOR + "([\"'])(?<url>[^\"']+)\\1[^;]*;?";
     /**
      * {@code @import url(...)}. {@link #URL_REGEX} matches its url as well, but only this one can drop
      * the whole at-rule, media condition included.
      */
-    public static final String CSS_IMPORT_URL_REGEX = "(?i)@import\\s+url\\(\\s*([\"'])?(?<url>[^\"')]+)\\1?\\s*\\)[^;]*;?";
+    public static final String CSS_IMPORT_URL_REGEX = "(?i)@import" + CSS_AT_RULE_SEPARATOR + "url\\(\\s*([\"'])?(?<url>[^\"')]+)\\1?\\s*\\)[^;]*;?";
     public static final String DATA_URL_PREFIX = "data:";
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -69,6 +69,8 @@ public class MediaUtils {
     public static final String CSS_IMPORT_URL_REGEX = "(?i)@import" + CSS_AT_RULE_SEPARATOR + "url\\((?<url>[^)]*)\\)[^;]*;?";
     public static final String DATA_URL_PREFIX = "data:";
     private static final String NETWORK_PATH_PREFIX = "//";
+    private static final Pattern STYLE_ELEMENT_PATTERN = Pattern.compile("(?is)(<style[^>]*>)(.*?)(</style>)");
+    private static final Pattern STYLE_ATTRIBUTE_PATTERN = Pattern.compile("(?i)style=([\"'])([^\"']*)\\1");
     private static final Pattern CSS_ESCAPE_PATTERN = Pattern.compile("\\\\(?:([0-9a-fA-F]{1,6})[ \\t\\r\\n\\f]?|(.))", Pattern.DOTALL);
     private static final String COMMENT_START = "/*";
     private static final String COMMENT_END = "*/";
@@ -331,6 +333,9 @@ public class MediaUtils {
     }
 
     public String inlineBase64Resources(String content, FileResourceProvider fileResourceProvider) {
+        // A comment may sit anywhere in CSS, a ')' or a quote inside one would derail every pattern
+        // below. They carry no meaning for the conversion, so they go first.
+        content = stripCommentsInCssRegions(content);
         // replace tags like <img src="...
         String result = RegexMatcher.get(IMG_SRC_REGEX).replace(content, replacement(fileResourceProvider, false));
         // An at-rule is never inlined, so any absolute target has to go: a forbidden one because the
@@ -398,6 +403,59 @@ public class MediaUtils {
             unwrapped = unwrapped.substring(1, unwrapped.length() - 1).trim();
         }
         return unwrapped;
+    }
+
+    /**
+     * Removes CSS comments from a stylesheet. A quoted string keeps what it holds, CSS starts no comment
+     * in there, and an unterminated comment runs to the end, as CSS says it does.
+     */
+    public String stripCssComments(@NotNull String css) {
+        if (!css.contains(COMMENT_START)) {
+            return css;
+        }
+        StringBuilder result = new StringBuilder(css.length());
+        char quote = 0;
+        for (int i = 0; i < css.length(); i++) {
+            char current = css.charAt(i);
+            if (quote != 0) {
+                result.append(current);
+                if (current == '\\' && i + 1 < css.length()) {
+                    result.append(css.charAt(++i));
+                } else if (current == quote) {
+                    quote = 0;
+                }
+            } else if (current == '"' || current == '\'') {
+                quote = current;
+                result.append(current);
+            } else if (current == '/' && i + 1 < css.length() && css.charAt(i + 1) == '*') {
+                int end = css.indexOf(COMMENT_END, i + 2);
+                i = end < 0 ? css.length() : end + 1;
+            } else {
+                result.append(current);
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * Removes CSS comments from the parts of an HTML document which are CSS, a style element and a style
+     * attribute. Everything else, a script or the text of the document, keeps what it has.
+     */
+    private String stripCommentsInCssRegions(@NotNull String html) {
+        String result = replaceGroup(STYLE_ELEMENT_PATTERN, html, 2);
+        return replaceGroup(STYLE_ATTRIBUTE_PATTERN, result, 2);
+    }
+
+    private String replaceGroup(@NotNull Pattern pattern, @NotNull String content, int group) {
+        Matcher matcher = pattern.matcher(content);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String css = matcher.group(group);
+            String replacement = matcher.group().replace(css, stripCssComments(css));
+            matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(result);
+        return result.toString();
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -384,12 +384,7 @@ public class MediaUtils {
             // style attribute of a large document is not worth a parser run for that
             return css;
         }
-        CSSReaderSettings settings = new CSSReaderSettings()
-                // a browser keeps what it understands and skips the rest, and so does the conversion service
-                .setBrowserCompliantMode(true)
-                .setCustomErrorHandler(new DoNothingCSSParseErrorHandler())
-                .setCustomExceptionHandler(new DoNothingCSSParseExceptionCallback());
-        CascadingStyleSheet stylesheet = CSSReader.readFromStringReader(css, settings);
+        CascadingStyleSheet stylesheet = parse(css);
         if (stylesheet == null) {
             logger.warn("Dropped a stylesheet which cannot be parsed, the resources it points at cannot be checked");
             return "";
@@ -398,50 +393,97 @@ public class MediaUtils {
         // The parser tells where each url and each import stands, and only those parts are rewritten.
         // Everything else keeps the formatting the document came with.
         int[] lineStarts = lineStartsOf(css);
-        List<int[]> accounted = new ArrayList<>();
-        List<CssEdit> edits = new ArrayList<>();
+        CssRewrite rewrite = new CssRewrite();
+        readImports(css, stylesheet, lineStarts, rewrite);
+        readUrls(css, stylesheet, lineStarts, rewrite, fileResourceProvider);
+
+        if (!rewrite.complete() || namesAnAddressNothingAccountedFor(css, stylesheet, lineStarts, rewrite.accounted())) {
+            logger.warn("Dropped a stylesheet: it names an absolute address which could not be read as a resource");
+            return "";
+        }
+        return applyEdits(css, rewrite.edits());
+    }
+
+    @Nullable
+    private CascadingStyleSheet parse(@NotNull String css) {
+        CSSReaderSettings settings = new CSSReaderSettings()
+                // a browser keeps what it understands and skips the rest, and so does the conversion service
+                .setBrowserCompliantMode(true)
+                .setCustomErrorHandler(new DoNothingCSSParseErrorHandler())
+                .setCustomExceptionHandler(new DoNothingCSSParseExceptionCallback());
+        return CSSReader.readFromStringReader(css, settings);
+    }
+
+    private void readImports(@NotNull String css, @NotNull CascadingStyleSheet stylesheet, int[] lineStarts, @NotNull CssRewrite rewrite) {
         for (CSSImportRule importRule : stylesheet.getAllImportRules()) {
-            int[] range = rangeOf(lineStarts, css, importRule.getSourceLocation());
-            if (isAbsoluteHttpUrl(decodeCssEscapes(importRule.getLocationString())) && range == null) {
-                return dropped(css);
-            }
-            if (range != null) {
-                accounted.add(range);
-                if (isAbsoluteHttpUrl(decodeCssEscapes(importRule.getLocationString()))) {
-                    edits.add(new CssEdit(range, ""));
+            CssRange range = rangeOf(lineStarts, css, importRule.getSourceLocation());
+            boolean absolute = isAbsoluteHttpUrl(decodeCssEscapes(importRule.getLocationString()));
+            if (range == null) {
+                rewrite.missed(!absolute);
+            } else {
+                rewrite.accounted().add(range);
+                if (absolute) {
+                    // an at-rule is never inlined, so the target of an absolute one has to go
+                    rewrite.edits().add(new CssEdit(range, ""));
                 }
             }
         }
-        boolean[] everyUrlPlaced = {true};
+    }
+
+    private void readUrls(@NotNull String css, @NotNull CascadingStyleSheet stylesheet, int[] lineStarts,
+                          @NotNull CssRewrite rewrite, @NotNull FileResourceProvider fileResourceProvider) {
         CSSVisitor.visitCSSUrl(stylesheet, new DefaultCSSUrlVisitor() {
             @Override
             public void onUrlDeclaration(@Nullable ICSSTopLevelRule topLevelRule, @NotNull CSSDeclaration declaration, @NotNull CSSExpressionMemberTermURI uri) {
-                int[] range = rangeOf(lineStarts, css, uri.getSourceLocation());
+                CssRange range = rangeOf(lineStarts, css, uri.getSourceLocation());
                 String replacement = replacementFor(fileResourceProvider, uri.getURIString());
                 if (range == null) {
-                    everyUrlPlaced[0] = replacement == null;
+                    rewrite.missed(replacement == null);
                     return;
                 }
-                accounted.add(range);
+                rewrite.accounted().add(range);
                 if (replacement != null) {
                     // no quotes around it: the value is a data url, and a quote would end a style attribute
-                    edits.add(new CssEdit(range, "url(" + replacement + ")"));
+                    rewrite.edits().add(new CssEdit(range, "url(" + replacement + ")"));
                 }
             }
         });
+    }
 
-        if (!everyUrlPlaced[0] || namesAnAddressNothingAccountedFor(css, stylesheet, lineStarts, accounted)) {
-            return dropped(css);
+    /**
+     * What a run over a stylesheet collects: where the parser accounted for something, what has to be
+     * written back, and whether anything it had to rewrite could not be placed.
+     */
+    @VisibleForTesting
+    static final class CssRewrite {
+        private final List<CssRange> accounted = new ArrayList<>();
+        private final List<CssEdit> edits = new ArrayList<>();
+        private boolean complete = true;
+
+        List<CssRange> accounted() {
+            return accounted;
         }
-        return applyEdits(css, edits);
+
+        List<CssEdit> edits() {
+            return edits;
+        }
+
+        boolean complete() {
+            return complete;
+        }
+
+        /**
+         * @param harmless whether what could not be placed needed no rewriting in the first place
+         */
+        void missed(boolean harmless) {
+            complete &= harmless;
+        }
     }
 
-    private String dropped(@NotNull String css) {
-        logger.warn("Dropped a stylesheet: it names an absolute address which could not be read as a resource");
-        return "";
+    private record CssRange(int start, int end) {
     }
 
-    private record CssEdit(@NotNull int[] range, @NotNull String replacement) {
+    private record CssEdit(@NotNull CssRange range, @NotNull String replacement) {
     }
 
     /**
@@ -450,8 +492,8 @@ public class MediaUtils {
     private String applyEdits(@NotNull String css, @NotNull List<CssEdit> edits) {
         StringBuilder result = new StringBuilder(css);
         edits.stream()
-                .sorted((left, right) -> Integer.compare(right.range()[0], left.range()[0]))
-                .forEach(edit -> result.replace(edit.range()[0], edit.range()[1], edit.replacement()));
+                .sorted((left, right) -> Integer.compare(right.range().start(), left.range().start()))
+                .forEach(edit -> result.replace(edit.range().start(), edit.range().end(), edit.replacement()));
         return result.toString();
     }
 
@@ -476,16 +518,20 @@ public class MediaUtils {
 
     private boolean mayReferenceAResource(@NotNull String css) {
         String probe = decodeCssEscapes(css).toLowerCase(Locale.ROOT);
-        return probe.contains("url(") || probe.contains("@import") || namesAnAbsoluteAddress(probe);
+        if (probe.contains("url(") || probe.contains("@import")) {
+            return true;
+        }
+        // an address of its own still has to reach the backstop, but the payload of a data url is the
+        // resource itself and an SVG in one names the namespace of SVG: that is no address to check
+        return namesAnAbsoluteAddress(probe.replaceAll("(?is)url\\([^)]*\\)", ""));
     }
 
     /**
-     * Tells whether a stylesheet names an address at all. A data url does not count, what it carries is
-     * the resource itself, and an SVG in one names the namespace of SVG.
+     * Tells whether a text names an address at all. Nothing is taken out of it here: the caller decides
+     * what its probe holds, and inside the backstop a url the parser read is already out of the way.
      */
     private boolean namesAnAbsoluteAddress(@NotNull String css) {
-        // a data url ends at the bracket of the url() around it, its payload may carry quotes of its own
-        String probe = decodeCssEscapes(css).replaceAll("(?i)data:[^)]*", "").toLowerCase(Locale.ROOT);
+        String probe = decodeCssEscapes(css).toLowerCase(Locale.ROOT);
         return probe.contains("http:") || probe.contains("https:") || probe.contains(NETWORK_PATH_PREFIX);
     }
 
@@ -500,8 +546,8 @@ public class MediaUtils {
      * </p>
      */
     private boolean namesAnAddressNothingAccountedFor(@NotNull String css, @NotNull CascadingStyleSheet stylesheet,
-                                                      int[] lineStarts, @NotNull List<int[]> accounted) {
-        List<int[]> ranges = new ArrayList<>(accounted);
+                                                      int[] lineStarts, @NotNull List<CssRange> accounted) {
+        List<CssRange> ranges = new ArrayList<>(accounted);
         stylesheet.getAllNamespaceRules().stream()
                 .map(rule -> rangeOf(lineStarts, css, rule.getSourceLocation()))
                 .filter(Objects::nonNull)
@@ -517,8 +563,8 @@ public class MediaUtils {
 
         StringBuilder probe = new StringBuilder(css);
         ranges.stream()
-                .sorted((left, right) -> Integer.compare(right[0], left[0]))
-                .forEach(range -> probe.replace(range[0], range[1], " "));
+                .sorted((left, right) -> Integer.compare(right.start(), left.start()))
+                .forEach(range -> probe.replace(range.start(), range.end(), " "));
         String text = stripCssComments(probe.toString());
         for (String readString : readStringsOf(stylesheet)) {
             text = text.replace(readString, "");
@@ -547,19 +593,19 @@ public class MediaUtils {
     /**
      * @return the part of a rule up to its body, the selector or the prelude, which fetches nothing
      */
-    private int[] selectorOf(@NotNull String css, @NotNull int[] ruleRange) {
-        int body = css.indexOf('{', ruleRange[0]);
-        return new int[]{ruleRange[0], body < 0 || body > ruleRange[1] ? ruleRange[1] : body};
+    private CssRange selectorOf(@NotNull String css, @NotNull CssRange ruleRange) {
+        int body = css.indexOf('{', ruleRange.start());
+        return new CssRange(ruleRange.start(), body < 0 || body > ruleRange.end() ? ruleRange.end() : body);
     }
 
     @Nullable
-    private int[] rangeOf(int[] lineStarts, @NotNull String css, @Nullable CSSSourceLocation location) {
+    private CssRange rangeOf(int[] lineStarts, @NotNull String css, @Nullable CSSSourceLocation location) {
         if (location == null) {
             return null;
         }
         int start = offsetOf(lineStarts, css, location.getFirstTokenBeginLineNumber(), location.getFirstTokenBeginColumnNumber() - 1);
         int end = offsetOf(lineStarts, css, location.getLastTokenEndLineNumber(), location.getLastTokenEndColumnNumber());
-        return start < 0 || end < start || end > css.length() ? null : new int[]{start, end};
+        return start < 0 || end < start || end > css.length() ? null : new CssRange(start, end);
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -5,6 +5,8 @@ import ch.sbb.polarion.extension.generic.util.BundleJarsPrioritizingRunnable;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
 import com.helger.css.CSSSourceLocation;
 import com.helger.css.ICSSSourceLocationAware;
+import com.helger.css.decl.CSSMediaRule;
+import com.helger.css.decl.CSSSupportsRule;
 import com.helger.css.decl.CSSStyleRule;
 import com.helger.css.decl.CSSUnknownRule;
 import com.helger.css.decl.ICSSExpressionMember;
@@ -567,15 +569,29 @@ public class MediaUtils {
     }
 
     /**
-     * @return where the parser read something which fetches nothing: a string, and the selector of a
-     * style rule at any depth, which the top-level pass does not reach inside a grouping at-rule
+     * @return where the parser read something which fetches nothing: a string, and the selector or the
+     * prelude of a rule at any depth, which the top-level pass does not reach inside a grouping at-rule
      */
     private List<CssRange> textRangesOf(@NotNull String css, @NotNull CascadingStyleSheet stylesheet, int[] lineStarts) {
         List<CssRange> ranges = new ArrayList<>();
         CSSVisitor.visitCSS(stylesheet, new DefaultCSSVisitor() {
             @Override
             public void onBeginStyleRule(@NotNull CSSStyleRule styleRule) {
-                CssRange range = rangeOf(lineStarts, css, styleRule.getSourceLocation());
+                addPreludeOf(styleRule);
+            }
+
+            @Override
+            public void onBeginMediaRule(@NotNull CSSMediaRule mediaRule) {
+                addPreludeOf(mediaRule);
+            }
+
+            @Override
+            public void onBeginSupportsRule(@NotNull CSSSupportsRule supportsRule) {
+                addPreludeOf(supportsRule);
+            }
+
+            private void addPreludeOf(@NotNull ICSSSourceLocationAware rule) {
+                CssRange range = rangeOf(lineStarts, css, rule.getSourceLocation());
                 if (range != null) {
                     ranges.add(selectorOf(css, range));
                 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -304,24 +304,33 @@ public class MediaUtils {
             if (rawUrl == null || rawUrl.isEmpty()) {
                 return null;
             }
-            String url = css ? unwrapCssUrl(rawUrl) : rawUrl;
-            if (MediaUtils.isDataUrl(url)) {
-                return null;
-            }
-            if (!fileResourceProvider.isForbidden(url)) {
-                // For renderable images (e.g. .png, .svg) strip 'thumbnail' to fetch full-size content.
-                // For everything else (spreadsheets, documents, unknown formats) keep 'thumbnail' so Polarion returns an icon preview.
-                String resourceUrl = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
-                String base64String = fileResourceProvider.getResourceAsBase64String(resourceUrl);
-                if (base64String != null) {
-                    return engine.group().replace(rawUrl, base64String);
-                }
-            }
-            // An absolute url which was not inlined, whatever the reason, must not stay in the HTML:
-            // WeasyPrint would load it from its own network position. A relative url is left untouched,
-            // WeasyPrint cannot resolve it.
-            return isAbsoluteHttpUrl(url) ? engine.group().replace(rawUrl, BLOCKED_RESOURCE_PLACEHOLDER) : null;
+            return inlineOrBlock(fileResourceProvider, engine.group(), rawUrl, css ? unwrapCssUrl(rawUrl) : rawUrl);
         };
+    }
+
+    private String inlineOrBlock(FileResourceProvider fileResourceProvider, String match, String rawUrl, String url) {
+        if (MediaUtils.isDataUrl(url)) {
+            return null;
+        }
+        String base64String = inline(fileResourceProvider, url);
+        if (base64String != null) {
+            return match.replace(rawUrl, base64String);
+        }
+        // An absolute url which was not inlined, whatever the reason, must not stay in the HTML:
+        // WeasyPrint would load it from its own network position. A relative url is left untouched,
+        // WeasyPrint cannot resolve it.
+        return isAbsoluteHttpUrl(url) ? match.replace(rawUrl, BLOCKED_RESOURCE_PLACEHOLDER) : null;
+    }
+
+    @Nullable
+    private String inline(FileResourceProvider fileResourceProvider, String url) {
+        if (fileResourceProvider.isForbidden(url)) {
+            return null;
+        }
+        // For renderable images (e.g. .png, .svg) strip 'thumbnail' to fetch full-size content.
+        // For everything else (spreadsheets, documents, unknown formats) keep 'thumbnail' so Polarion returns an icon preview.
+        String resourceUrl = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
+        return fileResourceProvider.getResourceAsBase64String(resourceUrl);
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -439,6 +439,8 @@ public class MediaUtils {
             @Override
             public void onUrlDeclaration(@Nullable ICSSTopLevelRule topLevelRule, @NotNull CSSDeclaration declaration, @NotNull CSSExpressionMemberTermURI uri) {
                 CssRange range = rangeOf(lineStarts, css, uri.getSourceLocation());
+                // the parser resolves the escapes of a url term itself, so this value is the one the
+                // renderer would read, and the one the policy is asked about
                 String replacement = replacementFor(fileResourceProvider, uri.getURIString());
                 if (range == null) {
                     rewrite.missed(replacement == null);

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -298,11 +298,21 @@ public class MediaUtils {
         StringBuilder decoded = new StringBuilder();
         while (matcher.find()) {
             String hex = matcher.group(1);
-            String replacement = hex != null ? Character.toString(Integer.parseInt(hex, 16)) : matcher.group(2);
+            // the pattern caps the escape at six hex digits, so the value always fits into an int
+            String replacement = hex != null ? codePointOf(Integer.parseInt(hex, 16)) : matcher.group(2);
             matcher.appendReplacement(decoded, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(decoded);
         return decoded.toString();
+    }
+
+    /**
+     * CSS turns an escape of zero, of a surrogate and of a value above the last code point into the
+     * replacement character, and so does this.
+     */
+    private String codePointOf(int value) {
+        boolean valid = value > 0 && value <= Character.MAX_CODE_POINT && !(value >= Character.MIN_SURROGATE && value <= Character.MAX_SURROGATE);
+        return valid ? Character.toString(value) : "\uFFFD";
     }
 
     public boolean isDataUrl(@Nullable String resourceUrl) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -64,8 +64,10 @@ public class MediaUtils {
      * {@code @import url(...)}. {@link #URL_REGEX} matches its url as well, but only this one can drop
      * the whole at-rule, media condition included.
      */
-    public static final String CSS_IMPORT_URL_REGEX = "(?i)@import" + CSS_AT_RULE_SEPARATOR + "url\\(\\s*([\"'])?(?<url>[^\"')]+)\\1?\\s*\\)[^;]*;?";
+    public static final String CSS_IMPORT_URL_REGEX = "(?i)@import" + CSS_AT_RULE_SEPARATOR + "url\\((?<url>[^)]*)\\)[^;]*;?";
     public static final String DATA_URL_PREFIX = "data:";
+    private static final String COMMENT_START = "/*";
+    private static final String COMMENT_END = "*/";
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
     /**
      * A 1x1 transparent PNG which replaces a resource the {@link ResourceUrlPolicy} rejected.
@@ -285,8 +287,24 @@ public class MediaUtils {
     }
 
     public String inlineBase64Resources(String content, FileResourceProvider fileResourceProvider) {
-        RegexMatcher.IReplacementCalculator dataReplacement = engine -> {
-            String url = engine.group("url");
+        // replace tags like <img src="...
+        String result = RegexMatcher.get(IMG_SRC_REGEX).replace(content, replacement(fileResourceProvider, false));
+        // drop a forbidden '@import' before its url reaches the pass below, which would only replace the url
+        RegexMatcher.IReplacementCalculator importReplacement = engine ->
+                fileResourceProvider.isForbidden(unwrapCssUrl(engine.group("url"))) ? "" : null;
+        result = RegexMatcher.get(CSS_IMPORT_URL_REGEX).useJavaUtil().replace(result, importReplacement);
+        result = RegexMatcher.get(CSS_IMPORT_REGEX).useJavaUtil().replace(result, importReplacement);
+        // replace CSS parameters like background: src('/polarion/...
+        return RegexMatcher.get(URL_REGEX).useJavaUtil().replace(result, replacement(fileResourceProvider, true));
+    }
+
+    private RegexMatcher.IReplacementCalculator replacement(FileResourceProvider fileResourceProvider, boolean css) {
+        return engine -> {
+            String rawUrl = engine.group("url");
+            if (rawUrl == null || rawUrl.isEmpty()) {
+                return null;
+            }
+            String url = css ? unwrapCssUrl(rawUrl) : rawUrl;
             if (MediaUtils.isDataUrl(url)) {
                 return null;
             }
@@ -296,26 +314,37 @@ public class MediaUtils {
                 String resourceUrl = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
                 String base64String = fileResourceProvider.getResourceAsBase64String(resourceUrl);
                 if (base64String != null) {
-                    return engine.group().replace(url, base64String);
+                    return engine.group().replace(rawUrl, base64String);
                 }
             }
             // An absolute url which was not inlined, whatever the reason, must not stay in the HTML:
             // WeasyPrint would load it from its own network position. A relative url is left untouched,
             // WeasyPrint cannot resolve it.
-            return isAbsoluteHttpUrl(url) ? engine.group().replace(url, BLOCKED_RESOURCE_PLACEHOLDER) : null;
+            return isAbsoluteHttpUrl(url) ? engine.group().replace(rawUrl, BLOCKED_RESOURCE_PLACEHOLDER) : null;
         };
+    }
 
-        // drop a forbidden '@import', there is nothing to inline it with
-        RegexMatcher.IReplacementCalculator importReplacement = engine ->
-                fileResourceProvider.isForbidden(engine.group("url")) ? "" : null;
-
-        // replace tags like <img src="...
-        String result = RegexMatcher.get(IMG_SRC_REGEX).replace(content, dataReplacement);
-        // drop a forbidden '@import' before its url reaches the pass below, which would only replace the url
-        result = RegexMatcher.get(CSS_IMPORT_URL_REGEX).useJavaUtil().replace(result, importReplacement);
-        result = RegexMatcher.get(CSS_IMPORT_REGEX).useJavaUtil().replace(result, importReplacement);
-        // replace CSS parameters like background: src('/polarion/...
-        return RegexMatcher.get(URL_REGEX).useJavaUtil().replace(result, dataReplacement);
+    /**
+     * Takes the target out of a CSS url value. A comment is allowed on either side of it, and a quote
+     * stays in the value whenever a comment kept the pattern from capturing it separately. Only the
+     * leading and the trailing comment go, a url may well carry the very same characters in its path.
+     */
+    public String unwrapCssUrl(@Nullable String url) {
+        if (url == null) {
+            return null;
+        }
+        String unwrapped = url.trim();
+        while (unwrapped.startsWith(COMMENT_START) && unwrapped.contains(COMMENT_END)) {
+            unwrapped = unwrapped.substring(unwrapped.indexOf(COMMENT_END) + COMMENT_END.length()).trim();
+        }
+        while (unwrapped.endsWith(COMMENT_END) && unwrapped.lastIndexOf(COMMENT_START) > 0) {
+            unwrapped = unwrapped.substring(0, unwrapped.lastIndexOf(COMMENT_START)).trim();
+        }
+        if (unwrapped.length() > 1 && (unwrapped.startsWith("\"") && unwrapped.endsWith("\"")
+                || unwrapped.startsWith("'") && unwrapped.endsWith("'"))) {
+            unwrapped = unwrapped.substring(1, unwrapped.length() - 1).trim();
+        }
+        return unwrapped;
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -66,6 +66,7 @@ public class MediaUtils {
      */
     public static final String CSS_IMPORT_URL_REGEX = "(?i)@import" + CSS_AT_RULE_SEPARATOR + "url\\((?<url>[^)]*)\\)[^;]*;?";
     public static final String DATA_URL_PREFIX = "data:";
+    private static final String NETWORK_PATH_PREFIX = "//";
     private static final String COMMENT_START = "/*";
     private static final String COMMENT_END = "*/";
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
@@ -289,9 +290,11 @@ public class MediaUtils {
     public String inlineBase64Resources(String content, FileResourceProvider fileResourceProvider) {
         // replace tags like <img src="...
         String result = RegexMatcher.get(IMG_SRC_REGEX).replace(content, replacement(fileResourceProvider, false));
-        // drop a forbidden '@import' before its url reaches the pass below, which would only replace the url
+        // An at-rule is never inlined, so any absolute target has to go: a forbidden one because the
+        // policy rejected it, an allowed one because WeasyPrint would then load it from its own network
+        // position, with none of the checks this class applies. A relative target stays.
         RegexMatcher.IReplacementCalculator importReplacement = engine ->
-                fileResourceProvider.isForbidden(unwrapCssUrl(engine.group("url"))) ? "" : null;
+                isAbsoluteHttpUrl(unwrapCssUrl(engine.group("url"))) ? "" : null;
         result = RegexMatcher.get(CSS_IMPORT_URL_REGEX).useJavaUtil().replace(result, importReplacement);
         result = RegexMatcher.get(CSS_IMPORT_REGEX).useJavaUtil().replace(result, importReplacement);
         // replace CSS parameters like background: src('/polarion/...
@@ -308,7 +311,7 @@ public class MediaUtils {
         };
     }
 
-    private String inlineOrBlock(FileResourceProvider fileResourceProvider, String match, String rawUrl, String url) {
+    private String inlineOrBlock(@NotNull FileResourceProvider fileResourceProvider, @NotNull String match, @NotNull String rawUrl, @NotNull String url) {
         if (MediaUtils.isDataUrl(url)) {
             return null;
         }
@@ -323,7 +326,7 @@ public class MediaUtils {
     }
 
     @Nullable
-    private String inline(FileResourceProvider fileResourceProvider, String url) {
+    private String inline(@NotNull FileResourceProvider fileResourceProvider, @NotNull String url) {
         if (fileResourceProvider.isForbidden(url)) {
             return null;
         }
@@ -338,10 +341,8 @@ public class MediaUtils {
      * stays in the value whenever a comment kept the pattern from capturing it separately. Only the
      * leading and the trailing comment go, a url may well carry the very same characters in its path.
      */
-    public String unwrapCssUrl(@Nullable String url) {
-        if (url == null) {
-            return null;
-        }
+    @NotNull
+    public String unwrapCssUrl(@NotNull String url) {
         String unwrapped = url.trim();
         while (unwrapped.startsWith(COMMENT_START) && unwrapped.contains(COMMENT_END)) {
             unwrapped = unwrapped.substring(unwrapped.indexOf(COMMENT_END) + COMMENT_END.length()).trim();
@@ -363,12 +364,21 @@ public class MediaUtils {
         return url.replace(" ", "%20").replace("%5F", "_");
     }
 
+    /**
+     * A network path reference like {@code //host/path} counts as well: the conversion service reads the
+     * document with a base url and gives such a reference the scheme of that base.
+     */
     public boolean isAbsoluteHttpUrl(@Nullable String url) {
         if (url == null) {
             return false;
         }
         String lowerCased = url.trim().toLowerCase(Locale.ROOT);
-        return lowerCased.startsWith("http://") || lowerCased.startsWith("https://");
+        return lowerCased.startsWith("http://") || lowerCased.startsWith("https://") || isNetworkPathReference(lowerCased);
+    }
+
+    public boolean isNetworkPathReference(@NotNull String url) {
+        String trimmed = url.trim();
+        return trimmed.startsWith(NETWORK_PATH_PREFIX) && trimmed.length() > NETWORK_PATH_PREFIX.length();
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -53,8 +53,14 @@ public class MediaUtils {
     public static final String URL_REGEX = "(?i)url\\(\\s*([\"'])?(?<url>.*?)\\1?\\s*\\)";
     /**
      * {@code @import "..."} without the {@code url(...)} wrapper, which {@link #URL_REGEX} does not match.
+     * The trailing {@code [^;]*} swallows a media condition, so the whole at-rule goes when it is dropped.
      */
-    public static final String CSS_IMPORT_REGEX = "(?i)@import\\s+([\"'])(?<url>[^\"']+)\\1\\s*;?";
+    public static final String CSS_IMPORT_REGEX = "(?i)@import\\s+([\"'])(?<url>[^\"']+)\\1[^;]*;?";
+    /**
+     * {@code @import url(...)}. {@link #URL_REGEX} matches its url as well, but only this one can drop
+     * the whole at-rule, media condition included.
+     */
+    public static final String CSS_IMPORT_URL_REGEX = "(?i)@import\\s+url\\(\\s*([\"'])?(?<url>[^\"')]+)\\1?\\s*\\)[^;]*;?";
     public static final String DATA_URL_PREFIX = "data:";
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
     /**
@@ -295,15 +301,17 @@ public class MediaUtils {
             return isAbsoluteHttpUrl(url) ? engine.group().replace(url, BLOCKED_RESOURCE_PLACEHOLDER) : null;
         };
 
-        // drop a forbidden '@import "..."', there is nothing to inline it with
+        // drop a forbidden '@import', there is nothing to inline it with
         RegexMatcher.IReplacementCalculator importReplacement = engine ->
                 fileResourceProvider.isForbidden(engine.group("url")) ? "" : null;
 
         // replace tags like <img src="...
         String result = RegexMatcher.get(IMG_SRC_REGEX).replace(content, dataReplacement);
+        // drop a forbidden '@import' before its url reaches the pass below, which would only replace the url
+        result = RegexMatcher.get(CSS_IMPORT_URL_REGEX).useJavaUtil().replace(result, importReplacement);
+        result = RegexMatcher.get(CSS_IMPORT_REGEX).useJavaUtil().replace(result, importReplacement);
         // replace CSS parameters like background: src('/polarion/...
-        result = RegexMatcher.get(URL_REGEX).useJavaUtil().replace(result, dataReplacement);
-        return RegexMatcher.get(CSS_IMPORT_REGEX).useJavaUtil().replace(result, importReplacement);
+        return RegexMatcher.get(URL_REGEX).useJavaUtil().replace(result, dataReplacement);
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -4,6 +4,9 @@ import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.generic.util.BundleJarsPrioritizingRunnable;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
 import com.helger.css.CSSSourceLocation;
+import com.helger.css.ICSSSourceLocationAware;
+import com.helger.css.decl.CSSUnknownRule;
+import com.helger.css.decl.ICSSExpressionMember;
 import com.helger.css.decl.CSSDeclaration;
 import com.helger.css.decl.CSSImportRule;
 import com.helger.css.decl.CSSExpressionMemberTermURI;
@@ -62,6 +65,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -375,6 +379,11 @@ public class MediaUtils {
      * </p>
      */
     public String inlineCssResources(@NotNull String css, @NotNull FileResourceProvider fileResourceProvider) {
+        if (!mayReferenceAResource(css)) {
+            // no url, no import and no address: there is nothing to rewrite and nothing to check, and a
+            // style attribute of a large document is not worth a parser run for that
+            return css;
+        }
         CSSReaderSettings settings = new CSSReaderSettings()
                 // a browser keeps what it understands and skips the rest, and so does the conversion service
                 .setBrowserCompliantMode(true)
@@ -388,48 +397,61 @@ public class MediaUtils {
 
         // The parser tells where each url and each import stands, and only those parts are rewritten.
         // Everything else keeps the formatting the document came with.
+        int[] lineStarts = lineStartsOf(css);
+        List<int[]> accounted = new ArrayList<>();
         List<CssEdit> edits = new ArrayList<>();
-        for (int i = 0; i < stylesheet.getImportRuleCount(); i++) {
-            CSSImportRule importRule = stylesheet.getImportRuleAtIndex(i);
-            if (isAbsoluteHttpUrl(decodeCssEscapes(importRule.getLocationString()))) {
-                edits.add(new CssEdit(importRule.getSourceLocation(), ""));
+        for (CSSImportRule importRule : stylesheet.getAllImportRules()) {
+            int[] range = rangeOf(lineStarts, css, importRule.getSourceLocation());
+            if (isAbsoluteHttpUrl(decodeCssEscapes(importRule.getLocationString())) && range == null) {
+                return dropped(css);
+            }
+            if (range != null) {
+                accounted.add(range);
+                if (isAbsoluteHttpUrl(decodeCssEscapes(importRule.getLocationString()))) {
+                    edits.add(new CssEdit(range, ""));
+                }
             }
         }
+        boolean[] everyUrlPlaced = {true};
         CSSVisitor.visitCSSUrl(stylesheet, new DefaultCSSUrlVisitor() {
             @Override
             public void onUrlDeclaration(@Nullable ICSSTopLevelRule topLevelRule, @NotNull CSSDeclaration declaration, @NotNull CSSExpressionMemberTermURI uri) {
+                int[] range = rangeOf(lineStarts, css, uri.getSourceLocation());
                 String replacement = replacementFor(fileResourceProvider, uri.getURIString());
+                if (range == null) {
+                    everyUrlPlaced[0] = replacement == null;
+                    return;
+                }
+                accounted.add(range);
                 if (replacement != null) {
                     // no quotes around it: the value is a data url, and a quote would end a style attribute
-                    edits.add(new CssEdit(uri.getSourceLocation(), "url(" + replacement + ")"));
+                    edits.add(new CssEdit(range, "url(" + replacement + ")"));
                 }
             }
         });
 
-        String result = applyEdits(css, edits);
-        if (namesAnAddressNothingRead(stylesheet, result)) {
-            logger.warn("Dropped a stylesheet: it names an absolute address which could not be read as a resource");
-            return "";
+        if (!everyUrlPlaced[0] || namesAnAddressNothingAccountedFor(css, stylesheet, lineStarts, accounted)) {
+            return dropped(css);
         }
-        return result;
+        return applyEdits(css, edits);
     }
 
-    private record CssEdit(@Nullable CSSSourceLocation location, @NotNull String replacement) {
+    private String dropped(@NotNull String css) {
+        logger.warn("Dropped a stylesheet: it names an absolute address which could not be read as a resource");
+        return "";
+    }
+
+    private record CssEdit(@NotNull int[] range, @NotNull String replacement) {
     }
 
     /**
      * Applies the edits back to front, so that an offset stays valid while the ones before it are used.
      */
     private String applyEdits(@NotNull String css, @NotNull List<CssEdit> edits) {
-        int[] lineStarts = lineStartsOf(css);
         StringBuilder result = new StringBuilder(css);
         edits.stream()
-                .filter(edit -> edit.location() != null)
-                .map(edit -> new int[]{offsetOf(lineStarts, css, edit.location().getFirstTokenBeginLineNumber(), edit.location().getFirstTokenBeginColumnNumber() - 1),
-                        offsetOf(lineStarts, css, edit.location().getLastTokenEndLineNumber(), edit.location().getLastTokenEndColumnNumber()), edits.indexOf(edit)})
-                .filter(range -> range[0] >= 0 && range[1] >= range[0] && range[1] <= css.length())
-                .sorted((left, right) -> Integer.compare(right[0], left[0]))
-                .forEach(range -> result.replace(range[0], range[1], edits.get(range[2]).replacement()));
+                .sorted((left, right) -> Integer.compare(right.range()[0], left.range()[0]))
+                .forEach(edit -> result.replace(edit.range()[0], edit.range()[1], edit.replacement()));
         return result.toString();
     }
 
@@ -452,6 +474,11 @@ public class MediaUtils {
         return offset > css.length() ? -1 : offset;
     }
 
+    private boolean mayReferenceAResource(@NotNull String css) {
+        String probe = decodeCssEscapes(css).toLowerCase(Locale.ROOT);
+        return probe.contains("url(") || probe.contains("@import") || namesAnAbsoluteAddress(probe);
+    }
+
     /**
      * Tells whether a stylesheet names an address at all. A data url does not count, what it carries is
      * the resource itself, and an SVG in one names the namespace of SVG.
@@ -463,15 +490,46 @@ public class MediaUtils {
     }
 
     /**
-     * Tells whether a rewritten stylesheet still names an absolute address which nothing checked. Every
-     * url the parser read is a data url or the placeholder by then, and an import of an address is gone,
-     * so an address which is left hid from the parser and the stylesheet cannot be handed on.
+     * Tells whether a stylesheet names an absolute address which nothing accounted for.
      * <p>
-     * A comment does not count, the renderer ignores it, and neither does a plain string value: css
-     * fetches nothing from a string, and a stylesheet may legitimately carry an address in one.
+     * What is accounted for is taken out of the text first: a url and an import the parser read, a
+     * namespace rule, the selector of every rule, the strings the parser read as values, the comments
+     * and the data urls. None of those makes the renderer fetch an unchecked address. Whatever names an
+     * address after that, an escaped at-keyword, a value the parser dropped, a function it does not
+     * know, was read by nothing, and the renderer may well read it.
      * </p>
      */
-    private boolean namesAnAddressNothingRead(@NotNull CascadingStyleSheet stylesheet, @NotNull String css) {
+    private boolean namesAnAddressNothingAccountedFor(@NotNull String css, @NotNull CascadingStyleSheet stylesheet,
+                                                      int[] lineStarts, @NotNull List<int[]> accounted) {
+        List<int[]> ranges = new ArrayList<>(accounted);
+        stylesheet.getAllNamespaceRules().stream()
+                .map(rule -> rangeOf(lineStarts, css, rule.getSourceLocation()))
+                .filter(Objects::nonNull)
+                .forEach(ranges::add);
+        stylesheet.getAllRules().stream()
+                // an unknown rule is one the parser could not read, and that is what this looks for
+                .filter(rule -> !(rule instanceof CSSUnknownRule))
+                .filter(ICSSSourceLocationAware.class::isInstance)
+                .map(rule -> rangeOf(lineStarts, css, ((ICSSSourceLocationAware) rule).getSourceLocation()))
+                .filter(Objects::nonNull)
+                .map(range -> selectorOf(css, range))
+                .forEach(ranges::add);
+
+        StringBuilder probe = new StringBuilder(css);
+        ranges.stream()
+                .sorted((left, right) -> Integer.compare(right[0], left[0]))
+                .forEach(range -> probe.replace(range[0], range[1], " "));
+        String text = stripCssComments(probe.toString());
+        for (String readString : readStringsOf(stylesheet)) {
+            text = text.replace(readString, "");
+        }
+        return namesAnAbsoluteAddress(text);
+    }
+
+    /**
+     * @return the string values the parser read, which are text: css fetches nothing from a string
+     */
+    private List<String> readStringsOf(@NotNull CascadingStyleSheet stylesheet) {
         List<String> readStrings = new ArrayList<>();
         CSSVisitor.visitCSS(stylesheet, new DefaultCSSVisitor() {
             @Override
@@ -483,11 +541,25 @@ public class MediaUtils {
                         .forEach(readStrings::add);
             }
         });
-        String probe = stripCssComments(css);
-        for (String readString : readStrings) {
-            probe = probe.replace(readString, "");
+        return readStrings;
+    }
+
+    /**
+     * @return the part of a rule up to its body, the selector or the prelude, which fetches nothing
+     */
+    private int[] selectorOf(@NotNull String css, @NotNull int[] ruleRange) {
+        int body = css.indexOf('{', ruleRange[0]);
+        return new int[]{ruleRange[0], body < 0 || body > ruleRange[1] ? ruleRange[1] : body};
+    }
+
+    @Nullable
+    private int[] rangeOf(int[] lineStarts, @NotNull String css, @Nullable CSSSourceLocation location) {
+        if (location == null) {
+            return null;
         }
-        return namesAnAbsoluteAddress(probe);
+        int start = offsetOf(lineStarts, css, location.getFirstTokenBeginLineNumber(), location.getFirstTokenBeginColumnNumber() - 1);
+        int end = offsetOf(lineStarts, css, location.getLastTokenEndLineNumber(), location.getLastTokenEndColumnNumber());
+        return start < 0 || end < start || end > css.length() ? null : new int[]{start, end};
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -31,6 +31,7 @@ import com.polarion.core.util.StringUtils;
 import org.jsoup.parser.Parser;
 import org.jsoup.nodes.Range;
 import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Entities;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.DataNode;
 import org.jsoup.Jsoup;
@@ -686,36 +687,55 @@ public class MediaUtils {
      */
     private String processResourceRegions(@NotNull String html, @NotNull FileResourceProvider fileResourceProvider) {
         Document document = Jsoup.parse(html, "", Parser.htmlParser().setTrackPosition(true));
-        List<Object[]> regions = new ArrayList<>();
+        List<Region> regions = new ArrayList<>();
         for (Element image : document.select("img[src]")) {
-            addRegion(regions, image.attributes().sourceRange("src").valueRange(),
+            // the value of an attribute is read as the parser read it, entities resolved: that is the
+            // address the renderer sees, and the markup says nothing the renderer would not
+            addAttributeRegion(regions, image, "src",
                     url -> Optional.ofNullable(replacementFor(fileResourceProvider, url)).orElse(url));
         }
         for (Element styleElement : document.select("style")) {
+            // a style element holds raw text, so its source and its value are the same characters
             styleElement.dataNodes().forEach(data ->
-                    addRegion(regions, data.sourceRange(), css -> inlineCssResources(css, fileResourceProvider)));
+                    addRegion(regions, data.sourceRange(), html, css -> inlineCssResources(css, fileResourceProvider), false));
         }
         for (Element element : document.select("[style]")) {
-            addRegion(regions, element.attributes().sourceRange("style").valueRange(),
+            addAttributeRegion(regions, element, "style",
                     css -> rewriteDeclarations(css, declarations -> inlineCssResources(declarations, fileResourceProvider)));
         }
 
         StringBuilder result = new StringBuilder(html);
         regions.stream()
-                .sorted((left, right) -> Integer.compare((int) right[0], (int) left[0]))
+                .sorted((left, right) -> Integer.compare(right.start(), left.start()))
                 .forEach(region -> {
-                    int start = (int) region[0];
-                    int end = (int) region[1];
-                    @SuppressWarnings("unchecked")
-                    UnaryOperator<String> rewrite = (UnaryOperator<String>) region[2];
-                    result.replace(start, end, rewrite.apply(html.substring(start, end)));
+                    String rewritten = region.rewrite().apply(region.input());
+                    if (!rewritten.equals(region.input())) {
+                        // an attribute is written back as markup, so what goes in there is escaped again
+                        result.replace(region.start(), region.end(), region.escape() ? Entities.escape(rewritten) : rewritten);
+                    }
                 });
         return result.toString();
     }
 
-    private void addRegion(@NotNull List<Object[]> regions, @NotNull Range range, @NotNull UnaryOperator<String> rewrite) {
+    private void addAttributeRegion(@NotNull List<Region> regions, @NotNull Element element, @NotNull String attribute,
+                                    @NotNull UnaryOperator<String> rewrite) {
+        Range range = element.attributes().sourceRange(attribute).valueRange();
         if (range.isTracked() && range.startPos() >= 0 && range.endPos() >= range.startPos()) {
-            regions.add(new Object[]{range.startPos(), range.endPos(), rewrite});
+            regions.add(new Region(range.startPos(), range.endPos(), element.attr(attribute), rewrite, true));
+        }
+    }
+
+    /**
+     * @param input   what the region says, as the parser read it
+     * @param escape  whether writing it back means writing markup
+     */
+    private record Region(int start, int end, @NotNull String input, @NotNull UnaryOperator<String> rewrite, boolean escape) {
+    }
+
+    private void addRegion(@NotNull List<Region> regions, @NotNull Range range, @NotNull String html,
+                           @NotNull UnaryOperator<String> rewrite, boolean escape) {
+        if (range.isTracked() && range.startPos() >= 0 && range.endPos() >= range.startPos()) {
+            regions.add(new Region(range.startPos(), range.endPos(), html.substring(range.startPos(), range.endPos()), rewrite, escape));
         }
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -53,6 +53,11 @@ public class MediaUtils {
     public static final String URL_REGEX = "url\\(\\s*([\"'])?(?<url>.*?)\\1?\\s*\\)";
     public static final String DATA_URL_PREFIX = "data:";
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
+    /**
+     * A 1x1 transparent PNG which replaces a resource the {@link ResourceUrlPolicy} rejected.
+     */
+    public static final String BLOCKED_RESOURCE_PLACEHOLDER =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
     private static final Logger logger = Logger.getLogger(MediaUtils.class);
     private static final int RIGHT_WHITE_AREA_PX = 30;
     private static final int PDF_TO_PNG_DPI = 300;
@@ -270,6 +275,10 @@ public class MediaUtils {
             String url = engine.group("url");
             if (MediaUtils.isDataUrl(url)) {
                 return null;
+            }
+            if (fileResourceProvider.isForbidden(url)) {
+                // the url is replaced, not kept, so that WeasyPrint does not load it either
+                return engine.group().replace(url, BLOCKED_RESOURCE_PLACEHOLDER);
             }
             // For renderable images (e.g. .png, .svg) strip 'thumbnail' to fetch full-size content.
             // For everything else (spreadsheets, documents, unknown formats) keep 'thumbnail' so Polarion returns an icon preview.

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -61,6 +61,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -336,21 +337,7 @@ public class MediaUtils {
     }
 
     public String inlineBase64Resources(String content, FileResourceProvider fileResourceProvider) {
-        // replace tags like <img src="...
-        String result = RegexMatcher.get(IMG_SRC_REGEX).replace(content, imageReplacement(fileResourceProvider));
-        // the css of the document is read by a parser, see inlineCssResources
-        return processCssRegions(result, css -> inlineCssResources(css, fileResourceProvider));
-    }
-
-    private RegexMatcher.IReplacementCalculator imageReplacement(FileResourceProvider fileResourceProvider) {
-        return engine -> {
-            String url = engine.group("url");
-            if (url == null || url.isEmpty() || MediaUtils.isDataUrl(url)) {
-                return null;
-            }
-            String replacement = replacementFor(fileResourceProvider, url);
-            return replacement == null ? null : engine.group().replace(url, replacement);
-        };
+        return processResourceRegions(content, fileResourceProvider);
     }
 
     /**
@@ -366,8 +353,8 @@ public class MediaUtils {
         if (!fileResourceProvider.isForbidden(url)) {
             // For renderable images (e.g. .png, .svg) strip 'thumbnail' to fetch full-size content.
             // For everything else (spreadsheets, documents, unknown formats) keep 'thumbnail' so Polarion returns an icon preview.
-            String resourceUrl = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
-            String base64String = fileResourceProvider.getResourceAsBase64String(resourceUrl);
+            String strippedUrl = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
+            String base64String = fileResourceProvider.getResourceAsBase64String(Objects.requireNonNullElse(strippedUrl, url));
             if (base64String != null) {
                 return base64String;
             }
@@ -388,10 +375,6 @@ public class MediaUtils {
      * </p>
      */
     public String inlineCssResources(@NotNull String css, @NotNull FileResourceProvider fileResourceProvider) {
-        if (!namesAnAbsoluteAddress(css)) {
-            // nothing to check and nothing to rewrite, so the css stays exactly as the document has it
-            return css;
-        }
         CSSReaderSettings settings = new CSSReaderSettings()
                 // a browser keeps what it understands and skips the rest, and so does the conversion service
                 .setBrowserCompliantMode(true)
@@ -417,7 +400,8 @@ public class MediaUtils {
             public void onUrlDeclaration(@Nullable ICSSTopLevelRule topLevelRule, @NotNull CSSDeclaration declaration, @NotNull CSSExpressionMemberTermURI uri) {
                 String replacement = replacementFor(fileResourceProvider, uri.getURIString());
                 if (replacement != null) {
-                    edits.add(new CssEdit(uri.getSourceLocation(), "url(\"" + replacement + "\")"));
+                    // no quotes around it: the value is a data url, and a quote would end a style attribute
+                    edits.add(new CssEdit(uri.getSourceLocation(), "url(" + replacement + ")"));
                 }
             }
         });
@@ -473,8 +457,8 @@ public class MediaUtils {
      * the resource itself, and an SVG in one names the namespace of SVG.
      */
     private boolean namesAnAbsoluteAddress(@NotNull String css) {
-        // a data url ends at the bracket or the quote around it, the base64 of it may hold anything else
-        String probe = decodeCssEscapes(css).replaceAll("(?i)data:[^)\"']*", "").toLowerCase(Locale.ROOT);
+        // a data url ends at the bracket of the url() around it, its payload may carry quotes of its own
+        String probe = decodeCssEscapes(css).replaceAll("(?i)data:[^)]*", "").toLowerCase(Locale.ROOT);
         return probe.contains("http:") || probe.contains("https:") || probe.contains(NETWORK_PATH_PREFIX);
     }
 
@@ -554,36 +538,44 @@ public class MediaUtils {
 
 
     /**
-     * Hands the parts of an HTML document which are CSS, a style element and a style attribute, to the
-     * given rewriting, and puts the result back where it stood. JSoup says where those parts are, so
-     * every form HTML allows is covered and nothing outside a tag is mistaken for one. The document is
-     * not written back by JSoup: only the parts which changed are replaced in the original text.
+     * Rewrites every resource an HTML document points at: the source of an image, the css of a style
+     * element and the css of a style attribute. JSoup says where each of them stands, so every form HTML
+     * allows is covered and nothing outside a tag is mistaken for one. JSoup does not write the document
+     * back, only the parts which changed are replaced in the original text.
      */
-    private String processCssRegions(@NotNull String html, @NotNull UnaryOperator<String> rewrite) {
+    private String processResourceRegions(@NotNull String html, @NotNull FileResourceProvider fileResourceProvider) {
         Document document = Jsoup.parse(html, "", Parser.htmlParser().setTrackPosition(true));
-        List<int[]> regions = new ArrayList<>();
+        List<Object[]> regions = new ArrayList<>();
+        for (Element image : document.select("img[src]")) {
+            addRegion(regions, image.attributes().sourceRange("src").valueRange(),
+                    url -> Optional.ofNullable(replacementFor(fileResourceProvider, url)).orElse(url));
+        }
         for (Element styleElement : document.select("style")) {
-            styleElement.dataNodes().stream()
-                    .map(DataNode::sourceRange)
-                    .filter(Range::isTracked)
-                    .forEach(range -> regions.add(new int[]{range.startPos(), range.endPos(), 0}));
+            styleElement.dataNodes().forEach(data ->
+                    addRegion(regions, data.sourceRange(), css -> inlineCssResources(css, fileResourceProvider)));
         }
         for (Element element : document.select("[style]")) {
-            Range valueRange = element.attributes().sourceRange("style").valueRange();
-            if (valueRange.isTracked()) {
-                regions.add(new int[]{valueRange.startPos(), valueRange.endPos(), 1});
-            }
+            addRegion(regions, element.attributes().sourceRange("style").valueRange(),
+                    css -> rewriteDeclarations(css, declarations -> inlineCssResources(declarations, fileResourceProvider)));
         }
 
         StringBuilder result = new StringBuilder(html);
         regions.stream()
-                .filter(region -> region[0] >= 0 && region[1] >= region[0] && region[1] <= html.length())
-                .sorted((left, right) -> Integer.compare(right[0], left[0]))
+                .sorted((left, right) -> Integer.compare((int) right[0], (int) left[0]))
                 .forEach(region -> {
-                    String css = html.substring(region[0], region[1]);
-                    result.replace(region[0], region[1], region[2] == 0 ? rewrite.apply(css) : rewriteDeclarations(css, rewrite));
+                    int start = (int) region[0];
+                    int end = (int) region[1];
+                    @SuppressWarnings("unchecked")
+                    UnaryOperator<String> rewrite = (UnaryOperator<String>) region[2];
+                    result.replace(start, end, rewrite.apply(html.substring(start, end)));
                 });
         return result.toString();
+    }
+
+    private void addRegion(@NotNull List<Object[]> regions, @NotNull Range range, @NotNull UnaryOperator<String> rewrite) {
+        if (range.isTracked() && range.startPos() >= 0 && range.endPos() >= range.startPos()) {
+            regions.add(new Object[]{range.startPos(), range.endPos(), rewrite});
+        }
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -22,6 +22,12 @@ import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.PdfVariant;
 import ch.sbb.polarion.extension.pdf_exporter.service.PdfExporterPolarionService;
 import com.polarion.alm.shared.api.transaction.TransactionalExecutor;
 import com.polarion.core.util.StringUtils;
+import org.jsoup.parser.Parser;
+import org.jsoup.nodes.Range;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.DataNode;
+import org.jsoup.Jsoup;
 import com.polarion.core.util.logging.Logger;
 import com.polarion.platform.service.repository.IRepositoryReadOnlyConnection;
 import com.polarion.subterra.base.location.ILocation;
@@ -70,7 +76,6 @@ public class MediaUtils {
     public static final String URL_REGEX = "(?i)url\\(\\s*([\"'])?(?<url>.*?)\\1?\\s*\\)";
     public static final String DATA_URL_PREFIX = "data:";
     private static final String NETWORK_PATH_PREFIX = "//";
-    private static final String STYLE_ATTRIBUTE = "style";
     private static final Pattern CSS_ESCAPE_PATTERN = Pattern.compile("\\\\(?:([0-9a-fA-F]{1,6})[ \\t\\r\\n\\f]?|(.))", Pattern.DOTALL);
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
     /**
@@ -534,90 +539,35 @@ public class MediaUtils {
 
     /**
      * Hands the parts of an HTML document which are CSS, a style element and a style attribute, to the
-     * given rewriting. Everything else, a script or the text of the document, stays as it is. The regions
-     * are found by scanning: a pattern over a whole document is one more thing an editor could make slow.
+     * given rewriting, and puts the result back where it stood. JSoup says where those parts are, so
+     * every form HTML allows is covered and nothing outside a tag is mistaken for one. The document is
+     * not written back by JSoup: only the parts which changed are replaced in the original text.
      */
     private String processCssRegions(@NotNull String html, @NotNull UnaryOperator<String> rewrite) {
-        return processStyleAttributes(processStyleElements(html, rewrite), rewrite);
-    }
-
-    private String processStyleElements(@NotNull String html, @NotNull UnaryOperator<String> rewrite) {
-        String lowerCased = html.toLowerCase(Locale.ROOT);
-        StringBuilder result = new StringBuilder(html.length());
-        int index = 0;
-        int start;
-        while ((start = lowerCased.indexOf("<style", index)) >= 0) {
-            int contentStart = html.indexOf('>', start);
-            int contentEnd = contentStart < 0 ? -1 : lowerCased.indexOf("</style", contentStart);
-            if (contentEnd < 0) {
-                break;
+        Document document = Jsoup.parse(html, "", Parser.htmlParser().setTrackPosition(true));
+        List<int[]> regions = new ArrayList<>();
+        for (Element styleElement : document.select("style")) {
+            styleElement.dataNodes().stream()
+                    .map(DataNode::sourceRange)
+                    .filter(Range::isTracked)
+                    .forEach(range -> regions.add(new int[]{range.startPos(), range.endPos(), 0}));
+        }
+        for (Element element : document.select("[style]")) {
+            Range valueRange = element.attributes().sourceRange("style").valueRange();
+            if (valueRange.isTracked()) {
+                regions.add(new int[]{valueRange.startPos(), valueRange.endPos(), 1});
             }
-            result.append(html, index, contentStart + 1).append(rewrite.apply(html.substring(contentStart + 1, contentEnd)));
-            index = contentEnd;
         }
-        return result.append(html, index, html.length()).toString();
-    }
 
-    /**
-     * Rewrites the value of every style attribute. HTML allows whitespace around the equals sign and a
-     * value without quotes, so the attribute is read rather than matched.
-     */
-    private String processStyleAttributes(@NotNull String html, @NotNull UnaryOperator<String> rewrite) {
-        String lowerCased = html.toLowerCase(Locale.ROOT);
-        StringBuilder result = new StringBuilder(html.length());
-        int index = 0;
-        int start;
-        while ((start = lowerCased.indexOf(STYLE_ATTRIBUTE, index)) >= 0) {
-            int nameEnd = start + STYLE_ATTRIBUTE.length();
-            int equals = skipWhitespace(html, nameEnd);
-            if (!isInsideTag(html, start) || start > 0 && !isAttributeStart(html.charAt(start - 1))
-                    || equals >= html.length() || html.charAt(equals) != '=') {
-                result.append(html, index, nameEnd);
-                index = nameEnd;
-                continue;
-            }
-            int valueStart = skipWhitespace(html, equals + 1);
-            char quote = valueStart < html.length() ? html.charAt(valueStart) : 0;
-            boolean quoted = quote == '"' || quote == '\'';
-            int contentStart = quoted ? valueStart + 1 : valueStart;
-            int contentEnd = quoted ? html.indexOf(quote, contentStart) : endOfUnquotedValue(html, contentStart);
-            if (contentEnd < 0) {
-                result.append(html, index, nameEnd);
-                index = nameEnd;
-                continue;
-            }
-            result.append(html, index, contentStart).append(rewriteDeclarations(html.substring(contentStart, contentEnd), rewrite));
-            index = contentEnd;
-        }
-        return result.append(html, index, html.length()).toString();
-    }
-
-    /**
-     * An attribute lives inside a tag. The same word in the text of the document is text, and rewriting
-     * that as css would take it out of the document.
-     */
-    private boolean isInsideTag(@NotNull String html, int index) {
-        return html.lastIndexOf('<', index) > html.lastIndexOf('>', index);
-    }
-
-    private boolean isAttributeStart(char character) {
-        return Character.isWhitespace(character) || character == '\'' || character == '"' || character == '/';
-    }
-
-    private int skipWhitespace(@NotNull String html, int index) {
-        int i = index;
-        while (i < html.length() && Character.isWhitespace(html.charAt(i))) {
-            i++;
-        }
-        return i;
-    }
-
-    private int endOfUnquotedValue(@NotNull String html, int index) {
-        int i = index;
-        while (i < html.length() && !Character.isWhitespace(html.charAt(i)) && html.charAt(i) != '>') {
-            i++;
-        }
-        return i;
+        StringBuilder result = new StringBuilder(html);
+        regions.stream()
+                .filter(region -> region[0] >= 0 && region[1] >= region[0] && region[1] <= html.length())
+                .sorted((left, right) -> Integer.compare(right[0], left[0]))
+                .forEach(region -> {
+                    String css = html.substring(region[0], region[1]);
+                    result.replace(region[0], region[1], region[2] == 0 ? rewrite.apply(css) : rewriteDeclarations(css, rewrite));
+                });
+        return result.toString();
     }
 
     /**
@@ -625,11 +575,11 @@ public class MediaUtils {
      * for the parser and unwrapped afterwards.
      */
     private String rewriteDeclarations(@NotNull String declarations, @NotNull UnaryOperator<String> rewrite) {
-        String rewritten = rewrite.apply("a{" + declarations + "}").trim();
+        String rewritten = rewrite.apply("a{" + declarations + "}");
         int open = rewritten.indexOf('{');
         int close = rewritten.lastIndexOf('}');
         // an empty or unexpected result means the declarations were dropped, they do not come back
-        return open < 0 || close < open ? "" : rewritten.substring(open + 1, close).trim();
+        return open < 0 || close < open ? "" : rewritten.substring(open + 1, close);
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -50,7 +50,11 @@ import static ch.sbb.polarion.extension.pdf_exporter.util.TikaMimeTypeResolver.P
 @UtilityClass
 public class MediaUtils {
     public static final String IMG_SRC_REGEX = "<img[^<>]*src=(\"|')(?<url>[^(\"|')]*)(\"|')";
-    public static final String URL_REGEX = "url\\(\\s*([\"'])?(?<url>.*?)\\1?\\s*\\)";
+    public static final String URL_REGEX = "(?i)url\\(\\s*([\"'])?(?<url>.*?)\\1?\\s*\\)";
+    /**
+     * {@code @import "..."} without the {@code url(...)} wrapper, which {@link #URL_REGEX} does not match.
+     */
+    public static final String CSS_IMPORT_REGEX = "(?i)@import\\s+([\"'])(?<url>[^\"']+)\\1\\s*;?";
     public static final String DATA_URL_PREFIX = "data:";
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
     /**
@@ -276,21 +280,45 @@ public class MediaUtils {
             if (MediaUtils.isDataUrl(url)) {
                 return null;
             }
-            if (fileResourceProvider.isForbidden(url)) {
-                // the url is replaced, not kept, so that WeasyPrint does not load it either
-                return engine.group().replace(url, BLOCKED_RESOURCE_PLACEHOLDER);
+            if (!fileResourceProvider.isForbidden(url)) {
+                // For renderable images (e.g. .png, .svg) strip 'thumbnail' to fetch full-size content.
+                // For everything else (spreadsheets, documents, unknown formats) keep 'thumbnail' so Polarion returns an icon preview.
+                String resourceUrl = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
+                String base64String = fileResourceProvider.getResourceAsBase64String(resourceUrl);
+                if (base64String != null) {
+                    return engine.group().replace(url, base64String);
+                }
             }
-            // For renderable images (e.g. .png, .svg) strip 'thumbnail' to fetch full-size content.
-            // For everything else (spreadsheets, documents, unknown formats) keep 'thumbnail' so Polarion returns an icon preview.
-            String resourceUrl = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
-            String base64String = fileResourceProvider.getResourceAsBase64String(resourceUrl);
-            return base64String == null ? null : engine.group().replace(url, base64String);
+            // An absolute url which was not inlined, whatever the reason, must not stay in the HTML:
+            // WeasyPrint would load it from its own network position. A relative url is left untouched,
+            // WeasyPrint cannot resolve it.
+            return isAbsoluteHttpUrl(url) ? engine.group().replace(url, BLOCKED_RESOURCE_PLACEHOLDER) : null;
         };
 
+        // drop a forbidden '@import "..."', there is nothing to inline it with
+        RegexMatcher.IReplacementCalculator importReplacement = engine ->
+                fileResourceProvider.isForbidden(engine.group("url")) ? "" : null;
+
         // replace tags like <img src="...
-        String intermediateResult = RegexMatcher.get(IMG_SRC_REGEX).replace(content, dataReplacement);
+        String result = RegexMatcher.get(IMG_SRC_REGEX).replace(content, dataReplacement);
         // replace CSS parameters like background: src('/polarion/...
-        return RegexMatcher.get(URL_REGEX).useJavaUtil().replace(intermediateResult, dataReplacement);
+        result = RegexMatcher.get(URL_REGEX).useJavaUtil().replace(result, dataReplacement);
+        return RegexMatcher.get(CSS_IMPORT_REGEX).useJavaUtil().replace(result, importReplacement);
+    }
+
+    /**
+     * Normalizes a resource url the same way for the policy check and for the request itself.
+     */
+    public String normalizeUrl(@NotNull String url) {
+        return url.replace(" ", "%20").replace("%5F", "_");
+    }
+
+    public boolean isAbsoluteHttpUrl(@Nullable String url) {
+        if (url == null) {
+            return false;
+        }
+        String lowerCased = url.trim().toLowerCase(Locale.ROOT);
+        return lowerCased.startsWith("http://") || lowerCased.startsWith("https://");
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -3,18 +3,20 @@ package ch.sbb.polarion.extension.pdf_exporter.util;
 import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.generic.util.BundleJarsPrioritizingRunnable;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
+import com.helger.css.CSSSourceLocation;
 import com.helger.css.decl.CSSDeclaration;
+import com.helger.css.decl.CSSImportRule;
 import com.helger.css.decl.CSSExpressionMemberTermURI;
 import com.helger.css.decl.CascadingStyleSheet;
 import com.helger.css.decl.ICSSTopLevelRule;
 import com.helger.css.decl.visit.CSSVisitor;
+import com.helger.css.decl.CSSExpressionMemberTermSimple;
 import com.helger.css.decl.visit.DefaultCSSUrlVisitor;
+import com.helger.css.decl.visit.DefaultCSSVisitor;
 import com.helger.css.handler.DoNothingCSSParseExceptionCallback;
 import com.helger.css.reader.CSSReader;
 import com.helger.css.reader.CSSReaderSettings;
 import com.helger.css.reader.errorhandler.DoNothingCSSParseErrorHandler;
-import com.helger.css.writer.CSSWriter;
-import com.helger.css.writer.CSSWriterSettings;
 import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.PdfVariant;
 import ch.sbb.polarion.extension.pdf_exporter.service.PdfExporterPolarionService;
@@ -56,7 +58,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 
@@ -69,7 +70,7 @@ public class MediaUtils {
     public static final String URL_REGEX = "(?i)url\\(\\s*([\"'])?(?<url>.*?)\\1?\\s*\\)";
     public static final String DATA_URL_PREFIX = "data:";
     private static final String NETWORK_PATH_PREFIX = "//";
-    private static final String STYLE_ATTRIBUTE = "style=";
+    private static final String STYLE_ATTRIBUTE = "style";
     private static final Pattern CSS_ESCAPE_PATTERN = Pattern.compile("\\\\(?:([0-9a-fA-F]{1,6})[ \\t\\r\\n\\f]?|(.))", Pattern.DOTALL);
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
     /**
@@ -380,6 +381,10 @@ public class MediaUtils {
      * </p>
      */
     public String inlineCssResources(@NotNull String css, @NotNull FileResourceProvider fileResourceProvider) {
+        if (!namesAnAbsoluteAddress(css)) {
+            // nothing to check and nothing to rewrite, so the css stays exactly as the document has it
+            return css;
+        }
         CSSReaderSettings settings = new CSSReaderSettings()
                 // a browser keeps what it understands and skips the rest, and so does the conversion service
                 .setBrowserCompliantMode(true)
@@ -390,41 +395,141 @@ public class MediaUtils {
             logger.warn("Dropped a stylesheet which cannot be parsed, the resources it points at cannot be checked");
             return "";
         }
-        AtomicBoolean changed = new AtomicBoolean(false);
-        for (int i = stylesheet.getImportRuleCount() - 1; i >= 0; i--) {
-            if (isAbsoluteHttpUrl(stylesheet.getImportRuleAtIndex(i).getLocationString())) {
-                stylesheet.removeImportRule(i);
-                changed.set(true);
+
+        // The parser tells where each url and each import stands, and only those parts are rewritten.
+        // Everything else keeps the formatting the document came with.
+        List<CssEdit> edits = new ArrayList<>();
+        for (int i = 0; i < stylesheet.getImportRuleCount(); i++) {
+            CSSImportRule importRule = stylesheet.getImportRuleAtIndex(i);
+            if (isAbsoluteHttpUrl(decodeCssEscapes(importRule.getLocationString()))) {
+                edits.add(new CssEdit(importRule.getSourceLocation(), ""));
             }
         }
         CSSVisitor.visitCSSUrl(stylesheet, new DefaultCSSUrlVisitor() {
             @Override
             public void onUrlDeclaration(@Nullable ICSSTopLevelRule topLevelRule, @NotNull CSSDeclaration declaration, @NotNull CSSExpressionMemberTermURI uri) {
                 String replacement = replacementFor(fileResourceProvider, uri.getURIString());
-                if (replacement != null && !replacement.equals(uri.getURIString())) {
-                    uri.setURIString(replacement);
-                    changed.set(true);
+                if (replacement != null) {
+                    edits.add(new CssEdit(uri.getSourceLocation(), "url(\"" + replacement + "\")"));
                 }
             }
         });
-        String result = changed.get() ? new CSSWriter(new CSSWriterSettings()).setWriteHeaderText(false).getCSSAsString(stylesheet) : css;
-        if (pointsAtAnAbsoluteAddress(result)) {
-            // The parser did not surface this address, so nothing checked it. Whatever syntax hid it from
-            // the parser, WeasyPrint may well understand, so the stylesheet does not go on.
-            logger.warn("Dropped a stylesheet: it points at an absolute address which could not be read as a resource");
+
+        String result = applyEdits(css, edits);
+        if (namesAnAddressNothingRead(stylesheet, result)) {
+            logger.warn("Dropped a stylesheet: it names an absolute address which could not be read as a resource");
             return "";
         }
         return result;
     }
 
+    private record CssEdit(@Nullable CSSSourceLocation location, @NotNull String replacement) {
+    }
+
     /**
-     * Tells whether a stylesheet still names an absolute address after every url of it was rewritten.
-     * Nothing may: an allowed one is embedded as a data url by then, a rejected one is the placeholder,
-     * and an import of one is removed. So one that is left is one nothing understood.
+     * Applies the edits back to front, so that an offset stays valid while the ones before it are used.
      */
-    private boolean pointsAtAnAbsoluteAddress(@NotNull String css) {
-        String probe = decodeCssEscapes(css).toLowerCase(Locale.ROOT).replaceAll("data:[^)\"';\\s]*", "");
+    private String applyEdits(@NotNull String css, @NotNull List<CssEdit> edits) {
+        int[] lineStarts = lineStartsOf(css);
+        StringBuilder result = new StringBuilder(css);
+        edits.stream()
+                .filter(edit -> edit.location() != null)
+                .map(edit -> new int[]{offsetOf(lineStarts, css, edit.location().getFirstTokenBeginLineNumber(), edit.location().getFirstTokenBeginColumnNumber() - 1),
+                        offsetOf(lineStarts, css, edit.location().getLastTokenEndLineNumber(), edit.location().getLastTokenEndColumnNumber()), edits.indexOf(edit)})
+                .filter(range -> range[0] >= 0 && range[1] >= range[0] && range[1] <= css.length())
+                .sorted((left, right) -> Integer.compare(right[0], left[0]))
+                .forEach(range -> result.replace(range[0], range[1], edits.get(range[2]).replacement()));
+        return result.toString();
+    }
+
+    private int[] lineStartsOf(@NotNull String css) {
+        List<Integer> starts = new ArrayList<>();
+        starts.add(0);
+        for (int i = 0; i < css.length(); i++) {
+            if (css.charAt(i) == '\n') {
+                starts.add(i + 1);
+            }
+        }
+        return starts.stream().mapToInt(Integer::intValue).toArray();
+    }
+
+    private int offsetOf(int[] lineStarts, @NotNull String css, int line, int column) {
+        if (line < 1 || line > lineStarts.length) {
+            return -1;
+        }
+        int offset = lineStarts[line - 1] + column;
+        return offset > css.length() ? -1 : offset;
+    }
+
+    /**
+     * Tells whether a stylesheet names an address at all. A data url does not count, what it carries is
+     * the resource itself, and an SVG in one names the namespace of SVG.
+     */
+    private boolean namesAnAbsoluteAddress(@NotNull String css) {
+        // a data url ends at the bracket or the quote around it, the base64 of it may hold anything else
+        String probe = decodeCssEscapes(css).replaceAll("(?i)data:[^)\"']*", "").toLowerCase(Locale.ROOT);
         return probe.contains("http:") || probe.contains("https:") || probe.contains(NETWORK_PATH_PREFIX);
+    }
+
+    /**
+     * Tells whether a rewritten stylesheet still names an absolute address which nothing checked. Every
+     * url the parser read is a data url or the placeholder by then, and an import of an address is gone,
+     * so an address which is left hid from the parser and the stylesheet cannot be handed on.
+     * <p>
+     * A comment does not count, the renderer ignores it, and neither does a plain string value: css
+     * fetches nothing from a string, and a stylesheet may legitimately carry an address in one.
+     * </p>
+     */
+    private boolean namesAnAddressNothingRead(@NotNull CascadingStyleSheet stylesheet, @NotNull String css) {
+        List<String> readStrings = new ArrayList<>();
+        CSSVisitor.visitCSS(stylesheet, new DefaultCSSVisitor() {
+            @Override
+            public void onDeclaration(@NotNull CSSDeclaration declaration) {
+                declaration.getExpression().getAllMembers().stream()
+                        .filter(CSSExpressionMemberTermSimple.class::isInstance)
+                        .map(member -> ((CSSExpressionMemberTermSimple) member).getValue())
+                        .filter(value -> value.startsWith("\"") || value.startsWith("'"))
+                        .forEach(readStrings::add);
+            }
+        });
+        String probe = stripCssComments(css);
+        for (String readString : readStrings) {
+            probe = probe.replace(readString, "");
+        }
+        return namesAnAbsoluteAddress(probe);
+    }
+
+    /**
+     * Removes the comments of a stylesheet, for reading it only. A quoted string keeps what it holds,
+     * css starts no comment in there, and an unterminated comment runs to the end, as css says it does.
+     */
+    private String stripCssComments(@NotNull String css) {
+        StringBuilder result = new StringBuilder(css.length());
+        char quote = 0;
+        int i = 0;
+        while (i < css.length()) {
+            char current = css.charAt(i);
+            if (quote != 0) {
+                result.append(current);
+                if (current == '\\' && i + 1 < css.length()) {
+                    result.append(css.charAt(++i));
+                } else if (current == quote) {
+                    quote = 0;
+                }
+                i++;
+            } else if (current == '"' || current == '\'') {
+                quote = current;
+                result.append(current);
+                i++;
+            } else if (current == '/' && i + 1 < css.length() && css.charAt(i + 1) == '*') {
+                int end = css.indexOf("*/", i + 2);
+                i = end < 0 ? css.length() : end + 2;
+            } else {
+                result.append(current);
+                i++;
+            }
+        }
+        return result.toString();
     }
 
     /**
@@ -453,24 +558,66 @@ public class MediaUtils {
         return result.append(html, index, html.length()).toString();
     }
 
+    /**
+     * Rewrites the value of every style attribute. HTML allows whitespace around the equals sign and a
+     * value without quotes, so the attribute is read rather than matched.
+     */
     private String processStyleAttributes(@NotNull String html, @NotNull UnaryOperator<String> rewrite) {
         String lowerCased = html.toLowerCase(Locale.ROOT);
         StringBuilder result = new StringBuilder(html.length());
         int index = 0;
         int start;
         while ((start = lowerCased.indexOf(STYLE_ATTRIBUTE, index)) >= 0) {
-            int quoteAt = start + STYLE_ATTRIBUTE.length();
-            char quote = quoteAt < html.length() ? html.charAt(quoteAt) : 0;
-            int valueEnd = quote == '"' || quote == '\'' ? html.indexOf(quote, quoteAt + 1) : -1;
-            if (valueEnd < 0) {
-                result.append(html, index, quoteAt);
-                index = quoteAt;
+            int nameEnd = start + STYLE_ATTRIBUTE.length();
+            int equals = skipWhitespace(html, nameEnd);
+            if (!isInsideTag(html, start) || start > 0 && !isAttributeStart(html.charAt(start - 1))
+                    || equals >= html.length() || html.charAt(equals) != '=') {
+                result.append(html, index, nameEnd);
+                index = nameEnd;
                 continue;
             }
-            result.append(html, index, quoteAt + 1).append(rewriteDeclarations(html.substring(quoteAt + 1, valueEnd), rewrite));
-            index = valueEnd;
+            int valueStart = skipWhitespace(html, equals + 1);
+            char quote = valueStart < html.length() ? html.charAt(valueStart) : 0;
+            boolean quoted = quote == '"' || quote == '\'';
+            int contentStart = quoted ? valueStart + 1 : valueStart;
+            int contentEnd = quoted ? html.indexOf(quote, contentStart) : endOfUnquotedValue(html, contentStart);
+            if (contentEnd < 0) {
+                result.append(html, index, nameEnd);
+                index = nameEnd;
+                continue;
+            }
+            result.append(html, index, contentStart).append(rewriteDeclarations(html.substring(contentStart, contentEnd), rewrite));
+            index = contentEnd;
         }
         return result.append(html, index, html.length()).toString();
+    }
+
+    /**
+     * An attribute lives inside a tag. The same word in the text of the document is text, and rewriting
+     * that as css would take it out of the document.
+     */
+    private boolean isInsideTag(@NotNull String html, int index) {
+        return html.lastIndexOf('<', index) > html.lastIndexOf('>', index);
+    }
+
+    private boolean isAttributeStart(char character) {
+        return Character.isWhitespace(character) || character == '\'' || character == '"' || character == '/';
+    }
+
+    private int skipWhitespace(@NotNull String html, int index) {
+        int i = index;
+        while (i < html.length() && Character.isWhitespace(html.charAt(i))) {
+            i++;
+        }
+        return i;
+    }
+
+    private int endOfUnquotedValue(@NotNull String html, int index) {
+        int i = index;
+        while (i < html.length() && !Character.isWhitespace(html.charAt(i)) && html.charAt(i) != '>') {
+            i++;
+        }
+        return i;
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
@@ -71,10 +71,11 @@ public class PdfExporterFileResourceProvider implements FileResourceProvider {
      */
     @Override
     public boolean isForbidden(@NotNull String resource) {
-        if (!MediaUtils.isAbsoluteHttpUrl(resource)) {
+        // the escapes go first: '\\68 ttp://host' names an address as much as 'http://host' does
+        String candidate = MediaUtils.decodeCssEscapes(resource).trim();
+        if (!MediaUtils.isAbsoluteHttpUrl(candidate)) {
             return false;
         }
-        String candidate = MediaUtils.decodeCssEscapes(resource).trim();
         try {
             if (MediaUtils.isNetworkPathReference(candidate)) {
                 // '//host/path' has no scheme of its own and is loaded under both, so both decide here

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
@@ -74,10 +74,10 @@ public class PdfExporterFileResourceProvider implements FileResourceProvider {
         if (!MediaUtils.isAbsoluteHttpUrl(resource)) {
             return false;
         }
-        String candidate = resource.trim();
+        String candidate = MediaUtils.decodeCssEscapes(resource).trim();
         if (MediaUtils.isNetworkPathReference(candidate)) {
-            // '//host/path' has no scheme of its own, the check runs against the plain http reading of it
-            candidate = "http:" + candidate;
+            // '//host/path' has no scheme of its own, it gets the one of the Polarion base url
+            candidate = policy.getBaseUrlScheme() + ":" + candidate;
         }
         try {
             return !policy.isAllowed(URI.create(MediaUtils.normalizeUrl(candidate)).toURL());

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
@@ -1,5 +1,6 @@
 package ch.sbb.polarion.extension.pdf_exporter.util;
 
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
 import com.polarion.alm.shared.api.transaction.TransactionalExecutor;
 import com.polarion.alm.tracker.internal.url.GenericUrlResolver;
 import com.polarion.alm.tracker.internal.url.IAttachmentUrlResolver;
@@ -41,14 +42,40 @@ public class PdfExporterFileResourceProvider implements FileResourceProvider {
     private static final Logger logger = Logger.getLogger(PdfExporterFileResourceProvider.class);
 
     private final List<IUrlResolver> resolvers;
+    private final ResourceUrlPolicy policy;
 
     public PdfExporterFileResourceProvider() {
-        this.resolvers = Arrays.asList(getPolarionUrlResolverWithoutGenericUrlChildResolver(), new CustomResourceUrlResolver());
+        this(ResourceUrlPolicy.getInstance());
+    }
+
+    private PdfExporterFileResourceProvider(@NotNull ResourceUrlPolicy policy) {
+        this.policy = policy;
+        this.resolvers = Arrays.asList(getPolarionUrlResolverWithoutGenericUrlChildResolver(), new CustomResourceUrlResolver(policy));
     }
 
     @VisibleForTesting
     public PdfExporterFileResourceProvider(List<IUrlResolver> resolvers) {
+        this(resolvers, new ResourceUrlPolicy(ResourceUrlPolicy.Mode.ALLOW_ALL, null, null,
+                PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_MAX_SIZE_MB_DEFAULT_VALUE));
+    }
+
+    @VisibleForTesting
+    public PdfExporterFileResourceProvider(List<IUrlResolver> resolvers, @NotNull ResourceUrlPolicy policy) {
         this.resolvers = resolvers;
+        this.policy = policy;
+    }
+
+    @Override
+    public boolean isForbidden(@NotNull String resource) {
+        if (MediaUtils.isDataUrl(resource) || resource.startsWith("/")) {
+            return false;
+        }
+        try {
+            return !policy.isAllowed(URI.create(resource).toURL());
+        } catch (Exception e) {
+            logger.warn("Cannot parse the resource url '" + resource + "', it is treated as forbidden");
+            return true;
+        }
     }
 
     @SneakyThrows

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
@@ -74,8 +74,13 @@ public class PdfExporterFileResourceProvider implements FileResourceProvider {
         if (!MediaUtils.isAbsoluteHttpUrl(resource)) {
             return false;
         }
+        String candidate = resource.trim();
+        if (MediaUtils.isNetworkPathReference(candidate)) {
+            // '//host/path' has no scheme of its own, the check runs against the plain http reading of it
+            candidate = "http:" + candidate;
+        }
         try {
-            return !policy.isAllowed(URI.create(MediaUtils.normalizeUrl(resource.trim())).toURL());
+            return !policy.isAllowed(URI.create(MediaUtils.normalizeUrl(candidate)).toURL());
         } catch (Exception e) {
             logger.warn("Cannot parse the resource url '" + resource + "', it is treated as forbidden");
             return true;

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
@@ -75,11 +75,12 @@ public class PdfExporterFileResourceProvider implements FileResourceProvider {
             return false;
         }
         String candidate = MediaUtils.decodeCssEscapes(resource).trim();
-        if (MediaUtils.isNetworkPathReference(candidate)) {
-            // '//host/path' has no scheme of its own, it gets the one of the Polarion base url
-            candidate = policy.getBaseUrlScheme() + ":" + candidate;
-        }
         try {
+            if (MediaUtils.isNetworkPathReference(candidate)) {
+                // '//host/path' has no scheme of its own and is loaded under both, so both decide here
+                return !policy.isAllowed(URI.create(MediaUtils.normalizeUrl("https:" + candidate)).toURL())
+                        && !policy.isAllowed(URI.create(MediaUtils.normalizeUrl("http:" + candidate)).toURL());
+            }
             return !policy.isAllowed(URI.create(MediaUtils.normalizeUrl(candidate)).toURL());
         } catch (Exception e) {
             logger.warn("Cannot parse the resource url '" + resource + "', it is treated as forbidden");

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
@@ -65,13 +65,17 @@ public class PdfExporterFileResourceProvider implements FileResourceProvider {
         this.policy = policy;
     }
 
+    /**
+     * Only an absolute http(s) url is checked. A relative url, a data url and an SVG fragment like
+     * {@code url(#gradient)} are never requested over the network, so they stay untouched.
+     */
     @Override
     public boolean isForbidden(@NotNull String resource) {
-        if (MediaUtils.isDataUrl(resource) || resource.startsWith("/")) {
+        if (!MediaUtils.isAbsoluteHttpUrl(resource)) {
             return false;
         }
         try {
-            return !policy.isAllowed(URI.create(resource).toURL());
+            return !policy.isAllowed(URI.create(MediaUtils.normalizeUrl(resource.trim())).toURL());
         } catch (Exception e) {
             logger.warn("Cannot parse the resource url '" + resource + "', it is treated as forbidden");
             return true;

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
@@ -188,6 +188,24 @@ public class ResourceUrlPolicy {
     }
 
     /**
+     * Tells whether a refusal of this url turned on the port its scheme implies. An allowlist entry may
+     * carry a port, {@code cdn.example.com:443} names the https spelling of that host and only that one,
+     * so the same reference under the other scheme is a question of its own.
+     *
+     * @return true when the url is not exempt as it stands, while the port of the other scheme is
+     */
+    public boolean isRefusalPortSpecific(@NotNull URL url) {
+        String rawHost = url.getHost();
+        if (rawHost == null || rawHost.isBlank() || url.getPort() != -1) {
+            // a port written out is the port under either scheme, so nothing turns on the scheme here
+            return false;
+        }
+        String host = stripBrackets(rawHost.toLowerCase(Locale.ROOT));
+        int port = effectivePort(url.getProtocol(), -1);
+        return !isExempt(host, port) && isExempt(host, port == 443 ? 80 : 443);
+    }
+
+    /**
      * @return the scheme a network path reference like {@code //host/path} gets, taken from the Polarion
      * base url the conversion service reads the document with
      */

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
@@ -12,12 +12,14 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.security.Security;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Decides which resource URLs the exporter may request while inlining images, fonts and stylesheets.
@@ -33,10 +35,17 @@ public class ResourceUrlPolicy {
 
     private static final String HTTP = "http";
     private static final String HTTPS = "https";
+    private static final String ADDRESS_CACHE_TTL_PROPERTY = "networkaddress.cache.ttl";
+    private static final AtomicBoolean ADDRESS_CACHE_WARNED = new AtomicBoolean();
 
     private static final List<String> ALLOWED_CONTENT_TYPE_PREFIXES = List.of(
             "image/", "font/", "application/font", "application/x-font", "text/css",
             "application/octet-stream", "binary/octet-stream");
+
+    // XML is not listed on purpose: Tika reports a plain SVG as application/xml often enough,
+    // and rejecting it would drop legitimate images.
+    private static final Set<String> REJECTED_SNIFFED_TYPES = Set.of(
+            "text/html", "application/xhtml+xml", "application/json");
 
     private final Mode mode;
     private final Set<String> allowedHosts;
@@ -87,8 +96,27 @@ public class ResourceUrlPolicy {
         if (StringUtils.isEmptyTrimmed(contentType)) {
             return true;
         }
-        String mediaType = contentType.split(";")[0].trim().toLowerCase(Locale.ROOT);
+        String mediaType = mediaType(contentType);
         return ALLOWED_CONTENT_TYPE_PREFIXES.stream().anyMatch(mediaType::startsWith);
+    }
+
+    /**
+     * A missing or generic content type tells nothing, so the content itself has to be looked at.
+     */
+    public boolean isSniffingRequired(@Nullable String contentType) {
+        return StringUtils.isEmptyTrimmed(contentType) || mediaType(contentType).endsWith("/octet-stream");
+    }
+
+    /**
+     * @param sniffedType media type detected in the content, null when nothing was detected
+     * @return true if the content is a document, which no image, font or stylesheet ever is
+     */
+    public boolean isRejectedSniffedType(@Nullable String sniffedType) {
+        return sniffedType != null && REJECTED_SNIFFED_TYPES.contains(mediaType(sniffedType));
+    }
+
+    private static String mediaType(@NotNull String contentType) {
+        return contentType.split(";")[0].trim().toLowerCase(Locale.ROOT);
     }
 
     public boolean isAllowed(@NotNull URL url) {
@@ -126,8 +154,18 @@ public class ResourceUrlPolicy {
     /**
      * Every address the host resolves to must be public. A host resolving to both a public and a
      * private address is rejected, otherwise the private one stays reachable.
+     * <p>
+     * The connection resolves the same name a second time, so a DNS rebinding attack would need the
+     * answer to change between the two calls. It cannot: this call fills the JVM address cache, and
+     * the connection reads it from there. The cache holds a positive answer for
+     * {@code networkaddress.cache.ttl} seconds, 30 by default. An installation which sets that
+     * property to 0 loses this protection, therefore {@link #warnAboutDisabledAddressCache()} logs it.
+     * Binding the socket to the vetted address instead is not possible here: {@code HttpURLConnection}
+     * refuses a {@code Host} header, and a literal address would break TLS host name verification.
+     * </p>
      */
     private boolean hasOnlyPublicAddresses(@NotNull URL url, @NotNull String host) {
+        warnAboutDisabledAddressCache();
         try {
             InetAddress[] addresses = InetAddress.getAllByName(host);
             if (addresses.length == 0) {
@@ -215,6 +253,19 @@ public class ResourceUrlPolicy {
         int eleventh = bytes[10] & 0xFF;
         int twelfth = bytes[11] & 0xFF;
         return (eleventh == 0 && twelfth == 0) || (eleventh == 0xFF && twelfth == 0xFF);
+    }
+
+    /**
+     * Logs once if the JVM address cache is off, because the policy relies on it, see
+     * {@link #hasOnlyPublicAddresses}.
+     */
+    @VisibleForTesting
+    static void warnAboutDisabledAddressCache() {
+        if (ADDRESS_CACHE_WARNED.compareAndSet(false, true) && "0".equals(Security.getProperty(ADDRESS_CACHE_TTL_PROPERTY))) {
+            logger.warn("The java security property '" + ADDRESS_CACHE_TTL_PROPERTY + "' is 0, which turns the JVM address cache off."
+                    + " A host name can then resolve to a different address for the check and for the request itself."
+                    + " Set it to a positive value, or list the hosts a document may load resources from.");
+        }
     }
 
     private static boolean deny(@NotNull URL url, @NotNull String reason) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
@@ -235,10 +235,33 @@ public class ResourceUrlPolicy {
         if (isIpv4Embedded(bytes)) { // ::ffff:0:0/96 and ::/96, an IPv4 address in IPv6 form
             return isPublicIpv4(Arrays.copyOfRange(bytes, 12, 16));
         }
+        if (isNat64WellKnown(bytes)) { // 64:ff9b::/96, DNS64 answers with it and NAT64 forwards to the IPv4 address
+            return isPublicIpv4(Arrays.copyOfRange(bytes, 12, 16));
+        }
+        if (isNat64LocalUse(bytes)) { // 64:ff9b:1::/48, the IPv4 address can sit at several offsets in there
+            return false;
+        }
         if (first == 0x20 && second == 0x02) { // 2002::/16, 6to4 carries the IPv4 address in the prefix
             return isPublicIpv4(Arrays.copyOfRange(bytes, 2, 6));
         }
         return first != 0x20 || second != 0x01 || bytes[2] != 0 || bytes[3] != 0; // 2001:0::/32, Teredo
+    }
+
+    private static boolean isNat64WellKnown(byte[] bytes) {
+        if (bytes[0] != 0 || (bytes[1] & 0xFF) != 0x64 || (bytes[2] & 0xFF) != 0xFF || (bytes[3] & 0xFF) != 0x9B) {
+            return false;
+        }
+        for (int i = 4; i < 12; i++) {
+            if (bytes[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isNat64LocalUse(byte[] bytes) {
+        return bytes[0] == 0 && (bytes[1] & 0xFF) == 0x64 && (bytes[2] & 0xFF) == 0xFF && (bytes[3] & 0xFF) == 0x9B
+                && bytes[4] == 0 && (bytes[5] & 0xFF) == 0x01;
     }
 
     private static boolean isIpv4Embedded(byte[] bytes) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
@@ -142,16 +142,23 @@ public class ResourceUrlPolicy {
             return denyAddresses(url, "the host is not in " + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_HOSTS);
         }
 
+        return resolveAddresses(url, host, exempt);
+    }
+
+    /**
+     * Unless the host is exempt, every address it resolves to must be public. A host resolving to both a
+     * public and a private address is rejected, otherwise the private one stays reachable.
+     */
+    @Nullable
+    private InetAddress[] resolveAddresses(@NotNull URL url, @NotNull String host, boolean exempt) {
         try {
             InetAddress[] addresses = InetAddress.getAllByName(host);
             if (addresses.length == 0) {
                 return denyAddresses(url, "the host resolves to no address");
             }
-            if (!exempt) {
-                for (InetAddress address : addresses) {
-                    if (!isPublicAddress(address)) {
-                        return denyAddresses(url, "the host resolves to the non public address " + address.getHostAddress());
-                    }
+            for (InetAddress address : addresses) {
+                if (!exempt && !isPublicAddress(address)) {
+                    return denyAddresses(url, "the host resolves to the non public address " + address.getHostAddress());
                 }
             }
             return addresses;

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
@@ -45,6 +45,7 @@ public class ResourceUrlPolicy {
     private final Mode mode;
     private final Set<String> allowedHosts;
     private final String baseUrlHost;
+    private final String baseUrlScheme;
     private final int baseUrlPort;
     private final long maxResourceBytes;
 
@@ -62,6 +63,7 @@ public class ResourceUrlPolicy {
         URI baseUri = parseBaseUrl(baseUrl);
         this.baseUrlHost = baseUri == null || baseUri.getHost() == null ? null : baseUri.getHost().toLowerCase(Locale.ROOT);
         this.baseUrlPort = baseUri == null ? -1 : effectivePort(baseUri.getScheme(), baseUri.getPort());
+        this.baseUrlScheme = baseUri != null && HTTPS.equalsIgnoreCase(baseUri.getScheme()) ? HTTPS : HTTP;
     }
 
     public static ResourceUrlPolicy getInstance() {
@@ -137,7 +139,7 @@ public class ResourceUrlPolicy {
         String host = stripBrackets(rawHost.toLowerCase(Locale.ROOT));
         int port = effectivePort(protocol, url.getPort());
 
-        boolean exempt = isBaseUrlOrigin(host, port) || isExplicitlyAllowed(host, port) || mode == Mode.ALLOW_ALL;
+        boolean exempt = isExempt(host, port);
         if (!exempt && mode == Mode.ALLOWLIST_ONLY) {
             return denyAddresses(url, "the host is not in " + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_HOSTS);
         }
@@ -165,6 +167,33 @@ public class ResourceUrlPolicy {
         } catch (UnknownHostException e) {
             return denyAddresses(url, "the host cannot be resolved");
         }
+    }
+
+    /**
+     * Tells whether the configuration trusts the url as such, rather than its addresses: the Polarion
+     * server itself, a host the administrator listed, or any host when the policy is off. Only such a
+     * url may be requested through a proxy, where the connection cannot be pinned to a checked address.
+     */
+    public boolean isExplicitlyTrusted(@NotNull URL url) {
+        String rawHost = url.getHost();
+        if (rawHost == null || rawHost.isBlank()) {
+            return false;
+        }
+        String protocol = url.getProtocol() == null ? "" : url.getProtocol().toLowerCase(Locale.ROOT);
+        return isExempt(stripBrackets(rawHost.toLowerCase(Locale.ROOT)), effectivePort(protocol, url.getPort()));
+    }
+
+    private boolean isExempt(@NotNull String host, int port) {
+        return isBaseUrlOrigin(host, port) || isExplicitlyAllowed(host, port) || mode == Mode.ALLOW_ALL;
+    }
+
+    /**
+     * @return the scheme a network path reference like {@code //host/path} gets, taken from the Polarion
+     * base url the conversion service reads the document with
+     */
+    @NotNull
+    public String getBaseUrlScheme() {
+        return baseUrlScheme;
     }
 
     private static String stripBrackets(@NotNull String host) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
@@ -2,7 +2,6 @@ package ch.sbb.polarion.extension.pdf_exporter.util;
 
 import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
 import com.polarion.core.boot.PolarionProperties;
-import com.polarion.core.util.StringUtils;
 import com.polarion.core.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -12,14 +11,12 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.security.Security;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Decides which resource URLs the exporter may request while inlining images, fonts and stylesheets.
@@ -35,8 +32,6 @@ public class ResourceUrlPolicy {
 
     private static final String HTTP = "http";
     private static final String HTTPS = "https";
-    private static final String ADDRESS_CACHE_TTL_PROPERTY = "networkaddress.cache.ttl";
-    private static final AtomicBoolean ADDRESS_CACHE_WARNED = new AtomicBoolean();
 
     private static final List<String> ALLOWED_CONTENT_TYPE_PREFIXES = List.of(
             "image/", "font/", "application/font", "application/x-font", "text/css",
@@ -58,7 +53,7 @@ public class ResourceUrlPolicy {
         this.allowedHosts = new HashSet<>();
         if (allowedHosts != null) {
             allowedHosts.stream()
-                    .filter(host -> !StringUtils.isEmptyTrimmed(host))
+                    .filter(host -> host != null && !host.isBlank())
                     .map(host -> host.trim().toLowerCase(Locale.ROOT))
                     .forEach(this.allowedHosts::add);
         }
@@ -93,7 +88,7 @@ public class ResourceUrlPolicy {
      * could return. An absent content type is accepted, the content is sniffed later anyway.
      */
     public boolean isAllowedContentType(@Nullable String contentType) {
-        if (StringUtils.isEmptyTrimmed(contentType)) {
+        if (contentType == null || contentType.isBlank()) {
             return true;
         }
         String mediaType = mediaType(contentType);
@@ -104,7 +99,7 @@ public class ResourceUrlPolicy {
      * A missing or generic content type tells nothing, so the content itself has to be looked at.
      */
     public boolean isSniffingRequired(@Nullable String contentType) {
-        return StringUtils.isEmptyTrimmed(contentType) || mediaType(contentType).endsWith("/octet-stream");
+        return contentType == null || contentType.isBlank() || mediaType(contentType).endsWith("/octet-stream");
     }
 
     /**
@@ -120,27 +115,53 @@ public class ResourceUrlPolicy {
     }
 
     public boolean isAllowed(@NotNull URL url) {
+        return vetAddresses(url) != null;
+    }
+
+    /**
+     * @return the addresses the url may be requested from, null if the url may not be requested at all.
+     * The caller connects to exactly these addresses, which is what makes the check binding: a second
+     * name resolution cannot answer with an address this method did not see.
+     */
+    @Nullable
+    public InetAddress[] vetAddresses(@NotNull URL url) {
         String protocol = url.getProtocol() == null ? "" : url.getProtocol().toLowerCase(Locale.ROOT);
         if (!HTTP.equals(protocol) && !HTTPS.equals(protocol)) {
-            return deny(url, "only http and https are supported");
+            return denyAddresses(url, "only http and https are supported");
         }
 
-        String host = url.getHost();
-        if (StringUtils.isEmptyTrimmed(host)) {
-            return deny(url, "no host");
+        String rawHost = url.getHost();
+        if (rawHost == null || rawHost.isBlank()) {
+            return denyAddresses(url, "no host");
         }
-        host = host.toLowerCase(Locale.ROOT);
+        String host = stripBrackets(rawHost.toLowerCase(Locale.ROOT));
         int port = effectivePort(protocol, url.getPort());
 
-        if (isBaseUrlOrigin(host, port) || isExplicitlyAllowed(host, port)) {
-            return true;
+        boolean exempt = isBaseUrlOrigin(host, port) || isExplicitlyAllowed(host, port) || mode == Mode.ALLOW_ALL;
+        if (!exempt && mode == Mode.ALLOWLIST_ONLY) {
+            return denyAddresses(url, "the host is not in " + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_HOSTS);
         }
 
-        return switch (mode) {
-            case ALLOW_ALL -> true;
-            case ALLOWLIST_ONLY -> deny(url, "the host is not in " + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_HOSTS);
-            case BLOCK_INTERNAL -> hasOnlyPublicAddresses(url, host);
-        };
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            if (addresses.length == 0) {
+                return denyAddresses(url, "the host resolves to no address");
+            }
+            if (!exempt) {
+                for (InetAddress address : addresses) {
+                    if (!isPublicAddress(address)) {
+                        return denyAddresses(url, "the host resolves to the non public address " + address.getHostAddress());
+                    }
+                }
+            }
+            return addresses;
+        } catch (UnknownHostException e) {
+            return denyAddresses(url, "the host cannot be resolved");
+        }
+    }
+
+    private static String stripBrackets(@NotNull String host) {
+        return host.startsWith("[") && host.endsWith("]") ? host.substring(1, host.length() - 1) : host;
     }
 
     private boolean isBaseUrlOrigin(@NotNull String host, int port) {
@@ -149,37 +170,6 @@ public class ResourceUrlPolicy {
 
     private boolean isExplicitlyAllowed(@NotNull String host, int port) {
         return allowedHosts.contains(host) || allowedHosts.contains(host + ":" + port);
-    }
-
-    /**
-     * Every address the host resolves to must be public. A host resolving to both a public and a
-     * private address is rejected, otherwise the private one stays reachable.
-     * <p>
-     * The connection resolves the same name a second time, so a DNS rebinding attack would need the
-     * answer to change between the two calls. It cannot: this call fills the JVM address cache, and
-     * the connection reads it from there. The cache holds a positive answer for
-     * {@code networkaddress.cache.ttl} seconds, 30 by default. An installation which sets that
-     * property to 0 loses this protection, therefore {@link #warnAboutDisabledAddressCache()} logs it.
-     * Binding the socket to the vetted address instead is not possible here: {@code HttpURLConnection}
-     * refuses a {@code Host} header, and a literal address would break TLS host name verification.
-     * </p>
-     */
-    private boolean hasOnlyPublicAddresses(@NotNull URL url, @NotNull String host) {
-        warnAboutDisabledAddressCache();
-        try {
-            InetAddress[] addresses = InetAddress.getAllByName(host);
-            if (addresses.length == 0) {
-                return deny(url, "the host resolves to no address");
-            }
-            for (InetAddress address : addresses) {
-                if (!isPublicAddress(address)) {
-                    return deny(url, "the host resolves to the non public address " + address.getHostAddress());
-                }
-            }
-            return true;
-        } catch (UnknownHostException e) {
-            return deny(url, "the host cannot be resolved");
-        }
     }
 
     @VisibleForTesting
@@ -255,28 +245,16 @@ public class ResourceUrlPolicy {
         return (eleventh == 0 && twelfth == 0) || (eleventh == 0xFF && twelfth == 0xFF);
     }
 
-    /**
-     * Logs once if the JVM address cache is off, because the policy relies on it, see
-     * {@link #hasOnlyPublicAddresses}.
-     */
-    @VisibleForTesting
-    static void warnAboutDisabledAddressCache() {
-        if (ADDRESS_CACHE_WARNED.compareAndSet(false, true) && "0".equals(Security.getProperty(ADDRESS_CACHE_TTL_PROPERTY))) {
-            logger.warn("The java security property '" + ADDRESS_CACHE_TTL_PROPERTY + "' is 0, which turns the JVM address cache off."
-                    + " A host name can then resolve to a different address for the check and for the request itself."
-                    + " Set it to a positive value, or list the hosts a document may load resources from.");
-        }
-    }
-
-    private static boolean deny(@NotNull URL url, @NotNull String reason) {
+    @Nullable
+    private static InetAddress[] denyAddresses(@NotNull URL url, @NotNull String reason) {
         logger.warn("Blocked the request to '" + url + "': " + reason
                 + ". See the '" + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY + "' property.");
-        return false;
+        return null;
     }
 
     @Nullable
     private static URI parseBaseUrl(@Nullable String baseUrl) {
-        if (StringUtils.isEmptyTrimmed(baseUrl)) {
+        if (baseUrl == null || baseUrl.isBlank()) {
             return null;
         }
         try {
@@ -309,7 +287,7 @@ public class ResourceUrlPolicy {
         ALLOW_ALL;
 
         public static Mode parse(@Nullable String value) {
-            if (!StringUtils.isEmptyTrimmed(value)) {
+            if (value != null && !value.isBlank()) {
                 String normalized = value.trim().replace("_", "").replace("-", "");
                 for (Mode mode : values()) {
                     if (mode.name().replace("_", "").equalsIgnoreCase(normalized)) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
@@ -1,0 +1,272 @@
+package ch.sbb.polarion.extension.pdf_exporter.util;
+
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
+import com.polarion.core.boot.PolarionProperties;
+import com.polarion.core.util.StringUtils;
+import com.polarion.core.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Decides which resource URLs the exporter may request while inlining images, fonts and stylesheets.
+ * <p>
+ * A document editor controls those URLs. Without a policy the Polarion server would fetch any address
+ * on behalf of the editor and the response body would end up in the exported document, which is a
+ * server side request forgery with full read access to the server's network.
+ * </p>
+ */
+public class ResourceUrlPolicy {
+
+    private static final Logger logger = Logger.getLogger(ResourceUrlPolicy.class);
+
+    private static final String HTTP = "http";
+    private static final String HTTPS = "https";
+
+    private static final List<String> ALLOWED_CONTENT_TYPE_PREFIXES = List.of(
+            "image/", "font/", "application/font", "application/x-font", "text/css",
+            "application/octet-stream", "binary/octet-stream");
+
+    private final Mode mode;
+    private final Set<String> allowedHosts;
+    private final String baseUrlHost;
+    private final int baseUrlPort;
+    private final long maxResourceBytes;
+
+    public ResourceUrlPolicy(@NotNull Mode mode, @Nullable Collection<String> allowedHosts, @Nullable String baseUrl, int maxSizeMB) {
+        this.mode = mode;
+        this.allowedHosts = new HashSet<>();
+        if (allowedHosts != null) {
+            allowedHosts.stream()
+                    .filter(host -> !StringUtils.isEmptyTrimmed(host))
+                    .map(host -> host.trim().toLowerCase(Locale.ROOT))
+                    .forEach(this.allowedHosts::add);
+        }
+        this.maxResourceBytes = (long) maxSizeMB * 1024 * 1024;
+
+        URI baseUri = parseBaseUrl(baseUrl);
+        this.baseUrlHost = baseUri == null || baseUri.getHost() == null ? null : baseUri.getHost().toLowerCase(Locale.ROOT);
+        this.baseUrlPort = baseUri == null ? -1 : effectivePort(baseUri.getScheme(), baseUri.getPort());
+    }
+
+    public static ResourceUrlPolicy getInstance() {
+        PdfExporterExtensionConfiguration configuration = PdfExporterExtensionConfiguration.getInstance();
+        return new ResourceUrlPolicy(
+                Mode.parse(configuration.getExternalResourcesPolicy()),
+                Arrays.asList(configuration.getExternalResourcesAllowedHosts().split(",")),
+                System.getProperty(PolarionProperties.BASE_URL),
+                configuration.getExternalResourcesMaxSizeMB());
+    }
+
+    /**
+     * @return maximal size in bytes a single fetched resource may reach
+     */
+    public long getMaxResourceBytes() {
+        return maxResourceBytes;
+    }
+
+    /**
+     * Checks the content type a remote host reports for a resource. An internal service answers with
+     * its own media type, JSON as a rule, so this check stops most of the responses a forged request
+     * could return. An absent content type is accepted, the content is sniffed later anyway.
+     */
+    public boolean isAllowedContentType(@Nullable String contentType) {
+        if (StringUtils.isEmptyTrimmed(contentType)) {
+            return true;
+        }
+        String mediaType = contentType.split(";")[0].trim().toLowerCase(Locale.ROOT);
+        return ALLOWED_CONTENT_TYPE_PREFIXES.stream().anyMatch(mediaType::startsWith);
+    }
+
+    public boolean isAllowed(@NotNull URL url) {
+        String protocol = url.getProtocol() == null ? "" : url.getProtocol().toLowerCase(Locale.ROOT);
+        if (!HTTP.equals(protocol) && !HTTPS.equals(protocol)) {
+            return deny(url, "only http and https are supported");
+        }
+
+        String host = url.getHost();
+        if (StringUtils.isEmptyTrimmed(host)) {
+            return deny(url, "no host");
+        }
+        host = host.toLowerCase(Locale.ROOT);
+        int port = effectivePort(protocol, url.getPort());
+
+        if (isBaseUrlOrigin(host, port) || isExplicitlyAllowed(host, port)) {
+            return true;
+        }
+
+        return switch (mode) {
+            case ALLOW_ALL -> true;
+            case ALLOWLIST_ONLY -> deny(url, "the host is not in " + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_HOSTS);
+            case BLOCK_INTERNAL -> hasOnlyPublicAddresses(url, host);
+        };
+    }
+
+    private boolean isBaseUrlOrigin(@NotNull String host, int port) {
+        return host.equals(baseUrlHost) && port == baseUrlPort;
+    }
+
+    private boolean isExplicitlyAllowed(@NotNull String host, int port) {
+        return allowedHosts.contains(host) || allowedHosts.contains(host + ":" + port);
+    }
+
+    /**
+     * Every address the host resolves to must be public. A host resolving to both a public and a
+     * private address is rejected, otherwise the private one stays reachable.
+     */
+    private boolean hasOnlyPublicAddresses(@NotNull URL url, @NotNull String host) {
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            if (addresses.length == 0) {
+                return deny(url, "the host resolves to no address");
+            }
+            for (InetAddress address : addresses) {
+                if (!isPublicAddress(address)) {
+                    return deny(url, "the host resolves to the non public address " + address.getHostAddress());
+                }
+            }
+            return true;
+        } catch (UnknownHostException e) {
+            return deny(url, "the host cannot be resolved");
+        }
+    }
+
+    @VisibleForTesting
+    static boolean isPublicAddress(@NotNull InetAddress address) {
+        if (address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress() || address.isMulticastAddress()) {
+            return false;
+        }
+        byte[] bytes = address.getAddress();
+        return bytes.length == 4 ? isPublicIpv4(bytes) : isPublicIpv6(bytes);
+    }
+
+    @SuppressWarnings("java:S3776") // the ranges read better as a flat list of guards
+    private static boolean isPublicIpv4(byte[] bytes) {
+        int first = bytes[0] & 0xFF;
+        int second = bytes[1] & 0xFF;
+        int third = bytes[2] & 0xFF;
+
+        if (first == 0) { // 0.0.0.0/8, "this network"
+            return false;
+        }
+        if (first == 10 || first == 127) { // 10.0.0.0/8 private, 127.0.0.0/8 loopback
+            return false;
+        }
+        if (first == 172 && second >= 16 && second <= 31) { // 172.16.0.0/12, private
+            return false;
+        }
+        if (first == 192 && second == 168) { // 192.168.0.0/16, private
+            return false;
+        }
+        if (first == 169 && second == 254) { // 169.254.0.0/16, link local, holds the cloud metadata address
+            return false;
+        }
+        if (first >= 224 && first <= 239) { // 224.0.0.0/4, multicast
+            return false;
+        }
+        if (first == 100 && second >= 64 && second <= 127) { // 100.64.0.0/10, carrier grade NAT
+            return false;
+        }
+        if (first == 192 && second == 0 && third == 0) { // 192.0.0.0/24, IETF protocol assignments
+            return false;
+        }
+        if (first == 198 && (second == 18 || second == 19)) { // 198.18.0.0/15, benchmarking
+            return false;
+        }
+        return first < 240; // 240.0.0.0/4, reserved, includes the broadcast address
+    }
+
+    private static boolean isPublicIpv6(byte[] bytes) {
+        int first = bytes[0] & 0xFF;
+        int second = bytes[1] & 0xFF;
+
+        if ((first & 0xFE) == 0xFC) { // fc00::/7, unique local
+            return false;
+        }
+        if (isIpv4Embedded(bytes)) { // ::ffff:0:0/96 and ::/96, an IPv4 address in IPv6 form
+            return isPublicIpv4(Arrays.copyOfRange(bytes, 12, 16));
+        }
+        if (first == 0x20 && second == 0x02) { // 2002::/16, 6to4 carries the IPv4 address in the prefix
+            return isPublicIpv4(Arrays.copyOfRange(bytes, 2, 6));
+        }
+        return first != 0x20 || second != 0x01 || bytes[2] != 0 || bytes[3] != 0; // 2001:0::/32, Teredo
+    }
+
+    private static boolean isIpv4Embedded(byte[] bytes) {
+        for (int i = 0; i < 10; i++) {
+            if (bytes[i] != 0) {
+                return false;
+            }
+        }
+        int eleventh = bytes[10] & 0xFF;
+        int twelfth = bytes[11] & 0xFF;
+        return (eleventh == 0 && twelfth == 0) || (eleventh == 0xFF && twelfth == 0xFF);
+    }
+
+    private static boolean deny(@NotNull URL url, @NotNull String reason) {
+        logger.warn("Blocked the request to '" + url + "': " + reason
+                + ". See the '" + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY + "' property.");
+        return false;
+    }
+
+    @Nullable
+    private static URI parseBaseUrl(@Nullable String baseUrl) {
+        if (StringUtils.isEmptyTrimmed(baseUrl)) {
+            return null;
+        }
+        try {
+            return URI.create(baseUrl.trim());
+        } catch (IllegalArgumentException e) {
+            logger.warn("Cannot parse the Polarion base url '" + baseUrl + "'");
+            return null;
+        }
+    }
+
+    private static int effectivePort(@Nullable String scheme, int port) {
+        if (port != -1) {
+            return port;
+        }
+        return HTTPS.equalsIgnoreCase(scheme) ? 443 : 80;
+    }
+
+    public enum Mode {
+        /**
+         * Requests to loopback, private, link local and other non public addresses are rejected.
+         */
+        BLOCK_INTERNAL,
+        /**
+         * Only the Polarion base url and the explicitly allowed hosts may be requested.
+         */
+        ALLOWLIST_ONLY,
+        /**
+         * No restriction. The behavior before the policy existed, it exposes the server's network.
+         */
+        ALLOW_ALL;
+
+        public static Mode parse(@Nullable String value) {
+            if (!StringUtils.isEmptyTrimmed(value)) {
+                String normalized = value.trim().replace("_", "").replace("-", "");
+                for (Mode mode : values()) {
+                    if (mode.name().replace("_", "").equalsIgnoreCase(normalized)) {
+                        return mode;
+                    }
+                }
+                logger.warn("Unknown value '" + value + "' of the property "
+                        + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY + ", falling back to " + BLOCK_INTERNAL);
+            }
+            return BLOCK_INTERNAL;
+        }
+    }
+}

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
@@ -62,11 +62,13 @@ public class ResourceUrlPolicy {
 
     public static ResourceUrlPolicy getInstance() {
         PdfExporterExtensionConfiguration configuration = PdfExporterExtensionConfiguration.getInstance();
+        String allowedHosts = configuration.getExternalResourcesAllowedHosts();
+        int maxSizeMB = configuration.getExternalResourcesMaxSizeMB();
         return new ResourceUrlPolicy(
                 Mode.parse(configuration.getExternalResourcesPolicy()),
-                Arrays.asList(configuration.getExternalResourcesAllowedHosts().split(",")),
+                allowedHosts == null ? List.of() : Arrays.asList(allowedHosts.split(",")),
                 System.getProperty(PolarionProperties.BASE_URL),
-                configuration.getExternalResourcesMaxSizeMB());
+                maxSizeMB > 0 ? maxSizeMB : PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_MAX_SIZE_MB_DEFAULT_VALUE);
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizer.java
@@ -36,9 +36,9 @@ public class ExternalCssInternalizer implements LinkInternalizer {
         }
         inlinedContent.append(">");
 
-        String cssContent = MediaUtils.stripCssComments(new String(fileResourceProvider.getResourceAsBytes(url)));
+        String cssContent = new String(fileResourceProvider.getResourceAsBytes(url));
         cssContent = processRelativeUrls(url, cssContent);
-        cssContent = MediaUtils.inlineBase64Resources(cssContent, fileResourceProvider);
+        cssContent = MediaUtils.inlineCssResources(cssContent, fileResourceProvider);
         inlinedContent.append(cssContent);
         inlinedContent.append("</style>");
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizer.java
@@ -36,7 +36,7 @@ public class ExternalCssInternalizer implements LinkInternalizer {
         }
         inlinedContent.append(">");
 
-        String cssContent = new String(fileResourceProvider.getResourceAsBytes(url));
+        String cssContent = MediaUtils.stripCssComments(new String(fileResourceProvider.getResourceAsBytes(url)));
         cssContent = processRelativeUrls(url, cssContent);
         cssContent = MediaUtils.inlineBase64Resources(cssContent, fileResourceProvider);
         inlinedContent.append(cssContent);

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizer.java
@@ -5,6 +5,7 @@ import ch.sbb.polarion.extension.pdf_exporter.util.FileResourceProvider;
 import ch.sbb.polarion.extension.pdf_exporter.util.MediaUtils;
 import com.polarion.core.util.StringUtils;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -53,7 +54,9 @@ public class ExternalCssInternalizer implements LinkInternalizer {
         String resourcePath = resourceUrl.substring(0, lastSlashPosition + 1);
         return RegexMatcher.get(MediaUtils.URL_REGEX).useJavaUtil().replace(cssContent, engine -> {
             String url = engine.group("url");
-            return Stream.of("/", "http:", "https:", MediaUtils.DATA_URL_PREFIX).anyMatch(url::startsWith) ? null :
+            // the pattern reads a url in any case, so the prefixes are compared in one
+            String lowerCased = url.toLowerCase(Locale.ROOT);
+            return Stream.of("/", "http:", "https:", MediaUtils.DATA_URL_PREFIX).anyMatch(lowerCased::startsWith) ? null :
                     "url(%s%s)".formatted(resourcePath, url);
         });
     }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessorTest.java
@@ -129,7 +129,7 @@ class CoverPageProcessorTest {
         when(coverPageSettings.processImagePlaceholders("test template css")).thenCallRealMethod();
         when(pdfTemplateProcessor.processUsing(eq(exportParams), eq("test document"), eq("test template css"), eq("replaced template html"), eq(""), any())).thenReturn("result title html");
         when(htmlProcessor.replaceResourcesAsBase64Encoded("replaced template html")).thenReturn("replaced template html");
-        when(htmlProcessor.replaceResourcesAsBase64Encoded("test template css")).thenReturn("test template css");
+        when(htmlProcessor.replaceCssResourcesAsBase64Encoded("test template css")).thenReturn("test template css");
         return documentData;
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterTest.java
@@ -117,6 +117,7 @@ class PdfConverterTest {
         when(weasyPrintServiceConnector.convertToPdf(eq("test html content"), any(WeasyPrintOptions.class), any(), any())).thenReturn("test document content".getBytes());
         when(htmlProcessor.internalizeLinks(anyString())).thenAnswer(a -> a.getArgument(0));
         when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
+        lenient().when(htmlProcessor.replaceCssResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
 
         // Act
         byte[] result = pdfConverter.convertToPdf(exportParams, null);
@@ -151,7 +152,7 @@ class PdfConverterTest {
         when(pdfExporterPolarionService.getPolarionProductName()).thenReturn("testProductName");
         when(pdfExporterPolarionService.getPolarionVersion()).thenReturn("testVersion");
         lenient().when(module.getCustomField("customField")).thenReturn("customValue");
-        when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
+        when(htmlProcessor.replaceCssResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
 
         String cssContent = pdfConverter.getCssContent(documentData, exportParams);
 
@@ -194,6 +195,7 @@ class PdfConverterTest {
 
         when(velocityEvaluator.evaluateVelocityExpressions(eq(documentData), anyString())).thenAnswer(a -> a.getArguments()[1]);
         when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
+        lenient().when(htmlProcessor.replaceCssResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
 
         // Act
         PdfConverter pdfConverter = new PdfConverter(null, headerFooterSettings, null, placeholderProcessor, velocityEvaluator, null, null, htmlProcessor, null);
@@ -419,6 +421,7 @@ class PdfConverterTest {
         when(velocityEvaluator.evaluateVelocityExpressions(eq(documentData), anyString())).thenAnswer(a -> a.getArguments()[1]);
         when(htmlProcessor.internalizeLinks(anyString())).thenAnswer(a -> a.getArgument(0));
         when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
+        lenient().when(htmlProcessor.replaceCssResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
 
         when(module.getValue("field1")).thenReturn("Value & <one>");
         when(module.getValue("my_field")).thenReturn("Quote\"Val");
@@ -472,6 +475,7 @@ class PdfConverterTest {
         when(velocityEvaluator.evaluateVelocityExpressions(eq(documentData), anyString())).thenAnswer(a -> a.getArguments()[1]);
         when(htmlProcessor.internalizeLinks(anyString())).thenAnswer(a -> a.getArgument(0));
         when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
+        lenient().when(htmlProcessor.replaceCssResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
 
         ArgumentCaptor<String> metaCaptor = ArgumentCaptor.forClass(String.class);
         when(pdfTemplateProcessor.processUsing(any(ExportParams.class), anyString(), anyString(), anyString(), metaCaptor.capture(), any()))

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfigurationTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfigurationTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -127,11 +128,45 @@ class PdfExporterExtensionConfigurationTest {
     }
 
     @Test
+    void getExternalResourcesPolicyReturnsConfiguredValue() {
+        when(systemValueReader.readString(anyString(), anyString())).thenReturn("allowlistOnly");
+
+        assertEquals("allowlistOnly", configuration.getExternalResourcesPolicy());
+    }
+
+    @Test
+    void getExternalResourcesAllowedHostsReturnsConfiguredValue() {
+        when(systemValueReader.readString(anyString(), anyString())).thenReturn("cdn.intranet");
+
+        assertEquals("cdn.intranet", configuration.getExternalResourcesAllowedHosts());
+    }
+
+    @Test
+    void getExternalResourcesMaxSizeMBReturnsConfiguredValue() {
+        when(systemValueReader.readInt(anyString(), anyInt())).thenReturn(32);
+
+        assertEquals(32, configuration.getExternalResourcesMaxSizeMB());
+    }
+
+    @Test
+    void getExternalResourcesDescriptionsAndDefaultsReturnConstants() {
+        assertEquals(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY_DESCRIPTION, configuration.getExternalResourcesPolicyDescription());
+        assertEquals(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY_DEFAULT_VALUE, configuration.getExternalResourcesPolicyDefaultValue());
+        assertEquals(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_HOSTS_DESCRIPTION, configuration.getExternalResourcesAllowedHostsDescription());
+        assertEquals(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_HOSTS_DEFAULT_VALUE, configuration.getExternalResourcesAllowedHostsDefaultValue());
+        assertEquals(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_MAX_SIZE_MB_DESCRIPTION, configuration.getExternalResourcesMaxSizeMBDescription());
+        assertEquals("16", configuration.getExternalResourcesMaxSizeMBDefaultValue());
+    }
+
+    @Test
     void getSupportedPropertiesContainsAllProperties() {
         var properties = configuration.getSupportedProperties();
 
         assertTrue(properties.contains(PdfExporterExtensionConfiguration.WEASYPRINT_SERVICE));
         assertTrue(properties.contains(PdfExporterExtensionConfiguration.WEBHOOKS_ENABLED));
         assertTrue(properties.contains(PdfExporterExtensionConfiguration.RENDERABLE_IMAGE_EXTENSIONS));
+        assertTrue(properties.contains(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY));
+        assertTrue(properties.contains(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_HOSTS));
+        assertTrue(properties.contains(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_MAX_SIZE_MB));
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -16,21 +16,24 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
-import java.security.cert.CertificateException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
-import java.net.SocketAddress;
-import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.io.InputStream;
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -347,16 +350,8 @@ class CustomResourceUrlResolverTest {
         // the client plans no route to a socks proxy, the jvm applies it under the connection, so a
         // socks setup keeps working: the request reaches the proxy rather than the host directly
         try (ServerSocket socksProxy = new ServerSocket(0)) {
-            AtomicBoolean reached = new AtomicBoolean();
-            Thread listener = new Thread(() -> {
-                try (Socket accepted = socksProxy.accept()) {
-                    reached.set(accepted != null);
-                } catch (IOException e) {
-                    // the test asks whether the connection arrived, and nothing else
-                }
-            });
-            listener.setDaemon(true);
-            listener.start();
+            SocksRequest seen = new SocksRequest();
+            Thread listener = readSocksRequest(socksProxy, seen);
             System.setProperty("socksProxyHost", "127.0.0.1");
             System.setProperty("socksProxyPort", String.valueOf(socksProxy.getLocalPort()));
             try {
@@ -365,12 +360,79 @@ class CustomResourceUrlResolverTest {
                 assertNull(new CustomResourceUrlResolver(policy).resolve("http://8.8.8.8/img.png"));
 
                 listener.join(5000);
-                assertTrue(reached.get());
+                assertTrue(seen.reached.get());
+                // and it names an address, never a host name the proxy would resolve on its own
+                assertEquals(SOCKS_ADDRESS_TYPE_IPV4, seen.addressType.get());
+                assertEquals("8.8.8.8", seen.address.get());
             } finally {
                 System.clearProperty("socksProxyHost");
                 System.clearProperty("socksProxyPort");
             }
         }
+    }
+
+    @Test
+    @SneakyThrows
+    void namesTheVettedAddressToASocksProxyRatherThanTheHost() {
+        // a proxy which resolves the host name itself would decide the address, and that is what this
+        // asks: the request names an address, so the name never reaches the proxy
+        try (ServerSocket socksProxy = new ServerSocket(0)) {
+            SocksRequest seen = new SocksRequest();
+            Thread listener = readSocksRequest(socksProxy, seen);
+            System.setProperty("socksProxyHost", "127.0.0.1");
+            System.setProperty("socksProxyPort", String.valueOf(socksProxy.getLocalPort()));
+            // the jvm keeps loopback out of every proxy by default, and here the proxy is the point
+            System.setProperty("socksNonProxyHosts", "");
+            try {
+                ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), null, 16);
+
+                assertNull(new CustomResourceUrlResolver(policy).resolve("http://localhost:" + server.getAddress().getPort() + "/img.png"));
+
+                listener.join(5000);
+                assertTrue(seen.reached.get());
+                assertEquals(SOCKS_ADDRESS_TYPE_IPV4, seen.addressType.get());
+                assertEquals("127.0.0.1", seen.address.get());
+            } finally {
+                System.clearProperty("socksProxyHost");
+                System.clearProperty("socksProxyPort");
+                System.clearProperty("socksNonProxyHosts");
+            }
+        }
+    }
+
+    /**
+     * Answers the greeting of a socks 5 client and keeps what its request names, then closes.
+     */
+    private Thread readSocksRequest(ServerSocket socksProxy, SocksRequest seen) {
+        Thread listener = new Thread(() -> {
+            try (Socket accepted = socksProxy.accept()) {
+                InputStream in = accepted.getInputStream();
+                in.read();
+                int methods = in.read();
+                in.readNBytes(Math.max(methods, 0));
+                accepted.getOutputStream().write(new byte[]{5, 0});
+                accepted.getOutputStream().flush();
+                byte[] head = in.readNBytes(4);
+                seen.reached.set(head.length == 4);
+                seen.addressType.set(head.length == 4 ? head[3] : -1);
+                if (head.length == 4 && head[3] == SOCKS_ADDRESS_TYPE_IPV4) {
+                    seen.address.set(InetAddress.getByAddress(in.readNBytes(4)).getHostAddress());
+                }
+            } catch (IOException e) {
+                // the test asks what the request named, and a closed connection names nothing
+            }
+        });
+        listener.setDaemon(true);
+        listener.start();
+        return listener;
+    }
+
+    private static final int SOCKS_ADDRESS_TYPE_IPV4 = 1;
+
+    private static final class SocksRequest {
+        private final AtomicBoolean reached = new AtomicBoolean();
+        private final AtomicInteger addressType = new AtomicInteger(-1);
+        private final AtomicReference<String> address = new AtomicReference<>();
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -261,6 +262,19 @@ class CustomResourceUrlResolverTest {
             assertNotNull(stream);
             assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
         }
+    }
+
+    @Test
+    @SneakyThrows
+    void keepsTheAnswerOfTheFirstSchemeOfANetworkPathReference() {
+        // the host answered, and 404 is an answer: asking it again over the other scheme adds nothing
+        status("/missing.png", 404);
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), "http://localhost", 16);
+        CustomResourceUrlResolver resolver = spy(new CustomResourceUrlResolver(policy));
+
+        assertNull(resolver.resolve("//127.0.0.1:" + server.getAddress().getPort() + "/missing.png"));
+
+        verify(resolver, times(1)).resolveImpl(any());
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -6,6 +6,7 @@ import ch.sbb.polarion.extension.generic.test_extensions.BundleJarsPrioritizingR
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import lombok.SneakyThrows;
+import org.apache.http.HttpHost;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -498,6 +499,42 @@ class CustomResourceUrlResolverTest {
             System.clearProperty("http.proxyHost");
             System.clearProperty("http.proxyPort");
         }
+    }
+
+    @Test
+    void readsTheProxyListAsTheJvmReadsIt() {
+        // a pac file writing 'DIRECT; PROXY host:port' means direct, and the entry after it is a fallback
+        CustomResourceUrlResolver resolver = resolver(16);
+        HttpHost proxyHost = new HttpHost("proxy.invalid", 3128);
+
+        assertFalse(resolver.decideProxy(selectorOf(Proxy.NO_PROXY, httpProxy()), toUrl("http://8.8.8.8/i.png")).proxied());
+        assertTrue(resolver.decideProxy(selectorOf(httpProxy(), Proxy.NO_PROXY), toUrl("http://8.8.8.8/i.png")).proxied());
+        // a socks entry is no route the client plans, so it decides nothing either way
+        assertEquals(proxyHost.toHostString(),
+                resolver.decideProxy(selectorOf(socksProxy(), httpProxy()), toUrl("http://8.8.8.8/i.png")).host().toHostString());
+        assertFalse(resolver.decideProxy(selectorOf(socksProxy()), toUrl("http://8.8.8.8/i.png")).proxied());
+    }
+
+    private Proxy httpProxy() {
+        return new Proxy(Proxy.Type.HTTP, InetSocketAddress.createUnresolved("proxy.invalid", 3128));
+    }
+
+    private Proxy socksProxy() {
+        return new Proxy(Proxy.Type.SOCKS, InetSocketAddress.createUnresolved("socks.invalid", 1080));
+    }
+
+    private ProxySelector selectorOf(Proxy... proxies) {
+        return new ProxySelector() {
+            @Override
+            public List<Proxy> select(URI uri) {
+                return List.of(proxies);
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress address, IOException failure) {
+                // the test asks what the list says, and never reports a failure to it
+            }
+        };
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -280,6 +280,26 @@ class CustomResourceUrlResolverTest {
 
     @Test
     @SneakyThrows
+    void keepsFetchingWhenOnlyASocksProxyIsConfigured() {
+        // the route planner of the client ignores a socks proxy, so the request stays direct and pinned
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        System.setProperty("socksProxyHost", "socks.invalid");
+        System.setProperty("socksProxyPort", "1080");
+        try {
+            ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), null, 16);
+
+            try (InputStream stream = new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/img.png")))) {
+                assertNotNull(stream);
+                assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+            }
+        } finally {
+            System.clearProperty("socksProxyHost");
+            System.clearProperty("socksProxyPort");
+        }
+    }
+
+    @Test
+    @SneakyThrows
     void keepsFetchingAHostTheProxyIsNotUsedFor() {
         respond("/img.png", "image/png", PNG_CONTENT, false);
         System.setProperty("http.proxyHost", "proxy.invalid");

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -17,6 +17,9 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import java.security.cert.CertificateException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -327,10 +330,44 @@ class CustomResourceUrlResolverTest {
                 assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
             }
             // and the classification itself, asked about an address no default non-proxy list covers
-            assertFalse(new CustomResourceUrlResolver(policy).isProxied(toUrl("http://8.8.8.8/img.png")));
+            assertFalse(new CustomResourceUrlResolver(policy).isProxied(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")));
         } finally {
             System.clearProperty("socksProxyHost");
             System.clearProperty("socksProxyPort");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void routesByTheSelectorAndNotByTheProperty() {
+        // the check reads the selector, so the routes have to come from there too: a selector answering
+        // no proxy wins over http.proxyHost, and a request under it stays direct as the check said
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        System.setProperty("http.proxyHost", "proxy.invalid");
+        System.setProperty("http.proxyPort", "3128");
+        ProxySelector previous = ProxySelector.getDefault();
+        ProxySelector.setDefault(new ProxySelector() {
+            @Override
+            public List<Proxy> select(URI uri) {
+                return List.of(Proxy.NO_PROXY);
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress address, java.io.IOException failure) {
+                // nothing to report, the test asks for a route and never for a failure
+            }
+        });
+        try {
+            ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), null, 16);
+
+            try (InputStream stream = new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/img.png")))) {
+                assertNotNull(stream);
+                assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+            }
+        } finally {
+            ProxySelector.setDefault(previous);
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
         }
     }
 
@@ -341,7 +378,7 @@ class CustomResourceUrlResolverTest {
         try {
             CustomResourceUrlResolver resolver = resolver(16);
 
-            assertTrue(resolver.isProxied(toUrl("http://8.8.8.8/img.png")));
+            assertTrue(resolver.isProxied(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")));
         } finally {
             System.clearProperty("http.proxyHost");
             System.clearProperty("http.proxyPort");

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -120,7 +119,7 @@ class CustomResourceUrlResolverTest {
     }
 
     @Test
-    void skipsResourceRejectedByPolicy() throws IOException {
+    void skipsResourceRejectedByPolicy() {
         respond("/img.png", "image/png", PNG_CONTENT, false);
         ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), null, 16);
         assertNull(new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/img.png"))));
@@ -128,13 +127,13 @@ class CustomResourceUrlResolverTest {
     }
 
     @Test
-    void skipsForeignContentType() throws IOException {
+    void skipsForeignContentType() {
         respond("/secret", "application/json", "{\"internal\":\"api response\"}".getBytes(StandardCharsets.UTF_8), false);
         assertNull(resolver(16).resolveImpl(toUrl(url("/secret"))));
     }
 
     @Test
-    void skipsDocumentDisguisedAsOctetStream() throws IOException {
+    void skipsDocumentDisguisedAsOctetStream() {
         respond("/secret", "application/octet-stream", "<html><body>internal page</body></html>".getBytes(StandardCharsets.UTF_8), false);
         assertNull(resolver(16).resolveImpl(toUrl(url("/secret"))));
     }
@@ -150,13 +149,13 @@ class CustomResourceUrlResolverTest {
     }
 
     @Test
-    void skipsResourceExceedingDeclaredSize() throws IOException {
+    void skipsResourceExceedingDeclaredSize() {
         respond("/img.png", "image/png", PNG_CONTENT, false);
         assertNull(resolver(0).resolveImpl(toUrl(url("/img.png"))));
     }
 
     @Test
-    void skipsResourceExceedingStreamedSize() throws IOException {
+    void skipsResourceExceedingStreamedSize() {
         respond("/img.png", "image/png", PNG_CONTENT, true);
         assertNull(resolver(0).resolveImpl(toUrl(url("/img.png"))));
     }
@@ -174,14 +173,14 @@ class CustomResourceUrlResolverTest {
     }
 
     @Test
-    void stopsOnRedirectLoop() throws IOException {
+    void stopsOnRedirectLoop() {
         redirect("/loop.png", url("/loop.png"));
         assertNull(resolver(16).resolveImpl(toUrl(url("/loop.png"))));
         assertEquals(6, requestCount.get());
     }
 
     @Test
-    void skipsRedirectWithoutLocation() throws IOException {
+    void skipsRedirectWithoutLocation() {
         server.createContext("/no-location.png", exchange -> {
             requestCount.incrementAndGet();
             exchange.sendResponseHeaders(302, -1);
@@ -191,7 +190,7 @@ class CustomResourceUrlResolverTest {
     }
 
     @Test
-    void skipsRedirectToBlockedTarget() throws IOException {
+    void skipsRedirectToBlockedTarget() {
         redirect("/old.png", "http://169.254.169.254/latest/meta-data/");
         ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of("127.0.0.1:" + server.getAddress().getPort()), null, 16);
         assertNull(new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/old.png"))));
@@ -199,7 +198,7 @@ class CustomResourceUrlResolverTest {
     }
 
     @Test
-    void skipsErrorResponse() throws IOException {
+    void skipsErrorResponse() {
         status("/missing.png", 404);
         assertNull(resolver(16).resolveImpl(toUrl(url("/missing.png"))));
     }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -326,8 +326,8 @@ class CustomResourceUrlResolverTest {
                 assertNotNull(stream);
                 assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
             }
-            // and the classification itself, which the mode of the policy above cannot answer for
-            assertFalse(new CustomResourceUrlResolver(policy).isProxied(toUrl(url("/img.png"))));
+            // and the classification itself, asked about an address no default non-proxy list covers
+            assertFalse(new CustomResourceUrlResolver(policy).isProxied(toUrl("http://8.8.8.8/img.png")));
         } finally {
             System.clearProperty("socksProxyHost");
             System.clearProperty("socksProxyPort");

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -359,6 +359,10 @@ class CustomResourceUrlResolverTest {
 
             assertTrue(resolver.decideProxy(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")).proxied());
             assertNull(resolver.resolveImpl(toUrl("http://8.8.8.8/img.png")));
+
+            // and a trusted host is no reason to send the request past the route the configuration names
+            ResourceUrlPolicy trusting = new ResourceUrlPolicy(Mode.ALLOWLIST_ONLY, List.of("8.8.8.8"), null, 16);
+            assertNull(new CustomResourceUrlResolver(trusting).resolveImpl(toUrl("http://8.8.8.8/img.png")));
         } finally {
             ProxySelector.setDefault(previous);
         }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -236,6 +236,55 @@ class CustomResourceUrlResolverTest {
     }
 
     @Test
+    @SneakyThrows
+    void resolvesANetworkPathReferenceAgainstItsOwnHost() {
+        // '//127.0.0.1:port/img.png' names its own host, only the scheme comes from the base url
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), "http://localhost", 16);
+        CustomResourceUrlResolver resolver = new CustomResourceUrlResolver(policy);
+
+        try (InputStream stream = resolver.resolve("//127.0.0.1:" + server.getAddress().getPort() + "/img.png")) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+        }
+    }
+
+    @Test
+    void skipsAProxiedResourceWhichIsNotExplicitlyTrusted() {
+        // a proxy resolves the host name itself, so the vetted addresses would decide nothing
+        System.setProperty("http.proxyHost", "proxy.invalid");
+        System.setProperty("http.proxyPort", "3128");
+        try {
+            ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), null, 16);
+
+            assertNull(new CustomResourceUrlResolver(policy).resolveImpl(toUrl("http://8.8.8.8/img.png")));
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void keepsFetchingAHostTheProxyIsNotUsedFor() {
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        System.setProperty("http.proxyHost", "proxy.invalid");
+        System.setProperty("http.proxyPort", "3128");
+        try {
+            ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL,
+                    List.of("127.0.0.1:" + server.getAddress().getPort()), null, 16);
+
+            try (InputStream stream = new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/img.png")))) {
+                assertNotNull(stream);
+                assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+            }
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
+    }
+
+    @Test
     void skipsErrorResponse() {
         status("/missing.png", 404);
         assertNull(resolver(16).resolveImpl(toUrl(url("/missing.png"))));

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -330,10 +330,37 @@ class CustomResourceUrlResolverTest {
                 assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
             }
             // and the classification itself, asked about an address no default non-proxy list covers
-            assertFalse(new CustomResourceUrlResolver(policy).isProxied(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")));
+            assertFalse(new CustomResourceUrlResolver(policy).decideProxy(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")).proxied());
         } finally {
             System.clearProperty("socksProxyHost");
             System.clearProperty("socksProxyPort");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void treatsASelectorWhichCannotAnswerAsAProxy() {
+        // a check which cannot be made is not a check that passed, so such a url is skipped as proxied
+        ProxySelector previous = ProxySelector.getDefault();
+        ProxySelector.setDefault(new ProxySelector() {
+            @Override
+            public List<Proxy> select(URI uri) {
+                throw new IllegalStateException("no answer");
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress address, java.io.IOException failure) {
+                // nothing to report, this selector never answers in the first place
+            }
+        });
+        try {
+            ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), null, 16);
+            CustomResourceUrlResolver resolver = new CustomResourceUrlResolver(policy);
+
+            assertTrue(resolver.decideProxy(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")).proxied());
+            assertNull(resolver.resolveImpl(toUrl("http://8.8.8.8/img.png")));
+        } finally {
+            ProxySelector.setDefault(previous);
         }
     }
 
@@ -378,7 +405,7 @@ class CustomResourceUrlResolverTest {
         try {
             CustomResourceUrlResolver resolver = resolver(16);
 
-            assertTrue(resolver.isProxied(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")));
+            assertTrue(resolver.decideProxy(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")).proxied());
         } finally {
             System.clearProperty("http.proxyHost");
             System.clearProperty("http.proxyPort");

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -13,6 +13,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import java.security.cert.CertificateException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -293,6 +297,22 @@ class CustomResourceUrlResolverTest {
     }
 
     @Test
+    void triesTheOtherSchemeWhereTheHostDoesNotSpeakTlsAtAll() {
+        CustomResourceUrlResolver resolver = resolver(16);
+
+        // a peer which is not speaking tls answered nothing, and the other scheme is the next question
+        assertFalse(resolver.isCertificateFailure(new SSLException("Unrecognized SSL message, plaintext connection?")));
+        // a refused certificate is an answer, and never one to repeat in the clear
+        assertTrue(resolver.isCertificateFailure(new SSLHandshakeException("failed") {
+            @Override
+            public synchronized Throwable getCause() {
+                return new CertificateException("no trusted certificate found");
+            }
+        }));
+        assertTrue(resolver.isCertificateFailure(new SSLPeerUnverifiedException("hostname mismatch")));
+    }
+
+    @Test
     @SneakyThrows
     void keepsFetchingWhenOnlyASocksProxyIsConfigured() {
         // the route planner of the client ignores a socks proxy, so the request stays direct and pinned
@@ -306,9 +326,25 @@ class CustomResourceUrlResolverTest {
                 assertNotNull(stream);
                 assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
             }
+            // and the classification itself, which the mode of the policy above cannot answer for
+            assertFalse(new CustomResourceUrlResolver(policy).isProxied(toUrl(url("/img.png"))));
         } finally {
             System.clearProperty("socksProxyHost");
             System.clearProperty("socksProxyPort");
+        }
+    }
+
+    @Test
+    void classifiesAnHttpProxyAsARoute() {
+        System.setProperty("http.proxyHost", "proxy.invalid");
+        System.setProperty("http.proxyPort", "3128");
+        try {
+            CustomResourceUrlResolver resolver = resolver(16);
+
+            assertTrue(resolver.isProxied(toUrl("http://8.8.8.8/img.png")));
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -20,6 +20,10 @@ import java.security.cert.CertificateException;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -334,6 +338,38 @@ class CustomResourceUrlResolverTest {
         } finally {
             System.clearProperty("socksProxyHost");
             System.clearProperty("socksProxyPort");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void sendsARequestThroughASocksProxyAtTheSocket() {
+        // the client plans no route to a socks proxy, the jvm applies it under the connection, so a
+        // socks setup keeps working: the request reaches the proxy rather than the host directly
+        try (ServerSocket socksProxy = new ServerSocket(0)) {
+            AtomicBoolean reached = new AtomicBoolean();
+            Thread listener = new Thread(() -> {
+                try (Socket accepted = socksProxy.accept()) {
+                    reached.set(accepted != null);
+                } catch (IOException e) {
+                    // the test asks whether the connection arrived, and nothing else
+                }
+            });
+            listener.setDaemon(true);
+            listener.start();
+            System.setProperty("socksProxyHost", "127.0.0.1");
+            System.setProperty("socksProxyPort", String.valueOf(socksProxy.getLocalPort()));
+            try {
+                ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), null, 16);
+
+                assertNull(new CustomResourceUrlResolver(policy).resolve("http://8.8.8.8/img.png"));
+
+                listener.join(5000);
+                assertTrue(reached.get());
+            } finally {
+                System.clearProperty("socksProxyHost");
+                System.clearProperty("socksProxyPort");
+            }
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -250,6 +250,20 @@ class CustomResourceUrlResolverTest {
     }
 
     @Test
+    @SneakyThrows
+    void fallsBackToTheOtherSchemeOfANetworkPathReference() {
+        // the base url says https, the server speaks http: the second attempt has to find it
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), "https://localhost", 16);
+        CustomResourceUrlResolver resolver = new CustomResourceUrlResolver(policy);
+
+        try (InputStream stream = resolver.resolve("//127.0.0.1:" + server.getAddress().getPort() + "/img.png")) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+        }
+    }
+
+    @Test
     void skipsAProxiedResourceWhichIsNotExplicitlyTrusted() {
         // a proxy resolves the host name itself, so the vetted addresses would decide nothing
         System.setProperty("http.proxyHost", "proxy.invalid");

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -1,6 +1,7 @@
 package ch.sbb.polarion.extension.pdf_exporter.util;
 
 import ch.sbb.polarion.extension.pdf_exporter.util.ResourceUrlPolicy.Mode;
+import ch.sbb.polarion.extension.generic.test_extensions.BundleJarsPrioritizingRunnableMockExtension;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import lombok.SneakyThrows;
@@ -31,7 +32,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, BundleJarsPrioritizingRunnableMockExtension.class})
 class CustomResourceUrlResolverTest {
 
     private static final byte[] PNG_CONTENT = "not really a png".getBytes(StandardCharsets.UTF_8);
@@ -130,6 +131,22 @@ class CustomResourceUrlResolverTest {
     void skipsForeignContentType() throws IOException {
         respond("/secret", "application/json", "{\"internal\":\"api response\"}".getBytes(StandardCharsets.UTF_8), false);
         assertNull(resolver(16).resolveImpl(toUrl(url("/secret"))));
+    }
+
+    @Test
+    void skipsDocumentDisguisedAsOctetStream() throws IOException {
+        respond("/secret", "application/octet-stream", "<html><body>internal page</body></html>".getBytes(StandardCharsets.UTF_8), false);
+        assertNull(resolver(16).resolveImpl(toUrl(url("/secret"))));
+    }
+
+    @Test
+    @SneakyThrows
+    void readsImageWithoutContentType() {
+        respond("/img.png", null, PNG_CONTENT, false);
+        try (InputStream stream = resolver(16).resolveImpl(toUrl(url("/img.png")))) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+        }
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -1,20 +1,97 @@
 package ch.sbb.polarion.extension.pdf_exporter.util;
 
+import ch.sbb.polarion.extension.pdf_exporter.util.ResourceUrlPolicy.Mode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CustomResourceUrlResolverTest {
+
+    private static final byte[] PNG_CONTENT = "not really a png".getBytes(StandardCharsets.UTF_8);
+
+    private HttpServer server;
+    private final AtomicInteger requestCount = new AtomicInteger();
+
+    @BeforeEach
+    @SneakyThrows
+    void startServer() {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private String url(String path) {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+    }
+
+    @SneakyThrows
+    private URL toUrl(String value) {
+        return URI.create(value).toURL();
+    }
+
+    private void respond(String path, String contentType, byte[] body, boolean chunked) {
+        server.createContext(path, exchange -> {
+            requestCount.incrementAndGet();
+            if (contentType != null) {
+                exchange.getResponseHeaders().add("Content-Type", contentType);
+            }
+            exchange.sendResponseHeaders(200, chunked ? 0 : body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+    }
+
+    private void redirect(String path, String location) {
+        server.createContext(path, exchange -> {
+            requestCount.incrementAndGet();
+            exchange.getResponseHeaders().add("Location", location);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+    }
+
+    private void status(String path, int code) {
+        server.createContext(path, (HttpExchange exchange) -> {
+            requestCount.incrementAndGet();
+            exchange.sendResponseHeaders(code, -1);
+            exchange.close();
+        });
+    }
+
+    private CustomResourceUrlResolver resolver(int maxSizeMB) {
+        return new CustomResourceUrlResolver(new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), null, maxSizeMB));
+    }
 
     @Test
     @SneakyThrows
@@ -24,10 +101,103 @@ class CustomResourceUrlResolverTest {
         when(resolver.resolve(any())).thenCallRealMethod();
         when(resolver.resolveImpl(any())).thenReturn(is);
         try (InputStream is1 = resolver.resolve("http://localhost/some path/img%5Fname.png")) {
-            try (InputStream is2 = verify(resolver, times(1)).resolveImpl(URI.create("http://localhost/some%20path/img_name.png").toURL())){
+            try (InputStream is2 = verify(resolver, times(1)).resolveImpl(URI.create("http://localhost/some%20path/img_name.png").toURL())) {
                 assertEquals(is, is1);
                 assertNull(is2);
             }
         }
+    }
+
+    @Test
+    @SneakyThrows
+    void readsAllowedResource() {
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        try (InputStream stream = resolver(16).resolveImpl(toUrl(url("/img.png")))) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+        }
+    }
+
+    @Test
+    void skipsResourceRejectedByPolicy() throws IOException {
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), null, 16);
+        assertNull(new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/img.png"))));
+        assertEquals(0, requestCount.get());
+    }
+
+    @Test
+    void skipsForeignContentType() throws IOException {
+        respond("/secret", "application/json", "{\"internal\":\"api response\"}".getBytes(StandardCharsets.UTF_8), false);
+        assertNull(resolver(16).resolveImpl(toUrl(url("/secret"))));
+    }
+
+    @Test
+    void skipsResourceExceedingDeclaredSize() throws IOException {
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        assertNull(resolver(0).resolveImpl(toUrl(url("/img.png"))));
+    }
+
+    @Test
+    void skipsResourceExceedingStreamedSize() throws IOException {
+        respond("/img.png", "image/png", PNG_CONTENT, true);
+        assertNull(resolver(0).resolveImpl(toUrl(url("/img.png"))));
+    }
+
+    @Test
+    @SneakyThrows
+    void followsRedirect() {
+        redirect("/old.png", "/img.png");
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        try (InputStream stream = resolver(16).resolveImpl(toUrl(url("/old.png")))) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+            assertEquals(2, requestCount.get());
+        }
+    }
+
+    @Test
+    void stopsOnRedirectLoop() throws IOException {
+        redirect("/loop.png", url("/loop.png"));
+        assertNull(resolver(16).resolveImpl(toUrl(url("/loop.png"))));
+        assertEquals(6, requestCount.get());
+    }
+
+    @Test
+    void skipsRedirectWithoutLocation() throws IOException {
+        server.createContext("/no-location.png", exchange -> {
+            requestCount.incrementAndGet();
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+        assertNull(resolver(16).resolveImpl(toUrl(url("/no-location.png"))));
+    }
+
+    @Test
+    void skipsRedirectToBlockedTarget() throws IOException {
+        redirect("/old.png", "http://169.254.169.254/latest/meta-data/");
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of("127.0.0.1:" + server.getAddress().getPort()), null, 16);
+        assertNull(new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/old.png"))));
+        assertEquals(1, requestCount.get());
+    }
+
+    @Test
+    void skipsErrorResponse() throws IOException {
+        status("/missing.png", 404);
+        assertNull(resolver(16).resolveImpl(toUrl(url("/missing.png"))));
+    }
+
+    @Test
+    void resolveReturnsNullOnFailure() {
+        assertNull(resolver(16).resolve("http://"));
+    }
+
+    @Test
+    void canResolveOnlyHttpAndAbsolutePaths() {
+        CustomResourceUrlResolver resolver = resolver(16);
+        assertTrue(resolver.canResolve("/polarion/img.png"));
+        assertTrue(resolver.canResolve("http://example.com/img.png"));
+        assertTrue(resolver.canResolve("https://example.com/img.png"));
+        assertFalse(resolver.canResolve("data:image/png;base64,AAAA"));
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -1,5 +1,6 @@
 package ch.sbb.polarion.extension.pdf_exporter.util;
 
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.pdf_exporter.util.ResourceUrlPolicy.Mode;
 import ch.sbb.polarion.extension.generic.test_extensions.BundleJarsPrioritizingRunnableMockExtension;
 import com.sun.net.httpserver.HttpExchange;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.InputStream;
@@ -27,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -187,6 +190,41 @@ class CustomResourceUrlResolverTest {
             exchange.close();
         });
         assertNull(resolver(16).resolveImpl(toUrl(url("/no-location.png"))));
+    }
+
+    @Test
+    @SneakyThrows
+    void followsPermanentRedirect() {
+        server.createContext("/old.png", exchange -> {
+            requestCount.incrementAndGet();
+            exchange.getResponseHeaders().add("Location", "/img.png");
+            exchange.sendResponseHeaders(301, -1);
+            exchange.close();
+        });
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        try (InputStream stream = resolver(16).resolveImpl(toUrl(url("/old.png")))) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+        }
+    }
+
+    @Test
+    void skipsRedirectWithBlankLocation() {
+        redirect("/blank.png", "  ");
+        assertNull(resolver(16).resolveImpl(toUrl(url("/blank.png"))));
+    }
+
+    @Test
+    void takesItsPolicyFromTheConfiguration() {
+        PdfExporterExtensionConfiguration configuration = mock(PdfExporterExtensionConfiguration.class);
+        when(configuration.getExternalResourcesPolicy()).thenReturn("allowAll");
+
+        try (MockedStatic<PdfExporterExtensionConfiguration> mocked = mockStatic(PdfExporterExtensionConfiguration.class)) {
+            mocked.when(PdfExporterExtensionConfiguration::getInstance).thenReturn(configuration);
+            respond("/img.png", "image/png", PNG_CONTENT, false);
+
+            assertNotNull(new CustomResourceUrlResolver().resolveImpl(toUrl(url("/img.png"))));
+        }
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -558,27 +558,18 @@ class HtmlProcessorTest {
             "@import url( \"URL\" /*sneaky*/ );",
             "@import \"http\\3a //169.254.169.254/latest/meta-data/\";",  // a css escape hides the scheme
             "@import url(/* ) */\"URL\");",                    // a ')' inside a comment used to cut the match
-            "@import/* ; */\"URL\";"                           // and a ';' inside one
+            "@import/* ; */\"URL\";",                          // and a ';' inside one
+            "@\\69mport \"URL\";",                              // an escaped at-keyword
+            "@\\69mport \\75rl(\"URL\");"                        // an escaped at-keyword and function
     })
     @SneakyThrows
     void dropAbsoluteCssImportTest(String atRule) {
         String html = "<style>" + atRule.replace("URL", "http://169.254.169.254/latest/meta-data/") + " body { color: red; }</style>";
 
-        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
+        // either the at-rule goes, or the whole stylesheet does when nothing could read it
+        assertFalse(processor.replaceResourcesAsBase64Encoded(html).contains("169.254.169.254"));
     }
 
-    @Test
-    @SneakyThrows
-    void replaceForbiddenCssUrlHiddenBehindACommentTest() {
-        String url = "http://169.254.169.254/latest/meta-data/";
-        String html = "<style>body { background: url(/*sneaky*/\"" + url + "\"); }</style>";
-        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
-
-        String result = processor.replaceResourcesAsBase64Encoded(html);
-
-        assertFalse(result.contains("169.254.169.254"));
-        assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
-    }
 
     @Test
     @SneakyThrows
@@ -592,37 +583,47 @@ class HtmlProcessorTest {
         assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
     }
 
-    @Test
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "url(/*sneaky*/\"ADDRESS\")",
+            "url(/* ) */\"ADDRESS\")",
+            "url(\"ADDRESS\" /*sneaky*/)",
+            "\\75rl(\"ADDRESS\")"
+    })
     @SneakyThrows
-    void replaceForbiddenCssUrlBehindACommentHoldingAParenthesisTest() {
-        String url = "http://169.254.169.254/latest/meta-data/";
-        String html = "<style>body { background: url(/* ) */\"" + url + "\"); }</style>";
-        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+    void keepAForbiddenCssUrlOutOfTheDocumentTest(String value) {
+        String address = "http://169.254.169.254/latest/meta-data/";
+        String html = "<style>body { background: " + value.replace("ADDRESS", address) + "; }</style>";
+        lenient().when(fileResourceProvider.isForbidden(address)).thenReturn(true);
 
-        String result = processor.replaceResourcesAsBase64Encoded(html);
-
-        assertFalse(result.contains("169.254.169.254"));
-        assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
+        assertFalse(processor.replaceResourcesAsBase64Encoded(html).contains("169.254.169.254"));
     }
 
     @Test
     @SneakyThrows
-    void stripsCommentsOnlyInsideCssTest() {
-        String html = "<script>var a = 1; /* keep me */</script><p>text /* keep me too */</p>"
-                + "<div style=\"color: red /* drop me */\"></div>";
+    void keepAForbiddenUrlOutOfAStyleAttributeTest() {
+        String address = "http://169.254.169.254/latest/meta-data/";
+        String html = "<div style=\"background: url(/*sneaky*/'" + address + "')\"></div>";
+        lenient().when(fileResourceProvider.isForbidden(address)).thenReturn(true);
 
-        String result = processor.replaceResourcesAsBase64Encoded(html);
-
-        assertEquals("<script>var a = 1; /* keep me */</script><p>text /* keep me too */</p>"
-                + "<div style=\"color: red \"></div>", result);
+        assertFalse(processor.replaceResourcesAsBase64Encoded(html).contains("169.254.169.254"));
     }
 
     @Test
     @SneakyThrows
     void keepsCommentLikeCharactersInsideAUrlTest() {
         // '/*' and '*/' are legal inside a path, only a leading or a trailing comment is stripped
-        String html = "<style>body { background: url(\"http://example.com/a/*b*/c.png\"); }</style>";
-        assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
+        String url = "http://example.com/a/*b*/c.png";
+        String html = "<style>body { background: url(\"" + url + "\"); }</style>";
+        when(fileResourceProvider.getResourceAsBase64String(url)).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        // the parser hands over the url as it stands, '/*' and '*/' in a path are part of it
+        verify(fileResourceProvider).getResourceAsBase64String(url);
+        assertTrue(result.contains("data:image/png;base64,AAAA"));
     }
 
     @Test
@@ -644,12 +645,17 @@ class HtmlProcessorTest {
     void dropExternalCssImportEvenWhenAllowedTest() {
         // the at-rule is never inlined, so WeasyPrint would load it itself, unchecked
         String html = "<style>@import \"http://example.com/theme.css\" screen; body { color: red; }</style>";
-        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertFalse(result.contains("theme.css"));
+        assertTrue(result.contains("color"));
     }
 
     @Test
     @SneakyThrows
     void keepRelativeCssImportTest() {
+        // WeasyPrint cannot resolve a relative import, and it names no address, so it stays
         String html = "<style>@import \"theme.css\"; body { color: red; }</style>";
         assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
     }
@@ -658,9 +664,12 @@ class HtmlProcessorTest {
     @SneakyThrows
     void replaceUppercaseCssUrlTest() {
         String html = "<style>body { background: URL(http://169.254.169.254/latest/meta-data/); }</style>";
-        when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+        lenient().when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+
         String result = processor.replaceResourcesAsBase64Encoded(html);
-        assertEquals("<style>body { background: URL(" + MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER + "); }</style>", result);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -687,7 +687,9 @@ class HtmlProcessorTest {
             "@namespace url(http://www.w3.org/1999/xhtml); a { color: red; }", // nor one in an at-rule prelude
             "a { content: \"https://example.com\"; color: red; }",         // nor one in a string value
             // nor one in a selector nested in a grouping at-rule, the print-stylesheet idiom
-            "@media print { a[href^=\"https://example.com\"]::after { color: red; } }"
+            "@media print { a[href^=\"https://example.com\"]::after { color: red; } }",
+            // nor one in the prelude of an at-rule nested in another one
+            "@media print { @supports (background: url(\"https://example.com/x.png\")) { a { color: red; } } }"
     })
     @SneakyThrows
     void keepAStylesheetWhoseAddressIsNotAResourceTest(String css) {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -558,10 +558,8 @@ class HtmlProcessorTest {
             "@import url( \"URL\" /*sneaky*/ );"
     })
     @SneakyThrows
-    void dropForbiddenCssImportTest(String atRule) {
-        String url = "http://169.254.169.254/latest/meta-data/";
-        String html = "<style>" + atRule.replace("URL", url) + " body { color: red; }</style>";
-        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+    void dropAbsoluteCssImportTest(String atRule) {
+        String html = "<style>" + atRule.replace("URL", "http://169.254.169.254/latest/meta-data/") + " body { color: red; }</style>";
 
         assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
     }
@@ -572,6 +570,18 @@ class HtmlProcessorTest {
         String url = "http://169.254.169.254/latest/meta-data/";
         String html = "<style>body { background: url(/*sneaky*/\"" + url + "\"); }</style>";
         when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
+    }
+
+    @Test
+    @SneakyThrows
+    void replaceForbiddenNetworkPathReferenceTest() {
+        String html = "<style>body { background: url(//169.254.169.254/latest/meta-data/); }</style>";
+        when(fileResourceProvider.isForbidden("//169.254.169.254/latest/meta-data/")).thenReturn(true);
 
         String result = processor.replaceResourcesAsBase64Encoded(html);
 
@@ -603,8 +613,16 @@ class HtmlProcessorTest {
 
     @Test
     @SneakyThrows
-    void keepAllowedCssImportTest() {
+    void dropExternalCssImportEvenWhenAllowedTest() {
+        // the at-rule is never inlined, so WeasyPrint would load it itself, unchecked
         String html = "<style>@import \"http://example.com/theme.css\" screen; body { color: red; }</style>";
+        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepRelativeCssImportTest() {
+        String html = "<style>@import \"theme.css\"; body { color: red; }</style>";
         assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -619,6 +619,19 @@ class HtmlProcessorTest {
 
     @Test
     @SneakyThrows
+    void inlineAnImageWrittenWithWhitespaceAroundItsUrlTest() {
+        String url = "//cdn.example/image.png";
+        String html = "<div><img src=\" " + url + " \"/></div>";
+        when(fileResourceProvider.getResourceAsBase64String(url)).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertTrue(result.contains("data:image/png;base64,AAAA"));
+        assertFalse(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
+    }
+
+    @Test
+    @SneakyThrows
     void keepTextWhichOnlyLooksLikeAStyleAttributeTest() {
         // neither the text of the document nor the value of another attribute is a style attribute
         String html = "<p>the style = big</p><div title=\"style=background:url(http://169.254.169.254/x)\">t</div>";

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -619,6 +619,15 @@ class HtmlProcessorTest {
 
     @Test
     @SneakyThrows
+    void keepTextWhichOnlyLooksLikeAStyleAttributeTest() {
+        // neither the text of the document nor the value of another attribute is a style attribute
+        String html = "<p>the style = big</p><div title=\"style=background:url(http://169.254.169.254/x)\">t</div>";
+
+        assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @Test
+    @SneakyThrows
     void keepACssStringHoldingAnAddressTest() {
         // a string value is text, css fetches nothing from it, so the stylesheet stays usable
         String html = "<style>/* see http://example.com */ body { content: \"https://example.com\"; color: red; }</style>";

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -556,7 +556,9 @@ class HtmlProcessorTest {
             "@import\"URL\";",                                // and it allows no separator at all
             "@import url(/*sneaky*/\"URL\");",                 // a comment inside url() too
             "@import url( \"URL\" /*sneaky*/ );",
-            "@import \"http\\3a //169.254.169.254/latest/meta-data/\";"   // a css escape hides the scheme
+            "@import \"http\\3a //169.254.169.254/latest/meta-data/\";",  // a css escape hides the scheme
+            "@import url(/* ) */\"URL\");",                    // a ')' inside a comment used to cut the match
+            "@import/* ; */\"URL\";"                           // and a ';' inside one
     })
     @SneakyThrows
     void dropAbsoluteCssImportTest(String atRule) {
@@ -588,6 +590,31 @@ class HtmlProcessorTest {
 
         assertFalse(result.contains("169.254.169.254"));
         assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
+    }
+
+    @Test
+    @SneakyThrows
+    void replaceForbiddenCssUrlBehindACommentHoldingAParenthesisTest() {
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String html = "<style>body { background: url(/* ) */\"" + url + "\"); }</style>";
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
+    }
+
+    @Test
+    @SneakyThrows
+    void stripsCommentsOnlyInsideCssTest() {
+        String html = "<script>var a = 1; /* keep me */</script><p>text /* keep me too */</p>"
+                + "<div style=\"color: red /* drop me */\"></div>";
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertEquals("<script>var a = 1; /* keep me */</script><p>text /* keep me too */</p>"
+                + "<div style=\"color: red \"></div>", result);
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -516,6 +516,16 @@ class HtmlProcessorTest {
 
     @Test
     @SneakyThrows
+    void replaceForbiddenImageWithPlaceholderTest() {
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String html = "<div><img id=\"image\" src=\"" + url + "\"/></div>";
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+        assertEquals("<div><img id=\"image\" src=\"" + MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER + "\"/></div>", result);
+    }
+
+    @Test
+    @SneakyThrows
     void replaceSvgImagesAsBase64EncodedTest() {
         String html = "<div><img id=\"image1\" src=\"http://localhost/some-path/img1.svg\"/> <img id='image2' src='http://localhost/some-path/img2.svg'/> <img id='image1' src='http://localhost/some-path/img1.svg'/></div>";
         byte[] imgBytes;

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -77,6 +77,9 @@ class HtmlProcessorTest {
         LocalizationModel localizationModel = new LocalizationModel(deTranslations, frTranslations, itTranslations);
 
         lenient().when(localizationSettings.load(anyString(), any(SettingId.class))).thenReturn(localizationModel);
+        // by default every resource inlines to itself, so that a test which is not about resources
+        // keeps its urls. A url which does not inline is replaced by a placeholder, see inlineBase64Resources.
+        lenient().when(fileResourceProvider.getResourceAsBase64String(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test
@@ -522,6 +525,43 @@ class HtmlProcessorTest {
         when(fileResourceProvider.isForbidden(url)).thenReturn(true);
         String result = processor.replaceResourcesAsBase64Encoded(html);
         assertEquals("<div><img id=\"image\" src=\"" + MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER + "\"/></div>", result);
+    }
+
+    @Test
+    @SneakyThrows
+    void replaceNotInlinedAbsoluteUrlWithPlaceholderTest() {
+        // the resolver refused the resource, for instance by its content type: the url must not survive
+        String html = "<div><img id=\"image\" src=\"http://example.com/img.png\"/></div>";
+        when(fileResourceProvider.getResourceAsBase64String(any())).thenReturn(null);
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+        assertEquals("<div><img id=\"image\" src=\"" + MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER + "\"/></div>", result);
+    }
+
+    @Test
+    @SneakyThrows
+    void keepNotInlinedRelativeUrlsTest() {
+        // a relative url and an SVG fragment cannot be loaded by WeasyPrint, leave them alone
+        String html = "<div style=\"fill: url(#gradient)\"><img id=\"image\" src=\"images/local.png\"/></div>";
+        when(fileResourceProvider.getResourceAsBase64String(any())).thenReturn(null);
+        assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @Test
+    @SneakyThrows
+    void dropForbiddenCssImportTest() {
+        String html = "<style>@import \"http://169.254.169.254/latest/meta-data/\"; body { color: red; }</style>";
+        when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+        assertEquals("<style> body { color: red; }</style>", result);
+    }
+
+    @Test
+    @SneakyThrows
+    void replaceUppercaseCssUrlTest() {
+        String html = "<style>body { background: URL(http://169.254.169.254/latest/meta-data/); }</style>";
+        when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+        assertEquals("<style>body { background: URL(" + MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER + "); }</style>", result);
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -555,7 +555,8 @@ class HtmlProcessorTest {
             "@import/*sneaky*/\"URL\";",                      // CSS allows a comment between the at-keyword and its target
             "@import\"URL\";",                                // and it allows no separator at all
             "@import url(/*sneaky*/\"URL\");",                 // a comment inside url() too
-            "@import url( \"URL\" /*sneaky*/ );"
+            "@import url( \"URL\" /*sneaky*/ );",
+            "@import \"http\\3a //169.254.169.254/latest/meta-data/\";"   // a css escape hides the scheme
     })
     @SneakyThrows
     void dropAbsoluteCssImportTest(String atRule) {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -667,6 +667,20 @@ class HtmlProcessorTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            // a data url token which no url() holds must not hide what stands after it
+            "a { --x: data: } @\\69mport \"http://169.254.169.254/latest/meta-data/\";",
+            // an import inside a media rule is dropped by the parser, and the renderer would read it
+            "@media print { @import url(http://169.254.169.254/latest/meta-data/); }"
+    })
+    @SneakyThrows
+    void dropAStylesheetNamingAnAddressNothingAccountedForTest(String css) {
+        String result = processor.replaceResourcesAsBase64Encoded("<style>" + css + "</style>");
+
+        assertFalse(result.contains("169.254.169.254"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
             "a[href^=\"https://example.com\"] { color: red; }",          // an address in a selector fetches nothing
             "@namespace url(http://www.w3.org/1999/xhtml); a { color: red; }", // nor one in an at-rule prelude
             "a { content: \"https://example.com\"; color: red; }"          // nor one in a string value

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -557,6 +557,32 @@ class HtmlProcessorTest {
 
     @Test
     @SneakyThrows
+    void dropForbiddenConditionalCssImportTest() {
+        // a media condition after the url must not save the at-rule from being dropped
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String html = "<style>@import \"" + url + "\" screen and (min-width:1px); body { color: red; }</style>";
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @Test
+    @SneakyThrows
+    void dropForbiddenCssImportUrlFormTest() {
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String html = "<style>@import url(\"" + url + "\") print; body { color: red; }</style>";
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepAllowedCssImportTest() {
+        String html = "<style>@import \"http://example.com/theme.css\" screen; body { color: red; }</style>";
+        assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @Test
+    @SneakyThrows
     void replaceUppercaseCssUrlTest() {
         String html = "<style>body { background: URL(http://169.254.169.254/latest/meta-data/); }</style>";
         when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -656,6 +656,23 @@ class HtmlProcessorTest {
 
     @Test
     @SneakyThrows
+    void blockAnAddressWrittenWithHtmlEntitiesInAnAttributeTest() {
+        // the renderer reads an attribute after the html parser resolved its entities, and so does this
+        when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+
+        String style = processor.replaceResourcesAsBase64Encoded(
+                "<div style=\"background: url(&quot;http://169.254.169.254/latest/meta-data/&quot;)\"></div>");
+        String image = processor.replaceResourcesAsBase64Encoded(
+                "<img src=\"&#104;ttp://169.254.169.254/latest/meta-data/\">");
+
+        assertFalse(style.contains("169.254.169.254"));
+        assertFalse(image.contains("169.254.169.254"));
+        assertTrue(style.contains("data:image/png;base64,"));
+        assertTrue(image.contains("data:image/png;base64,"));
+    }
+
+    @Test
+    @SneakyThrows
     void blockAnEscapedSchemeOfAForbiddenAddressTest() {
         // the parser resolves the escape, so the policy is asked about the address the renderer would read
         String html = "<style>a { background: url(\"http\\3a //169.254.169.254/latest/meta-data/\") }</style>";

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -665,6 +665,19 @@ class HtmlProcessorTest {
         assertTrue(result.contains("color"));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "a[href^=\"https://example.com\"] { color: red; }",          // an address in a selector fetches nothing
+            "@namespace url(http://www.w3.org/1999/xhtml); a { color: red; }", // nor one in an at-rule prelude
+            "a { content: \"https://example.com\"; color: red; }"          // nor one in a string value
+    })
+    @SneakyThrows
+    void keepAStylesheetWhoseAddressIsNotAResourceTest(String css) {
+        String html = "<style>" + css + "</style>";
+
+        assertTrue(processor.replaceResourcesAsBase64Encoded(html).contains("color"));
+    }
+
     @Test
     @SneakyThrows
     void keepTextWhichOnlyLooksLikeAStyleAttributeTest() {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -632,6 +632,41 @@ class HtmlProcessorTest {
 
     @Test
     @SneakyThrows
+    void inlineARelativeCssUrlTest() {
+        // a stylesheet whose urls are all relative is inlined as well, it names no address to check
+        String html = "<style>body { background: url(images/logo.png); }</style>";
+        when(fileResourceProvider.getResourceAsBase64String("images/logo.png")).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertTrue(result.contains("url(data:image/png;base64,AAAA)"));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepAStyleAttributeUsableAfterInliningTest() {
+        // a quote around the value would end the attribute early, so the data url goes in bare
+        String html = "<div style=\"background: url(images/logo.png)\"></div>";
+        when(fileResourceProvider.getResourceAsBase64String("images/logo.png")).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertEquals("<div style=\"background: url(data:image/png;base64,AAAA)\"></div>", result);
+    }
+
+    @Test
+    @SneakyThrows
+    void keepAStylesheetHoldingAnUnencodedSvgDataUrlTest() {
+        // the payload of such a data url carries quotes and the namespace of SVG, neither is an address
+        String html = "<style>body { background: url(\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>\"); color: red; }</style>";
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertTrue(result.contains("color"));
+    }
+
+    @Test
+    @SneakyThrows
     void keepTextWhichOnlyLooksLikeAStyleAttributeTest() {
         // neither the text of the document nor the value of another attribute is a style attribute
         String html = "<p>the style = big</p><div title=\"style=background:url(http://169.254.169.254/x)\">t</div>";

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -656,6 +656,19 @@ class HtmlProcessorTest {
 
     @Test
     @SneakyThrows
+    void blockAnEscapedSchemeOfAForbiddenAddressTest() {
+        // the parser resolves the escape, so the policy is asked about the address the renderer would read
+        String html = "<style>a { background: url(\"http\\3a //169.254.169.254/latest/meta-data/\") }</style>";
+        when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains("data:image/png;base64,"));
+    }
+
+    @Test
+    @SneakyThrows
     void keepAStylesheetHoldingAnUnencodedSvgDataUrlTest() {
         // the payload of such a data url carries quotes and the namespace of SVG, neither is an address
         String html = "<style>body { background: url(\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>\"); color: red; }</style>";

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -685,7 +685,9 @@ class HtmlProcessorTest {
     @ValueSource(strings = {
             "a[href^=\"https://example.com\"] { color: red; }",          // an address in a selector fetches nothing
             "@namespace url(http://www.w3.org/1999/xhtml); a { color: red; }", // nor one in an at-rule prelude
-            "a { content: \"https://example.com\"; color: red; }"          // nor one in a string value
+            "a { content: \"https://example.com\"; color: red; }",         // nor one in a string value
+            // nor one in a selector nested in a grouping at-rule, the print-stylesheet idiom
+            "@media print { a[href^=\"https://example.com\"]::after { color: red; } }"
     })
     @SneakyThrows
     void keepAStylesheetWhoseAddressIsNotAResourceTest(String css) {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -601,6 +601,34 @@ class HtmlProcessorTest {
         assertFalse(processor.replaceResourcesAsBase64Encoded(html).contains("169.254.169.254"));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "style=\"background: url(ADDRESS)\"",
+            "style = \"background: url(ADDRESS)\"",
+            "style='background: url(ADDRESS)'",
+            "style=background:url(ADDRESS)"
+    })
+    @SneakyThrows
+    void keepAForbiddenUrlOutOfEveryFormOfAStyleAttributeTest(String attribute) {
+        String address = "http://169.254.169.254/latest/meta-data/";
+        String html = "<div " + attribute.replace("ADDRESS", address) + "></div>";
+        lenient().when(fileResourceProvider.isForbidden(address)).thenReturn(true);
+
+        assertFalse(processor.replaceResourcesAsBase64Encoded(html).contains("169.254.169.254"));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepACssStringHoldingAnAddressTest() {
+        // a string value is text, css fetches nothing from it, so the stylesheet stays usable
+        String html = "<style>/* see http://example.com */ body { content: \"https://example.com\"; color: red; }</style>";
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertTrue(result.contains("https://example.com"));
+        assertTrue(result.contains("color"));
+    }
+
     @Test
     @SneakyThrows
     void keepAForbiddenUrlOutOfAStyleAttributeTest() {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -576,6 +576,39 @@ class HtmlProcessorTest {
 
     @Test
     @SneakyThrows
+    void dropForbiddenCssImportWithCommentTest() {
+        // CSS allows a comment, or nothing at all, between the at-keyword and its target
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String html = "<style>@import/*sneaky*/\"" + url + "\"; body { color: red; }</style>";
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @Test
+    @SneakyThrows
+    void dropForbiddenCssImportWithoutSeparatorTest() {
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String html = "<style>@import\"" + url + "\"; body { color: red; }</style>";
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @Test
+    @SneakyThrows
+    void replaceForbiddenImageWrittenInUppercaseTest() {
+        // the base64 pass always runs on JSoup output, which lowercases the tag and quotes the attribute
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String normalized = JSoupUtils.parseHtml("<div><IMG SRC=" + url + "></div>").body().html();
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+
+        String result = processor.replaceResourcesAsBase64Encoded(normalized);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
+    }
+
+    @Test
+    @SneakyThrows
     void keepAllowedCssImportTest() {
         String html = "<style>@import \"http://example.com/theme.css\" screen; body { color: red; }</style>";
         assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -546,51 +547,44 @@ class HtmlProcessorTest {
         assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "@import \"URL\";",
+            "@import \"URL\" screen and (min-width:1px);",   // a media condition must not save the at-rule
+            "@import url(\"URL\") print;",                    // the url() form goes as a whole too
+            "@import/*sneaky*/\"URL\";",                      // CSS allows a comment between the at-keyword and its target
+            "@import\"URL\";",                                // and it allows no separator at all
+            "@import url(/*sneaky*/\"URL\");",                 // a comment inside url() too
+            "@import url( \"URL\" /*sneaky*/ );"
+    })
+    @SneakyThrows
+    void dropForbiddenCssImportTest(String atRule) {
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String html = "<style>" + atRule.replace("URL", url) + " body { color: red; }</style>";
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+
+        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
+    }
+
     @Test
     @SneakyThrows
-    void dropForbiddenCssImportTest() {
-        String html = "<style>@import \"http://169.254.169.254/latest/meta-data/\"; body { color: red; }</style>";
-        when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+    void replaceForbiddenCssUrlHiddenBehindACommentTest() {
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String html = "<style>body { background: url(/*sneaky*/\"" + url + "\"); }</style>";
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+
         String result = processor.replaceResourcesAsBase64Encoded(html);
-        assertEquals("<style> body { color: red; }</style>", result);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
     }
 
     @Test
     @SneakyThrows
-    void dropForbiddenConditionalCssImportTest() {
-        // a media condition after the url must not save the at-rule from being dropped
-        String url = "http://169.254.169.254/latest/meta-data/";
-        String html = "<style>@import \"" + url + "\" screen and (min-width:1px); body { color: red; }</style>";
-        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
-        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
-    }
-
-    @Test
-    @SneakyThrows
-    void dropForbiddenCssImportUrlFormTest() {
-        String url = "http://169.254.169.254/latest/meta-data/";
-        String html = "<style>@import url(\"" + url + "\") print; body { color: red; }</style>";
-        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
-        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
-    }
-
-    @Test
-    @SneakyThrows
-    void dropForbiddenCssImportWithCommentTest() {
-        // CSS allows a comment, or nothing at all, between the at-keyword and its target
-        String url = "http://169.254.169.254/latest/meta-data/";
-        String html = "<style>@import/*sneaky*/\"" + url + "\"; body { color: red; }</style>";
-        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
-        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
-    }
-
-    @Test
-    @SneakyThrows
-    void dropForbiddenCssImportWithoutSeparatorTest() {
-        String url = "http://169.254.169.254/latest/meta-data/";
-        String html = "<style>@import\"" + url + "\"; body { color: red; }</style>";
-        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
-        assertEquals("<style> body { color: red; }</style>", processor.replaceResourcesAsBase64Encoded(html));
+    void keepsCommentLikeCharactersInsideAUrlTest() {
+        // '/*' and '*/' are legal inside a path, only a leading or a trailing comment is stripped
+        String html = "<style>body { background: url(\"http://example.com/a/*b*/c.png\"); }</style>";
+        assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -670,7 +670,9 @@ class HtmlProcessorTest {
             // a data url token which no url() holds must not hide what stands after it
             "a { --x: data: } @\\69mport \"http://169.254.169.254/latest/meta-data/\";",
             // an import inside a media rule is dropped by the parser, and the renderer would read it
-            "@media print { @import url(http://169.254.169.254/latest/meta-data/); }"
+            "@media print { @import url(http://169.254.169.254/latest/meta-data/); }",
+            // the same characters read as a string in one rule, and read by nothing in the next
+            "a { content: \"http://169.254.169.254/\" } @\\69mport \"http://169.254.169.254/\";"
     })
     @SneakyThrows
     void dropAStylesheetNamingAnAddressNothingAccountedForTest(String css) {

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -202,4 +202,28 @@ class MediaUtilsTest {
         g2d.dispose();
     }
 
+
+    @Test
+    void recognizesAbsoluteHttpUrls() {
+        assertTrue(MediaUtils.isAbsoluteHttpUrl("http://example.com/img.png"));
+        assertTrue(MediaUtils.isAbsoluteHttpUrl(" HTTPS://example.com/img.png"));
+        assertFalse(MediaUtils.isAbsoluteHttpUrl(null));
+        assertFalse(MediaUtils.isAbsoluteHttpUrl("/polarion/img.png"));
+        assertFalse(MediaUtils.isAbsoluteHttpUrl("data:image/png;base64,AAAA"));
+    }
+
+    @Test
+    void keepsDataUrlsWhileInlining() {
+        FileResourceProvider provider = org.mockito.Mockito.mock(FileResourceProvider.class);
+        String html = "<div><img src=\"data:image/png;base64,AAAA\"/></div>";
+
+        assertEquals(html, MediaUtils.inlineBase64Resources(html, provider));
+        org.mockito.Mockito.verifyNoInteractions(provider);
+    }
+
+    @Test
+    void normalizesUrlForTheRequestAndTheCheck() {
+        assertEquals("http://example.com/some%20path/img_name.png",
+                MediaUtils.normalizeUrl("http://example.com/some path/img%5Fname.png"));
+    }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -261,4 +261,14 @@ class MediaUtilsTest {
     void unwrapsAnEscapedCssUrl() {
         assertTrue(MediaUtils.isAbsoluteHttpUrl(MediaUtils.unwrapCssUrl("\"http\\3a //169.254.169.254/x\"")));
     }
+
+    @Test
+    void stripsCssComments() {
+        assertEquals("a{}", MediaUtils.stripCssComments("a{/* x */}"));
+        assertEquals("a{content:\"/* kept */\"}", MediaUtils.stripCssComments("a{content:\"/* kept */\"}"));
+        assertEquals("a{content:'/* kept */'}", MediaUtils.stripCssComments("a{content:'/* kept */'}"));
+        assertEquals("url(\"x\")", MediaUtils.stripCssComments("url(/* ) */\"x\")"));
+        assertEquals("a{", MediaUtils.stripCssComments("a{/* unterminated"));
+        assertEquals("plain", MediaUtils.stripCssComments("plain"));
+    }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -210,7 +210,9 @@ class MediaUtilsTest {
         assertTrue(MediaUtils.isAbsoluteHttpUrl("http://example.com/img.png"));
         assertTrue(MediaUtils.isAbsoluteHttpUrl(" HTTPS://example.com/img.png"));
         assertFalse(MediaUtils.isAbsoluteHttpUrl(null));
+        assertTrue(MediaUtils.isAbsoluteHttpUrl("//example.com/img.png"));
         assertFalse(MediaUtils.isAbsoluteHttpUrl("/polarion/img.png"));
+        assertFalse(MediaUtils.isAbsoluteHttpUrl("//"));
         assertFalse(MediaUtils.isAbsoluteHttpUrl("data:image/png;base64,AAAA"));
     }
 
@@ -238,6 +240,5 @@ class MediaUtilsTest {
         // '/*' and '*/' inside a path are part of the url, only a leading or a trailing comment goes
         assertEquals("http://example.com/a/*b*/c.png", MediaUtils.unwrapCssUrl("http://example.com/a/*b*/c.png"));
         assertEquals("", MediaUtils.unwrapCssUrl("/*just a comment*/"));
-        assertNull(MediaUtils.unwrapCssUrl(null));
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -241,4 +241,17 @@ class MediaUtilsTest {
         assertEquals("http://example.com/a/*b*/c.png", MediaUtils.unwrapCssUrl("http://example.com/a/*b*/c.png"));
         assertEquals("", MediaUtils.unwrapCssUrl("/*just a comment*/"));
     }
+
+    @Test
+    void decodesCssEscapes() {
+        assertEquals("http://host/x", MediaUtils.decodeCssEscapes("http\\3a //host/x"));
+        assertEquals("http://host/x", MediaUtils.decodeCssEscapes("\\68 ttp\\3A //host/x"));
+        assertEquals("http://host/x", MediaUtils.decodeCssEscapes("http\\:" + "//host/x"));
+        assertEquals("plain", MediaUtils.decodeCssEscapes("plain"));
+    }
+
+    @Test
+    void unwrapsAnEscapedCssUrl() {
+        assertTrue(MediaUtils.isAbsoluteHttpUrl(MediaUtils.unwrapCssUrl("\"http\\3a //169.254.169.254/x\"")));
+    }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -228,4 +228,16 @@ class MediaUtilsTest {
         assertEquals("http://example.com/some%20path/img_name.png",
                 MediaUtils.normalizeUrl("http://example.com/some path/img%5Fname.png"));
     }
+
+    @Test
+    void unwrapsCssUrlValues() {
+        assertEquals("http://example.com/a.png", MediaUtils.unwrapCssUrl("/*c*/\"http://example.com/a.png\""));
+        assertEquals("http://example.com/a.png", MediaUtils.unwrapCssUrl(" \"http://example.com/a.png\" /*c*/ "));
+        assertEquals("http://example.com/a.png", MediaUtils.unwrapCssUrl("'http://example.com/a.png'"));
+        assertEquals("http://example.com/a.png", MediaUtils.unwrapCssUrl("http://example.com/a.png"));
+        // '/*' and '*/' inside a path are part of the url, only a leading or a trailing comment goes
+        assertEquals("http://example.com/a/*b*/c.png", MediaUtils.unwrapCssUrl("http://example.com/a/*b*/c.png"));
+        assertEquals("", MediaUtils.unwrapCssUrl("/*just a comment*/"));
+        assertNull(MediaUtils.unwrapCssUrl(null));
+    }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -251,6 +251,13 @@ class MediaUtilsTest {
     }
 
     @Test
+    void turnsAnUnusableCssEscapeIntoTheReplacementCharacter() {
+        assertEquals("\uFFFD", MediaUtils.decodeCssEscapes("\\FFFFFF"));
+        assertEquals("\uFFFD", MediaUtils.decodeCssEscapes("\\0"));
+        assertEquals("\uFFFD", MediaUtils.decodeCssEscapes("\\D800"));
+    }
+
+    @Test
     void unwrapsAnEscapedCssUrl() {
         assertTrue(MediaUtils.isAbsoluteHttpUrl(MediaUtils.unwrapCssUrl("\"http\\3a //169.254.169.254/x\"")));
     }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -18,6 +18,8 @@ import java.util.Set;
 
 import static ch.sbb.polarion.extension.pdf_exporter.util.MediaUtils.THUMBNAIL_PARAMETER;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, BundleJarsPrioritizingRunnableMockExtension.class, PdfExporterExtensionConfigurationExtension.class})
@@ -214,11 +216,11 @@ class MediaUtilsTest {
 
     @Test
     void keepsDataUrlsWhileInlining() {
-        FileResourceProvider provider = org.mockito.Mockito.mock(FileResourceProvider.class);
+        FileResourceProvider provider = mock(FileResourceProvider.class);
         String html = "<div><img src=\"data:image/png;base64,AAAA\"/></div>";
 
         assertEquals(html, MediaUtils.inlineBase64Resources(html, provider));
-        org.mockito.Mockito.verifyNoInteractions(provider);
+        verifyNoInteractions(provider);
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -231,16 +231,6 @@ class MediaUtilsTest {
                 MediaUtils.normalizeUrl("http://example.com/some path/img%5Fname.png"));
     }
 
-    @Test
-    void unwrapsCssUrlValues() {
-        assertEquals("http://example.com/a.png", MediaUtils.unwrapCssUrl("/*c*/\"http://example.com/a.png\""));
-        assertEquals("http://example.com/a.png", MediaUtils.unwrapCssUrl(" \"http://example.com/a.png\" /*c*/ "));
-        assertEquals("http://example.com/a.png", MediaUtils.unwrapCssUrl("'http://example.com/a.png'"));
-        assertEquals("http://example.com/a.png", MediaUtils.unwrapCssUrl("http://example.com/a.png"));
-        // '/*' and '*/' inside a path are part of the url, only a leading or a trailing comment goes
-        assertEquals("http://example.com/a/*b*/c.png", MediaUtils.unwrapCssUrl("http://example.com/a/*b*/c.png"));
-        assertEquals("", MediaUtils.unwrapCssUrl("/*just a comment*/"));
-    }
 
     @Test
     void decodesCssEscapes() {
@@ -257,18 +247,5 @@ class MediaUtilsTest {
         assertEquals("\uFFFD", MediaUtils.decodeCssEscapes("\\D800"));
     }
 
-    @Test
-    void unwrapsAnEscapedCssUrl() {
-        assertTrue(MediaUtils.isAbsoluteHttpUrl(MediaUtils.unwrapCssUrl("\"http\\3a //169.254.169.254/x\"")));
-    }
 
-    @Test
-    void stripsCssComments() {
-        assertEquals("a{}", MediaUtils.stripCssComments("a{/* x */}"));
-        assertEquals("a{content:\"/* kept */\"}", MediaUtils.stripCssComments("a{content:\"/* kept */\"}"));
-        assertEquals("a{content:'/* kept */'}", MediaUtils.stripCssComments("a{content:'/* kept */'}"));
-        assertEquals("url(\"x\")", MediaUtils.stripCssComments("url(/* ) */\"x\")"));
-        assertEquals("a{", MediaUtils.stripCssComments("a{/* unterminated"));
-        assertEquals("plain", MediaUtils.stripCssComments("plain"));
-    }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -26,6 +26,19 @@ import static org.mockito.Mockito.when;
 class MediaUtilsTest {
 
     @Test
+    void anUnplaceableRewriteIsNotClearedByALaterOneTest() {
+        // the flag answers "was every rewrite placed", so one that was not stands whatever follows it
+        MediaUtils.CssRewrite rewrite = new MediaUtils.CssRewrite();
+        assertTrue(rewrite.complete());
+
+        rewrite.missed(false);
+        rewrite.missed(true);
+
+        assertFalse(rewrite.complete());
+    }
+
+
+    @Test
     void dataUrlTest() {
         assertFalse(MediaUtils.isDataUrl(null));
         assertFalse(MediaUtils.isDataUrl(""));

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
@@ -501,9 +501,14 @@ class PdfExporterFileResourceProviderTest {
 
         assertTrue(provider.isForbidden("http://169.254.169.254/latest/meta-data/"));
         assertTrue(provider.isForbidden("http://10.0.0.5/img.png"));
-        assertTrue(provider.isForbidden("http://a b c"));
+        assertTrue(provider.isForbidden("HTTP://10.0.0.5/img.png"));
         assertFalse(provider.isForbidden("https://8.8.8.8/img.png"));
+        // a url with a space is normalized the same way the resolver normalizes it before requesting
+        assertFalse(provider.isForbidden("https://8.8.8.8/some path/img.png"));
+        // nothing below is ever requested over the network, so nothing below may be replaced
         assertFalse(provider.isForbidden("/polarion/wi-attachment/elibrary/EL-1/img.png"));
         assertFalse(provider.isForbidden("data:image/png;base64,AAAA"));
+        assertFalse(provider.isForbidden("#gradient"));
+        assertFalse(provider.isForbidden("images/local.png"));
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
@@ -493,4 +493,17 @@ class PdfExporterFileResourceProviderTest {
             assertFalse(filteredResolvers.contains(mockResolver2));
         }
     }
+
+    @Test
+    void reportsUrlsRejectedByThePolicyAsForbidden() {
+        PdfExporterFileResourceProvider provider = new PdfExporterFileResourceProvider(
+                List.of(resolverMock), new ResourceUrlPolicy(ResourceUrlPolicy.Mode.BLOCK_INTERNAL, List.of(), null, 16));
+
+        assertTrue(provider.isForbidden("http://169.254.169.254/latest/meta-data/"));
+        assertTrue(provider.isForbidden("http://10.0.0.5/img.png"));
+        assertTrue(provider.isForbidden("http://a b c"));
+        assertFalse(provider.isForbidden("https://8.8.8.8/img.png"));
+        assertFalse(provider.isForbidden("/polarion/wi-attachment/elibrary/EL-1/img.png"));
+        assertFalse(provider.isForbidden("data:image/png;base64,AAAA"));
+    }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
@@ -1,5 +1,7 @@
 package ch.sbb.polarion.extension.pdf_exporter.util;
 
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
+
 import ch.sbb.polarion.extension.generic.test_extensions.PlatformContextMockExtension;
 import ch.sbb.polarion.extension.generic.test_extensions.TransactionalExecutorExtension;
 import com.polarion.alm.tracker.internal.url.GenericUrlResolver;
@@ -510,5 +512,24 @@ class PdfExporterFileResourceProviderTest {
         assertFalse(provider.isForbidden("data:image/png;base64,AAAA"));
         assertFalse(provider.isForbidden("#gradient"));
         assertFalse(provider.isForbidden("images/local.png"));
+        // an absolute url which cannot be parsed at all must not reach WeasyPrint either
+        assertTrue(provider.isForbidden("http://[unterminated/img.png"));
+    }
+
+    @Test
+    void buildsItsResolversFromTheConfiguration() {
+        PdfExporterExtensionConfiguration configuration = mock(PdfExporterExtensionConfiguration.class);
+        IAttachmentUrlResolver parentUrlResolver = mock(IAttachmentUrlResolver.class);
+
+        try (MockedStatic<PdfExporterExtensionConfiguration> configurationMock = mockStatic(PdfExporterExtensionConfiguration.class);
+             MockedStatic<PolarionUrlResolver> polarionUrlResolverMock = mockStatic(PolarionUrlResolver.class)) {
+            configurationMock.when(PdfExporterExtensionConfiguration::getInstance).thenReturn(configuration);
+            polarionUrlResolverMock.when(PolarionUrlResolver::getInstance).thenReturn(parentUrlResolver);
+
+            PdfExporterFileResourceProvider provider = new PdfExporterFileResourceProvider();
+
+            assertTrue(provider.isForbidden("http://10.0.0.5/img.png"));
+            assertFalse(provider.isForbidden("https://8.8.8.8/img.png"));
+        }
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
@@ -512,6 +512,9 @@ class PdfExporterFileResourceProviderTest {
         assertFalse(provider.isForbidden("data:image/png;base64,AAAA"));
         assertFalse(provider.isForbidden("#gradient"));
         assertFalse(provider.isForbidden("images/local.png"));
+        // a network path reference gets its scheme from the base url of the conversion service
+        assertTrue(provider.isForbidden("//169.254.169.254/latest/meta-data/"));
+        assertFalse(provider.isForbidden("//8.8.8.8/img.png"));
         // an absolute url which cannot be parsed at all must not reach WeasyPrint either
         assertTrue(provider.isForbidden("http://[unterminated/img.png"));
     }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
@@ -9,9 +9,11 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -81,6 +83,88 @@ class ResourceUrlPolicyTest {
     @Test
     void blocksUnresolvableHost() {
         assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url("http://unresolvable-host.invalid/img.png")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://[2002:ac10:0005::]/secret",  // 6to4 of 172.16.0.5
+            "http://[2002:c0a8:0105::]/secret",  // 6to4 of 192.168.1.5
+            "http://[2002:e000:0001::]/secret",  // 6to4 of 224.0.0.1
+            "http://[2002:6440:0001::]/secret",  // 6to4 of 100.64.0.1
+            "http://[2002:c000:0001::]/secret",  // 6to4 of 192.0.0.1
+            "http://[2002:c612:0001::]/secret",  // 6to4 of 198.18.0.1
+            "http://[2002:c613:0001::]/secret",  // 6to4 of 198.19.0.1
+            "http://[2002:0000:0001::]/secret",  // 6to4 of 0.0.0.1
+            "http://[2002:f000:0001::]/secret"   // 6to4 of 240.0.0.1
+    })
+    void blocksNonPublicAddressesEmbeddedInIpv6(String value) {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://[2002:ac0f:0001::]/img.png",  // 6to4 of 172.15.0.1, just below the private range
+            "http://[2002:ac20:0001::]/img.png",  // 6to4 of 172.32.0.1, just above it
+            "http://[2002:a9fd:0001::]/img.png",  // 6to4 of 169.253.0.1, not link local
+            "http://[2002:643f:0001::]/img.png",  // 6to4 of 100.63.0.1, below the shared range
+            "http://[2002:6480:0001::]/img.png",  // 6to4 of 100.128.0.1, above it
+            "http://[2002:c000:0101::]/img.png",  // 6to4 of 192.0.1.1, outside 192.0.0.0/24
+            "http://[2002:c001:0001::]/img.png",  // 6to4 of 192.1.0.1
+            "http://[2002:c611:0001::]/img.png",  // 6to4 of 198.17.0.1, below the benchmark range
+            "http://[2002:c614:0001::]/img.png",  // 6to4 of 198.20.0.1, above it
+            "http://[2001:0100::1]/img.png",      // not Teredo, the third byte is set
+            "http://[2001:0001::1]/img.png",      // not Teredo, the fourth byte is set
+            "http://[2003::1]/img.png"            // not Teredo, the second byte differs
+    })
+    void allowsPublicAddressesNextToTheBlockedRanges(String value) {
+        assertTrue(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
+    }
+
+    @Test
+    @SneakyThrows
+    void classifiesIpv4EmbeddedInIpv6() {
+        assertFalse(ResourceUrlPolicy.isPublicAddress(ipv6(compatible(10, 0, 0, 5))));
+        assertTrue(ResourceUrlPolicy.isPublicAddress(ipv6(compatible(8, 8, 8, 8))));
+        assertFalse(ResourceUrlPolicy.isPublicAddress(ipv6(mapped(127, 0, 0, 1))));
+        assertTrue(ResourceUrlPolicy.isPublicAddress(ipv6(mapped(8, 8, 8, 8))));
+        // the tenth byte is set, so nothing is embedded and the address stays a plain public IPv6 one
+        byte[] notEmbedded = compatible(10, 0, 0, 5);
+        notEmbedded[9] = 1;
+        assertTrue(ResourceUrlPolicy.isPublicAddress(ipv6(notEmbedded)));
+
+        // only 0x0000 and 0xFFFF in the eleventh and twelfth byte mark an embedded IPv4 address
+        byte[] halfZero = compatible(10, 0, 0, 5);
+        halfZero[11] = 5;
+        assertTrue(ResourceUrlPolicy.isPublicAddress(ipv6(halfZero)));
+        byte[] halfMapped = mapped(10, 0, 0, 5);
+        halfMapped[11] = 0;
+        assertTrue(ResourceUrlPolicy.isPublicAddress(ipv6(halfMapped)));
+    }
+
+    @SneakyThrows
+    private static InetAddress ipv6(byte[] address) {
+        return Inet6Address.getByAddress(null, address, 0);
+    }
+
+    private static byte[] compatible(int a, int b, int c, int d) {
+        return new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) a, (byte) b, (byte) c, (byte) d};
+    }
+
+    private static byte[] mapped(int a, int b, int c, int d) {
+        return new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xFF, (byte) 0xFF, (byte) a, (byte) b, (byte) c, (byte) d};
+    }
+
+    @Test
+    void blocksUrlWithoutHost() {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url("http:///img.png")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"   ", "not-a-url", "http://[unterminated"})
+    void survivesAnUnusableBaseUrlValue(String baseUrl) {
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, Arrays.asList("8.8.4.4", null), baseUrl, 16);
+        assertTrue(policy.isAllowed(url("https://8.8.4.4/img.png")));
+        assertFalse(policy.isAllowed(url("http://10.0.0.5/img.png")));
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
@@ -95,7 +95,9 @@ class ResourceUrlPolicyTest {
             "http://[2002:c612:0001::]/secret",  // 6to4 of 198.18.0.1
             "http://[2002:c613:0001::]/secret",  // 6to4 of 198.19.0.1
             "http://[2002:0000:0001::]/secret",  // 6to4 of 0.0.0.1
-            "http://[2002:f000:0001::]/secret"   // 6to4 of 240.0.0.1
+            "http://[2002:f000:0001::]/secret",  // 6to4 of 240.0.0.1
+            "http://[64:ff9b::a9fe:a9fe]/secret", // NAT64 well known prefix carrying 169.254.169.254
+            "http://[64:ff9b:1::1]/secret"       // NAT64 local use prefix, the address can sit anywhere in it
     })
     void blocksNonPublicAddressesEmbeddedInIpv6(String value) {
         assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
@@ -114,7 +116,9 @@ class ResourceUrlPolicyTest {
             "http://[2002:c614:0001::]/img.png",  // 6to4 of 198.20.0.1, above it
             "http://[2001:0100::1]/img.png",      // not Teredo, the third byte is set
             "http://[2001:0001::1]/img.png",      // not Teredo, the fourth byte is set
-            "http://[2003::1]/img.png"            // not Teredo, the second byte differs
+            "http://[2003::1]/img.png",           // not Teredo, the second byte differs
+            "http://[64:ff9b::808:808]/img.png",  // NAT64 well known prefix carrying 8.8.8.8
+            "http://[64:ff9c::1]/img.png"         // next to the NAT64 prefix, not in it
     })
     void allowsPublicAddressesNextToTheBlockedRanges(String value) {
         assertTrue(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
@@ -155,6 +155,25 @@ class ResourceUrlPolicyTest {
         assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowedContentType(contentType));
     }
 
+    @ParameterizedTest
+    @CsvSource({"'',true", "application/octet-stream,true", "binary/octet-stream; charset=binary,true",
+            "image/png,false", "text/css,false"})
+    void decidesWhenTheContentHasToBeSniffed(String contentType, boolean expected) {
+        assertEquals(expected, policy(Mode.BLOCK_INTERNAL, List.of()).isSniffingRequired(contentType));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"text/html,true", "application/xhtml+xml,true", "application/json; charset=utf-8,true",
+            "image/png,false", "text/css,false", "application/xml,false"})
+    void rejectsSniffedDocumentTypes(String sniffedType, boolean expected) {
+        assertEquals(expected, policy(Mode.BLOCK_INTERNAL, List.of()).isRejectedSniffedType(sniffedType));
+    }
+
+    @Test
+    void acceptsUnknownSniffedType() {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isRejectedSniffedType(null));
+    }
+
     @Test
     void acceptsMissingContentType() {
         assertTrue(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowedContentType(null));

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
@@ -180,6 +180,23 @@ class ResourceUrlPolicyTest {
     }
 
     @Test
+    void tellsWhichUrlsTheConfigurationTrustsAsSuch() {
+        ResourceUrlPolicy policy = policy(Mode.BLOCK_INTERNAL, List.of("8.8.4.4"));
+        assertTrue(policy.isExplicitlyTrusted(url("https://8.8.4.4/img.png")));
+        assertTrue(policy.isExplicitlyTrusted(url("http://localhost/polarion/img.png")));
+        assertFalse(policy.isExplicitlyTrusted(url("https://8.8.8.8/img.png")));
+        assertFalse(policy.isExplicitlyTrusted(url("http:///img.png")));
+        assertTrue(policy(Mode.ALLOW_ALL, List.of()).isExplicitlyTrusted(url("https://8.8.8.8/img.png")));
+    }
+
+    @Test
+    void readsTheSchemeOfTheBaseUrl() {
+        assertEquals("http", policy(Mode.BLOCK_INTERNAL, List.of()).getBaseUrlScheme());
+        assertEquals("https", new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), "https://polarion.example", 16).getBaseUrlScheme());
+        assertEquals("http", new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), null, 16).getBaseUrlScheme());
+    }
+
+    @Test
     void allowsExplicitlyListedHosts() {
         // an allowed host still has to resolve, so the test uses addresses instead of invented names
         ResourceUrlPolicy policy = policy(Mode.BLOCK_INTERNAL, List.of(" 10.0.0.5 ", "127.0.0.1:8443", ""));

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
@@ -214,6 +214,26 @@ class ResourceUrlPolicyTest {
     }
 
     @Test
+    void tellsWhetherARefusalTurnedOnThePortOfTheScheme() {
+        // an entry carrying a port names that port only, and the port of a url comes from its scheme
+        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of("cdn.example.com:443"));
+
+        assertTrue(policy.isRefusalPortSpecific(url("http://cdn.example.com/logo.png")));
+        assertFalse(policy.isRefusalPortSpecific(url("https://cdn.example.com/logo.png")));
+        // a port written out is the port under either scheme, and an unlisted host is refused as a host
+        assertFalse(policy.isRefusalPortSpecific(url("http://cdn.example.com:8080/logo.png")));
+        assertFalse(policy.isRefusalPortSpecific(url("http://other.example.com/logo.png")));
+    }
+
+    @Test
+    void tellsNothingTurnsOnThePortWhereTheHostIsListedWithoutOne() {
+        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of("cdn.example.com"));
+
+        assertFalse(policy.isRefusalPortSpecific(url("http://cdn.example.com/logo.png")));
+        assertFalse(policy.isRefusalPortSpecific(url("https://cdn.example.com/logo.png")));
+    }
+
+    @Test
     void allowAllRejectsNothingButForeignSchemes() {
         ResourceUrlPolicy policy = policy(Mode.ALLOW_ALL, List.of());
         assertTrue(policy.isAllowed(url("http://127.0.0.1:8080/secret")));

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
@@ -1,0 +1,185 @@
+package ch.sbb.polarion.extension.pdf_exporter.util;
+
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
+import ch.sbb.polarion.extension.pdf_exporter.util.ResourceUrlPolicy.Mode;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class ResourceUrlPolicyTest {
+
+    private static final String BASE_URL = "http://localhost:80/polarion";
+
+    @SneakyThrows
+    private static URL url(String value) {
+        return URI.create(value).toURL();
+    }
+
+    private static ResourceUrlPolicy policy(Mode mode, List<String> allowedHosts) {
+        return new ResourceUrlPolicy(mode, allowedHosts, BASE_URL, 16);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://127.0.0.1:8080/secret",
+            "http://127.5.6.7/secret",
+            "http://[::1]/secret",
+            "http://10.0.0.5/secret",
+            "http://172.16.0.5/secret",
+            "http://192.168.1.5/secret",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[fd00::1]/secret",
+            "http://[fe80::1]/secret",
+            "http://100.64.0.1/secret",
+            "http://192.0.0.1/secret",
+            "http://198.18.0.1/secret",
+            "http://240.0.0.1/secret",
+            "http://0.0.0.0/secret",
+            "http://[::ffff:127.0.0.1]/secret",
+            "http://[2002:7f00:0001::]/secret",
+            "http://[2002:0a00:0005::]/secret",
+            "http://[2002:a9fe:a9fe::]/secret",
+            "http://[2001:0:1::1]/secret",
+            "http://224.0.0.1/secret"
+    })
+    void blocksNonPublicAddresses(String value) {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://8.8.8.8/img.png",
+            "https://93.184.216.34/img.png",
+            "http://[2606:4700:4700::1111]/img.png",
+            "http://[2002:0808:0808::]/img.png"
+    })
+    void allowsPublicAddresses(String value) {
+        assertTrue(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ftp://8.8.8.8/img.png", "file:///etc/passwd", "jar:http://8.8.8.8/a.jar!/img.png"})
+    void blocksForeignSchemes(String value) {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
+    }
+
+    @Test
+    void blocksUnresolvableHost() {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url("http://unresolvable-host.invalid/img.png")));
+    }
+
+    @Test
+    void allowsPolarionBaseUrlItself() {
+        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of());
+        assertTrue(policy.isAllowed(url("http://localhost/polarion/some-resource.png")));
+        assertTrue(policy.isAllowed(url("http://LOCALHOST:80/polarion/some-resource.png")));
+        assertFalse(policy.isAllowed(url("http://localhost:8080/polarion/some-resource.png")));
+    }
+
+    @Test
+    void allowsExplicitlyListedHosts() {
+        ResourceUrlPolicy policy = policy(Mode.BLOCK_INTERNAL, List.of(" 10.0.0.5 ", "cdn.intranet:8443", ""));
+        assertTrue(policy.isAllowed(url("http://10.0.0.5/img.png")));
+        assertTrue(policy.isAllowed(url("https://cdn.intranet:8443/img.png")));
+        assertFalse(policy.isAllowed(url("https://cdn.intranet/img.png")));
+        assertFalse(policy.isAllowed(url("http://10.0.0.6/img.png")));
+    }
+
+    @Test
+    void allowlistOnlyRejectsEverythingElse() {
+        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of("cdn.example.com"));
+        assertTrue(policy.isAllowed(url("https://cdn.example.com/img.png")));
+        assertFalse(policy.isAllowed(url("https://8.8.8.8/img.png")));
+    }
+
+    @Test
+    void allowAllRejectsNothingButForeignSchemes() {
+        ResourceUrlPolicy policy = policy(Mode.ALLOW_ALL, List.of());
+        assertTrue(policy.isAllowed(url("http://127.0.0.1:8080/secret")));
+        assertTrue(policy.isAllowed(url("http://169.254.169.254/latest/meta-data/")));
+        assertFalse(policy.isAllowed(url("ftp://127.0.0.1/secret")));
+    }
+
+    @Test
+    @SneakyThrows
+    void handlesUnusableBaseUrl() {
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOWLIST_ONLY, null, null, 16);
+        assertFalse(policy.isAllowed(url("http://localhost/polarion/some-resource.png")));
+        assertTrue(ResourceUrlPolicy.isPublicAddress(InetAddress.getByName("8.8.8.8")));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "blockInternal,BLOCK_INTERNAL",
+            "BLOCK_INTERNAL,BLOCK_INTERNAL",
+            "block-internal,BLOCK_INTERNAL",
+            " allowlistOnly ,ALLOWLIST_ONLY",
+            "allowAll,ALLOW_ALL",
+            "nonsense,BLOCK_INTERNAL",
+            "'',BLOCK_INTERNAL"
+    })
+    void parsesMode(String value, Mode expected) {
+        assertEquals(expected, Mode.parse(value));
+    }
+
+    @Test
+    void parsesMissingMode() {
+        assertEquals(Mode.BLOCK_INTERNAL, Mode.parse(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"image/png", "IMAGE/SVG+XML", "image/jpeg; charset=binary", "font/woff2",
+            "application/font-woff", "application/x-font-ttf", "text/css", "application/octet-stream", "  "})
+    void allowsResourceContentTypes(String contentType) {
+        assertTrue(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowedContentType(contentType));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"application/json", "text/html", "text/plain", "application/xml"})
+    void rejectsForeignContentTypes(String contentType) {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowedContentType(contentType));
+    }
+
+    @Test
+    void acceptsMissingContentType() {
+        assertTrue(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowedContentType(null));
+    }
+
+    @Test
+    void readsItsConfiguration() {
+        PdfExporterExtensionConfiguration configuration = mock(PdfExporterExtensionConfiguration.class);
+        when(configuration.getExternalResourcesPolicy()).thenReturn("allowlistOnly");
+        when(configuration.getExternalResourcesAllowedHosts()).thenReturn("cdn.example.com, 10.0.0.5");
+        when(configuration.getExternalResourcesMaxSizeMB()).thenReturn(4);
+
+        try (MockedStatic<PdfExporterExtensionConfiguration> mocked = mockStatic(PdfExporterExtensionConfiguration.class)) {
+            mocked.when(PdfExporterExtensionConfiguration::getInstance).thenReturn(configuration);
+
+            ResourceUrlPolicy policy = ResourceUrlPolicy.getInstance();
+            assertEquals(4L * 1024 * 1024, policy.getMaxResourceBytes());
+            assertTrue(policy.isAllowed(url("https://cdn.example.com/img.png")));
+            assertTrue(policy.isAllowed(url("http://10.0.0.5/img.png")));
+            assertFalse(policy.isAllowed(url("https://other.example.com/img.png")));
+        }
+    }
+
+    @Test
+    void convertsSizeLimitToBytes() {
+        assertEquals(16L * 1024 * 1024, policy(Mode.BLOCK_INTERNAL, List.of()).getMaxResourceBytes());
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
@@ -179,6 +179,19 @@ class ResourceUrlPolicyTest {
     }
 
     @Test
+    void fallsBackWhenTheConfigurationIsEmpty() {
+        PdfExporterExtensionConfiguration configuration = mock(PdfExporterExtensionConfiguration.class);
+
+        try (MockedStatic<PdfExporterExtensionConfiguration> mocked = mockStatic(PdfExporterExtensionConfiguration.class)) {
+            mocked.when(PdfExporterExtensionConfiguration::getInstance).thenReturn(configuration);
+
+            ResourceUrlPolicy policy = ResourceUrlPolicy.getInstance();
+            assertEquals(16L * 1024 * 1024, policy.getMaxResourceBytes());
+            assertFalse(policy.isAllowed(url("http://127.0.0.1/secret")));
+        }
+    }
+
+    @Test
     void convertsSizeLimitToBytes() {
         assertEquals(16L * 1024 * 1024, policy(Mode.BLOCK_INTERNAL, List.of()).getMaxResourceBytes());
     }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
@@ -93,17 +93,18 @@ class ResourceUrlPolicyTest {
 
     @Test
     void allowsExplicitlyListedHosts() {
-        ResourceUrlPolicy policy = policy(Mode.BLOCK_INTERNAL, List.of(" 10.0.0.5 ", "cdn.intranet:8443", ""));
+        // an allowed host still has to resolve, so the test uses addresses instead of invented names
+        ResourceUrlPolicy policy = policy(Mode.BLOCK_INTERNAL, List.of(" 10.0.0.5 ", "127.0.0.1:8443", ""));
         assertTrue(policy.isAllowed(url("http://10.0.0.5/img.png")));
-        assertTrue(policy.isAllowed(url("https://cdn.intranet:8443/img.png")));
-        assertFalse(policy.isAllowed(url("https://cdn.intranet/img.png")));
+        assertTrue(policy.isAllowed(url("https://127.0.0.1:8443/img.png")));
+        assertFalse(policy.isAllowed(url("https://127.0.0.1/img.png")));
         assertFalse(policy.isAllowed(url("http://10.0.0.6/img.png")));
     }
 
     @Test
     void allowlistOnlyRejectsEverythingElse() {
-        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of("cdn.example.com"));
-        assertTrue(policy.isAllowed(url("https://cdn.example.com/img.png")));
+        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of("8.8.4.4"));
+        assertTrue(policy.isAllowed(url("https://8.8.4.4/img.png")));
         assertFalse(policy.isAllowed(url("https://8.8.8.8/img.png")));
     }
 
@@ -183,7 +184,7 @@ class ResourceUrlPolicyTest {
     void readsItsConfiguration() {
         PdfExporterExtensionConfiguration configuration = mock(PdfExporterExtensionConfiguration.class);
         when(configuration.getExternalResourcesPolicy()).thenReturn("allowlistOnly");
-        when(configuration.getExternalResourcesAllowedHosts()).thenReturn("cdn.example.com, 10.0.0.5");
+        when(configuration.getExternalResourcesAllowedHosts()).thenReturn("8.8.4.4, 10.0.0.5");
         when(configuration.getExternalResourcesMaxSizeMB()).thenReturn(4);
 
         try (MockedStatic<PdfExporterExtensionConfiguration> mocked = mockStatic(PdfExporterExtensionConfiguration.class)) {
@@ -191,9 +192,9 @@ class ResourceUrlPolicyTest {
 
             ResourceUrlPolicy policy = ResourceUrlPolicy.getInstance();
             assertEquals(4L * 1024 * 1024, policy.getMaxResourceBytes());
-            assertTrue(policy.isAllowed(url("https://cdn.example.com/img.png")));
+            assertTrue(policy.isAllowed(url("https://8.8.4.4/img.png")));
             assertTrue(policy.isAllowed(url("http://10.0.0.5/img.png")));
-            assertFalse(policy.isAllowed(url("https://other.example.com/img.png")));
+            assertFalse(policy.isAllowed(url("https://8.8.8.8/img.png")));
         }
     }
 


### PR DESCRIPTION
### Proposed changes

This pull request introduces a configurable security policy for loading external resources (such as images, fonts, and stylesheets) into exported PDFs. It allows administrators to control which hosts and resource types are permitted, limits the size of loaded resources, and ensures that blocked resources are replaced with placeholders rather than being fetched. The changes enhance both security and configurability of the PDF exporter.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
