### PR TITLE
fix: vet every external resource before loading it

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,64 @@ To override this list, adjust the following property in the `polarion.properties
 ch.sbb.polarion.extension.pdf-exporter.renderable.image.extensions=png, jpg, jpeg, gif, bmp, svg, webp, avif, ico, cur, tif, tiff, vsdx
 ```
 
+### External resources
+
+A document can reference an image, a font or a stylesheet by an absolute URL. The extension loads such a
+resource and embeds it into the exported PDF. Because a document editor controls that URL, the request is
+restricted. By default the extension rejects every address which is not public: loopback, private ranges,
+link local addresses including the cloud metadata address `169.254.169.254`, and their IPv6 equivalents.
+The Polarion server itself, as configured by `base.url`, always stays reachable.
+
+To load resources from an internal host, list its origin explicitly:
+```properties
+ch.sbb.polarion.extension.pdf-exporter.externalResources.allowedOrigins=cdn.intranet,https://images.intranet:8443
+```
+
+An entry is written `[scheme://]host[:port]`, and what it leaves out is not compared:
+
+| Entry | What it allows |
+| --- | --- |
+| `cdn.intranet` | that host under either scheme, on any port |
+| `cdn.intranet:8443` | that host on port 8443, under either scheme |
+| `https://cdn.intranet` | that host under https, on port 443 |
+| `https://cdn.intranet:8443` | that host under https, on port 8443 |
+
+A reference written `//host/path` takes the scheme of `base.url` first and the other one after, so it
+reaches the host under whichever scheme an entry names.
+
+The policy itself can be changed. The value is one of these three names, written exactly so:
+```properties
+# BLOCK_INTERNAL (default) - public addresses, the Polarion server and the allowed origins
+# ALLOWLIST_ONLY           - only the Polarion server and the allowed origins
+# ALLOW_ALL                - no restriction, this exposes the server's network to document editors
+ch.sbb.polarion.extension.pdf-exporter.externalResources.policy=ALLOWLIST_ONLY
+```
+
+A loaded resource must be served as an image, a font or a stylesheet. Where the sender says nothing about
+the content, or calls it `application/octet-stream`, the content itself decides and must be recognizable as
+one of the three: a text of any other kind is refused, and so is a body nothing could be detected in.
+
+A resource may not exceed 16 MB. To change the size limit:
+```properties
+ch.sbb.polarion.extension.pdf-exporter.externalResources.maxSizeMB=32
+```
+
+A CSS `@import` of an absolute address is removed, whether the policy allows the address or not: an
+at-rule cannot be embedded, so WeasyPrint would have to load it itself, past every check above. Reference
+such a stylesheet with `<link rel="stylesheet">` instead, the extension loads and embeds that one.
+
+A configured JVM proxy (`http.proxyHost` and friends) is used for these requests. A proxy resolves the
+host name itself, so a request routed through one cannot be pinned to a checked address. Such a request
+is therefore only made for a host the configuration trusts as such: the Polarion server and the origins
+listed above. Everything else is loaded directly, with the address check binding, or not at all. Hosts
+in `http.nonProxyHosts` are loaded directly and keep the address check.
+
+A SOCKS proxy needs no such gate. It is no route the client plans, the JVM applies it at the socket, and
+the socket is connected to the address the check approved, not to a host name the proxy would resolve.
+So a request does traverse the SOCKS proxy, and its destination is still the vetted address.
+
+Blocked resources are reported in the Polarion log. The document is exported without them.
+
 ### Debug option
 
 This extension makes intensive HTML processing to extend similar standard Polarion functionality. There is a possibility to log

--- a/pom.xml
+++ b/pom.xml
@@ -65,14 +65,17 @@
         <maven-jar-plugin.Configuration-Properties-Prefix>ch.sbb.polarion.extension.pdf-exporter.</maven-jar-plugin.Configuration-Properties-Prefix>
         <web.app.name>${maven-jar-plugin.Extension-Context}</web.app.name>
 
+
         <!-- Extension-specific Require-Bundle (in addition to common ones from parent POM):
             com.polarion.alm.wiki
             org.jsoup
             net.bytebuddy.byte-buddy
             org.apache.tika.patched;resolution:=optional
             org.apache.tika;resolution:=optional
+            org.apache.httpcomponents.httpclient, org.apache.httpcomponents.httpcore (used by
+              CustomResourceUrlResolver to pin a request to the addresses ResourceUrlPolicy vetted)
         -->
-        <maven-jar-plugin.Require-Bundle.extension>com.polarion.alm.wiki,org.jsoup,net.bytebuddy.byte-buddy,org.apache.tika.patched;resolution:=optional,org.apache.tika;resolution:=optional</maven-jar-plugin.Require-Bundle.extension>
+        <maven-jar-plugin.Require-Bundle.extension>com.polarion.alm.wiki,org.jsoup,net.bytebuddy.byte-buddy,org.apache.tika.patched;resolution:=optional,org.apache.tika;resolution:=optional,org.apache.httpcomponents.httpclient,org.apache.httpcomponents.httpcore</maven-jar-plugin.Require-Bundle.extension>
         <maven-jar-plugin.Require-Bundle>${maven-jar-plugin.Require-Bundle.common},${maven-jar-plugin.Require-Bundle.extension}</maven-jar-plugin.Require-Bundle>
 
         <!-- A broken README.md -> about.html conversion fails the build instead of shipping an
@@ -151,6 +154,20 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Polarion's own httpcomponents bundles, resolved at runtime via Require-Bundle above
+             and never packaged. Used by CustomResourceUrlResolver. -->
+        <dependency>
+            <groupId>com.polarion.thirdparty</groupId>
+            <artifactId>org.apache.httpcomponents.httpclient_4.5.14</artifactId>
+            <version>${polarion.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.polarion.thirdparty</groupId>
+            <artifactId>org.apache.httpcomponents.httpcore_4.4.16</artifactId>
+            <version>${polarion.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>ch.sbb.polarion.extensions</groupId>
             <artifactId>ch.sbb.polarion.extension.generic.app</artifactId>

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessor.java
@@ -100,7 +100,7 @@ public class CoverPageProcessor {
         content = htmlProcessor.replaceResourcesAsBase64Encoded(content);
         String evaluatedContent = velocityEvaluator.evaluateVelocityExpressions(documentData, content);
         String css = coverPageSettings.processImagePlaceholders(settings.getTemplateCss());
-        css = htmlProcessor.replaceResourcesAsBase64Encoded(css);
+        css = htmlProcessor.replaceCssResourcesAsBase64Encoded(css);
         // Resolve the language the same way as the body (same resolver, same inputs) so the cover page hyphenates consistently
         String documentLanguage = DocumentLanguageResolver.resolve(documentData, exportParams);
         return pdfTemplateProcessor.processUsing(exportParams, documentData.getTitle(), css, evaluatedContent, "", documentLanguage);

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessor.java
@@ -103,7 +103,10 @@ public class CoverPageProcessor {
         css = htmlProcessor.replaceCssResourcesAsBase64Encoded(css);
         // Resolve the language the same way as the body (same resolver, same inputs) so the cover page hyphenates consistently
         String documentLanguage = DocumentLanguageResolver.resolve(documentData, exportParams);
-        return pdfTemplateProcessor.processUsing(exportParams, documentData.getTitle(), css, evaluatedContent, "", documentLanguage);
+        String titleHtml = pdfTemplateProcessor.processUsing(exportParams, documentData.getTitle(), css, evaluatedContent, "", documentLanguage);
+        // a link of the template names a stylesheet the conversion service would fetch itself, so it is
+        // read here as the body of a document is, and its target goes through the resource policy
+        return htmlProcessor.internalizeLinks(titleHtml);
     }
 
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverter.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverter.java
@@ -376,7 +376,7 @@ public class PdfConverter {
         String processed = velocityEvaluator.evaluateVelocityExpressions(documentData, content);
 
         String cssContent = (exportParams.getDocumentType() != DocumentType.LIVE_DOC) ? appendWikiCss(processed) : processed;
-        return htmlProcessor.replaceResourcesAsBase64Encoded(cssContent);
+        return htmlProcessor.replaceCssResourcesAsBase64Encoded(cssContent);
     }
 
     @VisibleForTesting

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfiguration.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfiguration.java
@@ -36,6 +36,18 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
             "png", "jpg", "jpeg", "gif", "bmp", "svg", "webp", "avif", "ico", "cur", "tif", "tiff", "vsdx"
     ));
 
+    public static final String EXTERNAL_RESOURCES_POLICY = "externalResources.policy";
+    public static final String EXTERNAL_RESOURCES_POLICY_DESCRIPTION = "BLOCK_INTERNAL, ALLOWLIST_ONLY or ALLOW_ALL: where a document may load <a href='#external-resources'>images, fonts and stylesheets</a> from";
+    public static final String EXTERNAL_RESOURCES_POLICY_DEFAULT_VALUE = "BLOCK_INTERNAL";
+
+    public static final String EXTERNAL_RESOURCES_ALLOWED_ORIGINS = "externalResources.allowedOrigins";
+    public static final String EXTERNAL_RESOURCES_ALLOWED_ORIGINS_DESCRIPTION = "Comma separated origins, [scheme://]host[:port], which are always allowed as a source of <a href='#external-resources'>external resources</a>";
+    public static final String EXTERNAL_RESOURCES_ALLOWED_ORIGINS_DEFAULT_VALUE = "";
+
+    public static final String EXTERNAL_RESOURCES_MAX_SIZE_MB = "externalResources.maxSizeMB";
+    public static final String EXTERNAL_RESOURCES_MAX_SIZE_MB_DESCRIPTION = "Size in MB a single loaded <a href='#external-resources'>external resource</a> may reach";
+    public static final int EXTERNAL_RESOURCES_MAX_SIZE_MB_DEFAULT_VALUE = 16;
+
     @Override
     public String getDebugDescription() {
         return DEBUG_DESCRIPTION;
@@ -103,12 +115,66 @@ public class PdfExporterExtensionConfiguration extends ExtensionConfiguration {
         return String.join(", ", RENDERABLE_IMAGE_EXTENSIONS_DEFAULT_VALUE);
     }
 
+    @PropertyMapping(EXTERNAL_RESOURCES_POLICY)
+    public String getExternalResourcesPolicy() {
+        return SystemValueReader.getInstance().readString(getPropertyPrefix() + EXTERNAL_RESOURCES_POLICY, EXTERNAL_RESOURCES_POLICY_DEFAULT_VALUE);
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDescription(EXTERNAL_RESOURCES_POLICY)
+    public String getExternalResourcesPolicyDescription() {
+        return EXTERNAL_RESOURCES_POLICY_DESCRIPTION;
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDefaultValue(EXTERNAL_RESOURCES_POLICY)
+    public String getExternalResourcesPolicyDefaultValue() {
+        return EXTERNAL_RESOURCES_POLICY_DEFAULT_VALUE;
+    }
+
+    @PropertyMapping(EXTERNAL_RESOURCES_ALLOWED_ORIGINS)
+    public String getExternalResourcesAllowedOrigins() {
+        return SystemValueReader.getInstance().readString(getPropertyPrefix() + EXTERNAL_RESOURCES_ALLOWED_ORIGINS, EXTERNAL_RESOURCES_ALLOWED_ORIGINS_DEFAULT_VALUE);
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDescription(EXTERNAL_RESOURCES_ALLOWED_ORIGINS)
+    public String getExternalResourcesAllowedOriginsDescription() {
+        return EXTERNAL_RESOURCES_ALLOWED_ORIGINS_DESCRIPTION;
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDefaultValue(EXTERNAL_RESOURCES_ALLOWED_ORIGINS)
+    public String getExternalResourcesAllowedOriginsDefaultValue() {
+        return EXTERNAL_RESOURCES_ALLOWED_ORIGINS_DEFAULT_VALUE;
+    }
+
+    @PropertyMapping(EXTERNAL_RESOURCES_MAX_SIZE_MB)
+    public int getExternalResourcesMaxSizeMB() {
+        return SystemValueReader.getInstance().readInt(getPropertyPrefix() + EXTERNAL_RESOURCES_MAX_SIZE_MB, EXTERNAL_RESOURCES_MAX_SIZE_MB_DEFAULT_VALUE);
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDescription(EXTERNAL_RESOURCES_MAX_SIZE_MB)
+    public String getExternalResourcesMaxSizeMBDescription() {
+        return EXTERNAL_RESOURCES_MAX_SIZE_MB_DESCRIPTION;
+    }
+
+    @SuppressWarnings("unused")
+    @PropertyMappingDefaultValue(EXTERNAL_RESOURCES_MAX_SIZE_MB)
+    public String getExternalResourcesMaxSizeMBDefaultValue() {
+        return String.valueOf(EXTERNAL_RESOURCES_MAX_SIZE_MB_DEFAULT_VALUE);
+    }
+
     @Override
     public @NotNull List<String> getSupportedProperties() {
         List<String> supportedProperties = new ArrayList<>(super.getSupportedProperties());
         supportedProperties.add(WEASYPRINT_SERVICE);
         supportedProperties.add(WEBHOOKS_ENABLED);
         supportedProperties.add(RENDERABLE_IMAGE_EXTENSIONS);
+        supportedProperties.add(EXTERNAL_RESOURCES_POLICY);
+        supportedProperties.add(EXTERNAL_RESOURCES_ALLOWED_ORIGINS);
+        supportedProperties.add(EXTERNAL_RESOURCES_MAX_SIZE_MB);
         return supportedProperties;
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolver.java
@@ -4,24 +4,75 @@ import com.polarion.alm.tracker.internal.url.IUrlResolver;
 import com.polarion.core.util.StringUtils;
 import com.polarion.core.util.logging.Logger;
 import lombok.SneakyThrows;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.DnsResolver;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.SystemDefaultDnsResolver;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.apache.http.impl.conn.DefaultRoutePlanner;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URL;
+import java.security.cert.CertificateException;
+import java.util.Set;
 import java.util.stream.Stream;
 
-import static java.net.HttpURLConnection.*;
+import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
+import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_SEE_OTHER;
 
 /**
  * Custom version of {@link com.polarion.alm.tracker.internal.url.GenericUrlResolver} with the redirect support.
+ * <p>
+ * Every request passes {@link ResourceUrlPolicy}, which keeps a document editor from making the server
+ * fetch an arbitrary address and from getting the response body back in the exported document. The
+ * connection is pinned to the addresses the policy vetted, so a second name resolution cannot reach an
+ * address the policy never saw.
+ * </p>
  */
 public class CustomResourceUrlResolver implements IUrlResolver {
 
+    private static final Logger logger = Logger.getLogger(CustomResourceUrlResolver.class);
+
     private static final int CONNECTION_TIMEOUT_MS = 3_000;
     private static final int READ_TIMEOUT_MS = 3_000;
+    private static final int MAX_REDIRECTS = 5;
+    private static final int BUFFER_SIZE = 8192;
+    private static final String SKIPPED_RESOURCE = "Skipped resource ";
+    // every redirect a client follows, the permanent and the temporary ones of both generations
+    private static final Set<Integer> REDIRECT_STATUS_CODES = Set.of(HTTP_MOVED_PERM, HTTP_MOVED_TEMP, HTTP_SEE_OTHER, 307, 308);
+    private static final String HTTP_SCHEME = "http";
+    private static final String HTTPS_SCHEME = "https";
+
+    private final ResourceUrlPolicy policy;
+
+    public CustomResourceUrlResolver() {
+        this(ResourceUrlPolicy.getInstance());
+    }
+
+    public CustomResourceUrlResolver(@NotNull ResourceUrlPolicy policy) {
+        this.policy = policy;
+    }
 
     public boolean canResolve(@NotNull String url) {
         return Stream.of("/", "http:", "https:").anyMatch(url::startsWith);
@@ -29,35 +80,286 @@ public class CustomResourceUrlResolver implements IUrlResolver {
 
     public InputStream resolve(@NotNull String urlStr) {
         try {
-            URI uri = URI.create(normalizeUrl(ensureAbsoluteUrl(urlStr)));
-            return resolveImpl(uri.toURL());
+            if (MediaUtils.isNetworkPathReference(urlStr)) {
+                return resolveNetworkPathReference(urlStr);
+            }
+            return resolveImpl(URI.create(normalizeUrl(ensureAbsoluteUrl(urlStr))).toURL());
         } catch (Exception e) {
-            Logger.getLogger(this).warn("Failed to load resource: " + urlStr, e);
+            logger.warn("Failed to load resource: " + urlStr, e);
         }
         return null;
+    }
+
+    /**
+     * A reference like {@code //host/path} takes the scheme of the base url the document carries, and
+     * that base is built elsewhere, from the cluster host among other things. Rather than guessing which
+     * one it ends up with, both are tried, each one checked by the policy on its own.
+     */
+    private InputStream resolveNetworkPathReference(@NotNull String urlStr) {
+        String preferredScheme = policy.getBaseUrlScheme();
+        String otherScheme = HTTPS_SCHEME.equals(preferredScheme) ? HTTP_SCHEME : HTTPS_SCHEME;
+        SchemeAttempt preferred = resolveWithScheme(preferredScheme, urlStr);
+        if (preferred.conclusive()) {
+            // the host answered, and what it answered was read or refused: the other scheme adds nothing,
+            // and a host which speaks tls badly is not asked for the same resource in the clear either
+            return preferred.stream();
+        }
+        SchemeAttempt other = resolveWithScheme(otherScheme, urlStr);
+        if (other.stream() == null) {
+            logger.warn(SKIPPED_RESOURCE + urlStr + ": neither " + preferredScheme + " nor " + otherScheme + " could read it");
+        }
+        return other.stream();
+    }
+
+    private SchemeAttempt resolveWithScheme(@NotNull String scheme, @NotNull String urlStr) {
+        try {
+            URL url = URI.create(normalizeUrl(scheme + ":" + urlStr)).toURL();
+            InputStream stream = resolveImpl(url);
+            // a decision was taken, whether it produced a resource or refused one, unless the refusal
+            // itself turned on the scheme: an allowed origin may name one, and then it names no other
+            return new SchemeAttempt(stream, stream != null || !policy.isRefusalSchemeSpecific(url));
+        } catch (Exception e) {
+            logger.debug("Failed to load resource " + scheme + ":" + urlStr + ": " + e.getMessage());
+            // nothing was decided unless the peer showed a certificate which was refused
+            return new SchemeAttempt(null, isCertificateFailure(e));
+        }
+    }
+
+    /**
+     * @param stream     what the scheme produced, null if it produced nothing
+     * @param conclusive whether trying the other scheme would still answer the question
+     */
+    private record SchemeAttempt(@Nullable InputStream stream, boolean conclusive) {
+    }
+
+    /**
+     * A host which does not speak tls on that port answered nothing, and the other scheme of a network
+     * path reference is the question to ask next. A host which showed a certificate the client refused
+     * did answer, and the answer to a refused certificate is never the same resource in the clear.
+     */
+    @VisibleForTesting
+    boolean isCertificateFailure(@NotNull Throwable failure) {
+        for (Throwable current = failure; current != null; current = current.getCause()) {
+            if (current instanceof CertificateException || current instanceof SSLPeerUnverifiedException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @SneakyThrows
     @VisibleForTesting
     public InputStream resolveImpl(@NotNull URL url) {
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        connection.setConnectTimeout(CONNECTION_TIMEOUT_MS);
-        connection.setReadTimeout(READ_TIMEOUT_MS);
-        connection.connect();
-        int responseCode = connection.getResponseCode();
-        if (responseCode == HTTP_OK) {
-            return connection.getInputStream();
-        } else if (responseCode == HTTP_MOVED_PERM || responseCode == HTTP_MOVED_TEMP) {
-            String location = connection.getHeaderField("Location");
-            if (location != null && canResolve(location)) {
-                return resolve(location);
+        URL currentUrl = url;
+        // the selector is asked once per hop, and the answer both decides and routes: what the check
+        // let through cannot be routed anywhere else
+        ProxySelector selector = ProxySelector.getDefault();
+        for (int redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
+            ProxyDecision proxy = decideProxy(selector, currentUrl);
+            if (!mayBeFetched(currentUrl, proxy)) {
+                return null;
+            }
+            // a proxied request is decided by name, and the socket goes to the proxy: the addresses of
+            // the host would bind nothing, and a server whose egress is the proxy often cannot even
+            // resolve that name. It is the trust in the url which carries such a request, not an address
+            InetAddress[] addresses = null;
+            if (!proxy.proxied()) {
+                addresses = policy.vetAddresses(currentUrl);
+                if (addresses == null) {
+                    return null;
+                }
+            }
+            try (CloseableHttpClient client = createClient(currentUrl, addresses, proxy);
+                 CloseableHttpResponse response = client.execute(new HttpGet(URI.create(currentUrl.toString())))) {
+                if (response.getStatusLine().getStatusCode() == HTTP_OK) {
+                    return readContent(response, currentUrl);
+                }
+                URL target = redirectTarget(response, currentUrl);
+                if (target == null) {
+                    return null;
+                }
+                currentUrl = target;
             }
         }
+        logger.warn("Failed to load resource: " + url + ", more than " + MAX_REDIRECTS + " redirects");
         return null;
+    }
+
+    /**
+     * @return whether the request may be made at all, given where it would be routed
+     */
+    private boolean mayBeFetched(@NotNull URL url, @NotNull ProxyDecision proxy) {
+        if (!proxy.proxied()) {
+            return true;
+        }
+        if (!policy.isExplicitlyTrusted(url)) {
+            // A proxy resolves the host name itself, so the vetted addresses would decide nothing.
+            // Only a host the configuration trusts as such may be fetched that way.
+            logger.warn(SKIPPED_RESOURCE + url + ": it would go through a proxy, which resolves the host name itself."
+                    + " List the host in the allowed hosts property to fetch it anyway.");
+            return false;
+        }
+        if (proxy.host() == null) {
+            // the host is trusted, but the proxy to reach it through was not named, and a request
+            // sent past the configured route is not the request the configuration asked for
+            logger.warn(SKIPPED_RESOURCE + url + ": it goes through a proxy which could not be named.");
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return where the response sends the request next, null where it sends it nowhere
+     */
+    @SneakyThrows
+    @Nullable
+    private URL redirectTarget(@NotNull CloseableHttpResponse response, @NotNull URL currentUrl) {
+        if (!REDIRECT_STATUS_CODES.contains(response.getStatusLine().getStatusCode())) {
+            return null;
+        }
+        Header location = response.getFirstHeader(HttpHeaders.LOCATION);
+        if (location == null || StringUtils.isEmptyTrimmed(location.getValue())) {
+            return null;
+        }
+        return URI.create(normalizeUrl(currentUrl.toString())).resolve(normalizeUrl(location.getValue().trim())).toURL();
+    }
+
+    /**
+     * Builds a client for a single request. Its name resolution answers with the vetted addresses for the
+     * host of that request, which binds the request to what {@link ResourceUrlPolicy#vetAddresses}
+     * approved. The host name stays in the request, so the Host header and the TLS host name verification
+     * keep working. Any other name, a proxy host as a rule, is left to the system resolver.
+     *
+     * @param addresses the addresses the host was vetted for, null where the request goes to a proxy
+     *                  which resolves the name itself
+     */
+    private CloseableHttpClient createClient(@NotNull URL url, @Nullable InetAddress[] addresses, @NotNull ProxyDecision proxy) {
+        String pinnedHost = url.getHost() == null ? "" : stripBrackets(url.getHost());
+        DnsResolver pinnedResolver = host -> addresses != null && pinnedHost.equalsIgnoreCase(host)
+                ? addresses
+                : SystemDefaultDnsResolver.INSTANCE.resolve(host);
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(CONNECTION_TIMEOUT_MS)
+                .setConnectionRequestTimeout(CONNECTION_TIMEOUT_MS)
+                .setSocketTimeout(READ_TIMEOUT_MS)
+                // redirects are followed by this class, so that the policy sees every single hop
+                .setRedirectsEnabled(false)
+                .build();
+        return HttpClients.custom()
+                // the replaced HttpURLConnection honoured http.proxyHost and friends, keep doing that.
+                // Behind a proxy the socket goes to the proxy, so the proxy resolves the host name and
+                // the addresses below only decide whether the request is made at all.
+                .useSystemProperties()
+                // the route is the answer the check already got, so the selector is asked no second time
+                .setRoutePlanner(proxy.host() == null ? new DefaultRoutePlanner(null) : new DefaultProxyRoutePlanner(proxy.host()))
+                .setDefaultRequestConfig(requestConfig)
+                .setDnsResolver(pinnedResolver)
+                .disableAutomaticRetries()
+                .disableCookieManagement()
+                .disableAuthCaching()
+                .build();
+    }
+
+    /**
+     * Reads at most {@link ResourceUrlPolicy#getMaxResourceBytes()} bytes. The content is fully read here
+     * because the response is closed as soon as this method returns.
+     */
+    @SneakyThrows
+    private InputStream readContent(@NotNull CloseableHttpResponse response, @NotNull URL url) {
+        HttpEntity entity = response.getEntity();
+        if (entity == null) {
+            return null;
+        }
+
+        Header contentTypeHeader = entity.getContentType();
+        String contentType = contentTypeHeader == null ? null : contentTypeHeader.getValue();
+        if (!policy.isAllowedContentType(contentType)) {
+            logger.warn(SKIPPED_RESOURCE + url + ": the content type '" + contentType + "' is not an image, a font or a stylesheet");
+            return null;
+        }
+
+        long maxBytes = policy.getMaxResourceBytes();
+        if (entity.getContentLength() > maxBytes) {
+            logger.warn(SKIPPED_RESOURCE + url + ": it is larger than " + maxBytes + " bytes");
+            return null;
+        }
+
+        ByteArrayOutputStream content = new ByteArrayOutputStream();
+        byte[] buffer = new byte[BUFFER_SIZE];
+        try (InputStream inputStream = entity.getContent()) {
+            int read;
+            while ((read = inputStream.read(buffer)) != -1) {
+                if (content.size() + read > maxBytes) {
+                    logger.warn(SKIPPED_RESOURCE + url + ": it is larger than " + maxBytes + " bytes");
+                    return null;
+                }
+                content.write(buffer, 0, read);
+            }
+        }
+
+        byte[] bytes = content.toByteArray();
+        // the header says what the sender calls it, and the content says what it is: both are asked,
+        // so a service which answers a forged request cannot name its way past the check
+        String sniffedType = MediaUtils.getMimeTypeUsingTikaByContent(url.toString(), bytes);
+        if (policy.isRejectedContent(contentType, sniffedType)) {
+            logger.warn(SKIPPED_RESOURCE + url + ": its content is '" + sniffedType + "', not an image, a font or a stylesheet");
+            return null;
+        }
+        return new ByteArrayInputStream(bytes);
     }
 
     private String ensureAbsoluteUrl(String url) {
         return url.startsWith("/") ? getBaseUrl() + url : url;
+    }
+
+    private static String stripBrackets(@NotNull String host) {
+        return host.startsWith("[") && host.endsWith("]") ? host.substring(1, host.length() - 1) : host;
+    }
+
+    /**
+     * Asks the selector once and keeps the answer. The request is routed by this answer and by nothing
+     * else, so a selector which answers differently the next time it is asked cannot route a request the
+     * check let through. Only an http proxy is a route: a socks one the jvm applies at the socket, after
+     * the connection has been bound to a vetted address.
+     *
+     * @return what to do with the url, and where to route it if that is through a proxy
+     */
+    @VisibleForTesting
+    ProxyDecision decideProxy(@Nullable ProxySelector selector, @NotNull URL url) {
+        if (selector == null) {
+            return new ProxyDecision(false, null);
+        }
+        try {
+            // the jvm takes the first entry it can use, direct or http, and reading the list the same way
+            // keeps the answer the one the configuration meant: 'DIRECT; PROXY host:port' means direct
+            return selector.select(URI.create(url.toString())).stream()
+                    .filter(proxy -> proxy.type() == Proxy.Type.DIRECT || proxy.type() == Proxy.Type.HTTP)
+                    .findFirst()
+                    .map(proxy -> proxy.type() == Proxy.Type.HTTP
+                            ? new ProxyDecision(true, hostOf(proxy))
+                            : new ProxyDecision(false, null))
+                    .orElseGet(() -> new ProxyDecision(false, null));
+        } catch (RuntimeException e) {
+            // a selector which cannot answer is no reason to fetch anything past the check
+            logger.warn("Cannot tell whether '" + url + "' goes through a proxy, it is treated as proxied", e);
+            return new ProxyDecision(true, null);
+        }
+    }
+
+    @Nullable
+    private HttpHost hostOf(@NotNull Proxy proxy) {
+        if (proxy.address() instanceof InetSocketAddress address) {
+            return new HttpHost(address.getHostString(), address.getPort());
+        }
+        return null;
+    }
+
+    /**
+     * @param proxied whether the url would be requested through an http proxy
+     * @param host    the proxy to route to, null where there is nothing to route to or nothing was told
+     */
+    @VisibleForTesting
+    record ProxyDecision(boolean proxied, @Nullable HttpHost host) {
     }
 
     private String getBaseUrl() {
@@ -65,7 +367,8 @@ public class CustomResourceUrlResolver implements IUrlResolver {
         return StringUtils.removeSuffix(baseUrl, "/");
     }
 
+    // delegates, so that the policy check and the request itself normalize a url identically
     private String normalizeUrl(String urlStr) {
-        return urlStr.replace(" ", "%20").replace("%5F", "_");
+        return MediaUtils.normalizeUrl(urlStr);
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/FileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/FileResourceProvider.java
@@ -10,4 +10,12 @@ public interface FileResourceProvider {
 
     byte[] getResourceAsBytes(@NotNull String resource);
 
+    /**
+     * Tells whether the resource policy forbids requesting this URL. Such a URL must not be left in the
+     * HTML either: WeasyPrint would then load it from its own network position.
+     */
+    default boolean isForbidden(@NotNull String resource) {
+        return false;
+    }
+
 }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessor.java
@@ -1430,6 +1430,13 @@ public class HtmlProcessor {
         return MediaUtils.inlineBase64Resources(html, fileResourceProvider);
     }
 
+    /**
+     * The same for a value which is a stylesheet rather than a document, a cover page style for one.
+     */
+    public String replaceCssResourcesAsBase64Encoded(String css) {
+        return MediaUtils.inlineCssResources(css, fileResourceProvider);
+    }
+
     public String internalizeLinks(String html) {
         return httpLinksHelper.internalizeLinks(html);
     }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -3,11 +3,38 @@ package ch.sbb.polarion.extension.pdf_exporter.util;
 import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.generic.util.BundleJarsPrioritizingRunnable;
 import ch.sbb.polarion.extension.generic.util.ScopeUtils;
+import com.helger.css.CSSSourceLocation;
+import com.helger.css.ICSSSourceLocationAware;
+import com.helger.css.decl.CSSMediaRule;
+import com.helger.css.decl.CSSSupportsRule;
+import com.helger.css.decl.CSSStyleRule;
+import com.helger.css.decl.CSSUnknownRule;
+import com.helger.css.decl.ICSSExpressionMember;
+import com.helger.css.decl.CSSDeclaration;
+import com.helger.css.decl.CSSImportRule;
+import com.helger.css.decl.CSSExpressionMemberTermURI;
+import com.helger.css.decl.CascadingStyleSheet;
+import com.helger.css.decl.ICSSTopLevelRule;
+import com.helger.css.decl.visit.CSSVisitor;
+import com.helger.css.decl.CSSExpressionMemberTermSimple;
+import com.helger.css.decl.visit.DefaultCSSUrlVisitor;
+import com.helger.css.decl.visit.DefaultCSSVisitor;
+import com.helger.css.handler.DoNothingCSSParseExceptionCallback;
+import com.helger.css.reader.CSSReader;
+import com.helger.css.reader.CSSReaderSettings;
+import com.helger.css.reader.errorhandler.DoNothingCSSParseErrorHandler;
 import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.PdfVariant;
 import ch.sbb.polarion.extension.pdf_exporter.service.PdfExporterPolarionService;
 import com.polarion.alm.shared.api.transaction.TransactionalExecutor;
 import com.polarion.core.util.StringUtils;
+import org.jsoup.parser.Parser;
+import org.jsoup.nodes.Range;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Entities;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.DataNode;
+import org.jsoup.Jsoup;
 import com.polarion.core.util.logging.Logger;
 import com.polarion.platform.service.repository.IRepositoryReadOnlyConnection;
 import com.polarion.subterra.base.location.ILocation;
@@ -41,8 +68,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
 
 import static ch.sbb.polarion.extension.pdf_exporter.util.TikaMimeTypeResolver.PARAM_RESULT;
 import static ch.sbb.polarion.extension.pdf_exporter.util.TikaMimeTypeResolver.PARAM_VALUE;
@@ -50,9 +82,25 @@ import static ch.sbb.polarion.extension.pdf_exporter.util.TikaMimeTypeResolver.P
 @UtilityClass
 public class MediaUtils {
     public static final String IMG_SRC_REGEX = "<img[^<>]*src=(\"|')(?<url>[^(\"|')]*)(\"|')";
-    public static final String URL_REGEX = "url\\(\\s*([\"'])?(?<url>.*?)\\1?\\s*\\)";
+    public static final String URL_REGEX = "(?i)url\\(\\s*([\"'])?(?<url>.*?)\\1?\\s*\\)";
     public static final String DATA_URL_PREFIX = "data:";
+    private static final String NETWORK_PATH_PREFIX = "//";
+    // what a detector answers when it read the content and recognized nothing in it
+    private static final String OCTET_STREAM = "application/octet-stream";
+
+    private static final Document.OutputSettings ATTRIBUTE_OUTPUT_SETTINGS =
+            new Document.OutputSettings().escapeMode(Entities.EscapeMode.xhtml);
+
+    // a url which names a scheme names where it is read from, and this class can vet two of them
+    private static final Pattern SCHEME_PATTERN = Pattern.compile("^[a-z][a-z\\d+.-]*:", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern CSS_ESCAPE_PATTERN = Pattern.compile("\\\\(?:([0-9a-fA-F]{1,6})[ \\t\\r\\n\\f]?|(.))", Pattern.DOTALL);
     public static final String THUMBNAIL_PARAMETER = "thumbnail";
+    /**
+     * A 1x1 transparent PNG which replaces a resource the {@link ResourceUrlPolicy} rejected.
+     */
+    public static final String BLOCKED_RESOURCE_PLACEHOLDER =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
     private static final Logger logger = Logger.getLogger(MediaUtils.class);
     private static final int RIGHT_WHITE_AREA_PX = 30;
     private static final int PDF_TO_PNG_DPI = 300;
@@ -259,6 +307,46 @@ public class MediaUtils {
     }
 
     /**
+     * Resolves the CSS escapes of a value, {@code http\\3a //host} and the like. A stylesheet reaches
+     * WeasyPrint as text, and WeasyPrint resolves them, so the check has to see the same value.
+     */
+    public String decodeCssEscapes(@NotNull String value) {
+        if (value.indexOf('\\') < 0) {
+            return value;
+        }
+        Matcher matcher = CSS_ESCAPE_PATTERN.matcher(value);
+        StringBuilder decoded = new StringBuilder();
+        while (matcher.find()) {
+            String hex = matcher.group(1);
+            String replacement = hex != null ? codePointOf(hexValueOf(hex)) : matcher.group(2);
+            matcher.appendReplacement(decoded, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(decoded);
+        return decoded.toString();
+    }
+
+    /**
+     * Reads the hex digits of a CSS escape. The pattern caps them at six, so the value fits into an int,
+     * and every character it captured is a hex digit, so there is nothing here that could fail.
+     */
+    private int hexValueOf(@NotNull String hex) {
+        int value = 0;
+        for (int i = 0; i < hex.length(); i++) {
+            value = (value << 4) + Character.digit(hex.charAt(i), 16);
+        }
+        return value;
+    }
+
+    /**
+     * CSS turns an escape of zero, of a surrogate and of a value above the last code point into the
+     * replacement character, and so does this.
+     */
+    private String codePointOf(int value) {
+        boolean valid = value > 0 && value <= Character.MAX_CODE_POINT && !(value >= Character.MIN_SURROGATE && value <= Character.MAX_SURROGATE);
+        return valid ? Character.toString(value) : "\uFFFD";
+    }
+
+    /**
      * Check whether particular string is a <a href="https://www.rfc-editor.org/rfc/rfc2397">'data' URL</a>-encoded entry.
      */
     public boolean isDataUrl(@Nullable String resourceUrl) {
@@ -266,22 +354,492 @@ public class MediaUtils {
     }
 
     public String inlineBase64Resources(String content, FileResourceProvider fileResourceProvider) {
-        RegexMatcher.IReplacementCalculator dataReplacement = engine -> {
-            String url = engine.group("url");
-            if (MediaUtils.isDataUrl(url)) {
-                return null;
-            }
-            // For renderable images (e.g. .png, .svg) strip 'thumbnail' to fetch full-size content.
-            // For everything else (spreadsheets, documents, unknown formats) keep 'thumbnail' so Polarion returns an icon preview.
-            String resourceUrl = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
-            String base64String = fileResourceProvider.getResourceAsBase64String(resourceUrl);
-            return base64String == null ? null : engine.group().replace(url, base64String);
-        };
+        return processResourceRegions(content, fileResourceProvider);
+    }
 
-        // replace tags like <img src="...
-        String intermediateResult = RegexMatcher.get(IMG_SRC_REGEX).replace(content, dataReplacement);
-        // replace CSS parameters like background: src('/polarion/...
-        return RegexMatcher.get(URL_REGEX).useJavaUtil().replace(intermediateResult, dataReplacement);
+    /**
+     * @return what the url of a resource has to be replaced with, null when it may stay as it is
+     */
+    @Nullable
+    private String replacementFor(@NotNull FileResourceProvider fileResourceProvider, @NotNull String rawUrl) {
+        // the document may write a url with whitespace around it, every step below has to see the same one
+        String url = rawUrl.trim();
+        // the escapes are resolved for the decisions and for those only: what is fetched is the url as
+        // it stands, and a backslash a path carries is a backslash. isForbidden resolves them as well,
+        // so the gate and the decision below cannot read the same url differently
+        String decoded = decodeCssEscapes(url);
+        if (isDataUrl(decoded)) {
+            return null;
+        }
+        if (!fileResourceProvider.isForbidden(url)) {
+            // a renderable image is wanted at its full size, so the thumbnail parameter goes. Everything
+            // else keeps it, and Polarion answers with the icon preview it has for a document
+            String requested = isRenderableImageUrl(url) ? removeQueryParameter(url, THUMBNAIL_PARAMETER) : url;
+            String base64String = fileResourceProvider.getResourceAsBase64String(Objects.requireNonNullElse(requested, url));
+            if (base64String != null) {
+                return base64String;
+            }
+        }
+        // A url which was not inlined, whatever the reason, must not stay in the document where the
+        // conversion service would read it from its own network or its own file system. A relative url
+        // is left untouched, no service reads one.
+        return isReadElsewhere(decoded) ? BLOCKED_RESOURCE_PLACEHOLDER : null;
+    }
+
+    /**
+     * Rewrites the resources a stylesheet points at: every url is inlined, replaced by the placeholder or
+     * left alone, and an {@code @import} of an absolute address is removed, since an at-rule is never
+     * inlined and WeasyPrint would load it itself.
+     * <p>
+     * The stylesheet is parsed rather than matched. A comment, an escape or a media condition may sit
+     * almost anywhere in CSS, and a pattern that survives all of them does not exist.
+     * </p>
+     */
+    public String inlineCssResources(@NotNull String css, @NotNull FileResourceProvider fileResourceProvider) {
+        if (!mayReferenceAResource(css)) {
+            // no url, no import and no address: there is nothing to rewrite and nothing to check, and a
+            // style attribute of a large document is not worth a parser run for that
+            return css;
+        }
+        CascadingStyleSheet stylesheet = parse(css);
+        if (stylesheet == null) {
+            logger.warn("Dropped a stylesheet which cannot be parsed, the resources it points at cannot be checked");
+            return "";
+        }
+
+        // The parser tells where each url and each import stands, and only those parts are rewritten.
+        // Everything else keeps the formatting the document came with.
+        int[] lineStarts = lineStartsOf(css);
+        CssRewrite rewrite = new CssRewrite();
+        readImports(css, stylesheet, lineStarts, rewrite);
+        readUrls(css, stylesheet, lineStarts, rewrite, fileResourceProvider);
+
+        if (!rewrite.complete() || namesAnAddressNothingAccountedFor(css, stylesheet, lineStarts, rewrite.accounted())) {
+            logger.warn("Dropped a stylesheet: it names an absolute address which could not be read as a resource");
+            return "";
+        }
+        return applyEdits(css, rewrite.edits());
+    }
+
+    @Nullable
+    private CascadingStyleSheet parse(@NotNull String css) {
+        CSSReaderSettings settings = new CSSReaderSettings()
+                // a browser keeps what it understands and skips the rest, and so does the conversion service
+                .setBrowserCompliantMode(true)
+                // a tab counts as one column, so a column of the parser is an offset of the text again:
+                // the default of eight moves every position on a line which carries one
+                .setTabSize(1)
+                .setCustomErrorHandler(new DoNothingCSSParseErrorHandler())
+                .setCustomExceptionHandler(new DoNothingCSSParseExceptionCallback());
+        return CSSReader.readFromStringReader(css, settings);
+    }
+
+    private void readImports(@NotNull String css, @NotNull CascadingStyleSheet stylesheet, int[] lineStarts, @NotNull CssRewrite rewrite) {
+        for (CSSImportRule importRule : stylesheet.getAllImportRules()) {
+            CssRange range = rangeOf(lineStarts, css, importRule.getSourceLocation());
+            boolean absolute = isReadElsewhere(decodeCssEscapes(importRule.getLocationString()));
+            if (range == null) {
+                rewrite.missed(!absolute);
+            } else {
+                rewrite.accounted().add(range);
+                if (absolute) {
+                    // an at-rule is never inlined, so the target of an absolute one has to go
+                    rewrite.edits().add(new CssEdit(range, ""));
+                }
+            }
+        }
+    }
+
+    private void readUrls(@NotNull String css, @NotNull CascadingStyleSheet stylesheet, int[] lineStarts,
+                          @NotNull CssRewrite rewrite, @NotNull FileResourceProvider fileResourceProvider) {
+        CSSVisitor.visitCSSUrl(stylesheet, new DefaultCSSUrlVisitor() {
+            @Override
+            public void onUrlDeclaration(@Nullable ICSSTopLevelRule topLevelRule, @NotNull CSSDeclaration declaration, @NotNull CSSExpressionMemberTermURI uri) {
+                CssRange range = rangeOf(lineStarts, css, uri.getSourceLocation());
+                // the parser resolves the escapes of a url term itself, so this value is the one the
+                // renderer would read, and the one the policy is asked about
+                String replacement = replacementFor(fileResourceProvider, uri.getURIString());
+                if (range == null) {
+                    rewrite.missed(replacement == null);
+                    return;
+                }
+                rewrite.accounted().add(range);
+                if (replacement != null) {
+                    // no quotes around it: the value is a data url, and a quote would end a style attribute
+                    rewrite.edits().add(new CssEdit(range, "url(" + replacement + ")"));
+                }
+            }
+        });
+    }
+
+    /**
+     * What a run over a stylesheet collects: where the parser accounted for something, what has to be
+     * written back, and whether anything it had to rewrite could not be placed.
+     */
+    @VisibleForTesting
+    static final class CssRewrite {
+        private final List<CssRange> accounted = new ArrayList<>();
+        private final List<CssEdit> edits = new ArrayList<>();
+        private boolean complete = true;
+
+        List<CssRange> accounted() {
+            return accounted;
+        }
+
+        List<CssEdit> edits() {
+            return edits;
+        }
+
+        boolean complete() {
+            return complete;
+        }
+
+        /**
+         * @param harmless whether what could not be placed needed no rewriting in the first place
+         */
+        void missed(boolean harmless) {
+            complete &= harmless;
+        }
+    }
+
+    private record CssRange(int start, int end) {
+    }
+
+    private record CssEdit(@NotNull CssRange range, @NotNull String replacement) {
+    }
+
+    /**
+     * Applies the edits back to front, so that an offset stays valid while the ones before it are used.
+     */
+    private String applyEdits(@NotNull String css, @NotNull List<CssEdit> edits) {
+        StringBuilder result = new StringBuilder(css);
+        edits.stream()
+                .sorted((left, right) -> Integer.compare(right.range().start(), left.range().start()))
+                .forEach(edit -> result.replace(edit.range().start(), edit.range().end(), edit.replacement()));
+        return result.toString();
+    }
+
+    /**
+     * Where each line of a stylesheet begins, counted the way the parser counts it: a line feed ends a
+     * line, a carriage return ends one as well, the two together end one line and not two. A form feed
+     * ends none, which is what the parser reports for it.
+     */
+    private int[] lineStartsOf(@NotNull String css) {
+        List<Integer> starts = new ArrayList<>();
+        starts.add(0);
+        int i = 0;
+        while (i < css.length()) {
+            char current = css.charAt(i);
+            if (current == '\r' && i + 1 < css.length() && css.charAt(i + 1) == '\n') {
+                i += 2;
+                starts.add(i);
+            } else if (current == '\r' || current == '\n') {
+                i++;
+                starts.add(i);
+            } else {
+                i++;
+            }
+        }
+        return starts.stream().mapToInt(Integer::intValue).toArray();
+    }
+
+    private int offsetOf(int[] lineStarts, @NotNull String css, int line, int column) {
+        if (line < 1 || line > lineStarts.length) {
+            return -1;
+        }
+        int offset = lineStarts[line - 1] + column;
+        return offset > css.length() ? -1 : offset;
+    }
+
+    private boolean mayReferenceAResource(@NotNull String css) {
+        String probe = decodeCssEscapes(css).toLowerCase(Locale.ROOT);
+        // an address of its own still has to reach the backstop, which is what judges whether anything
+        // accounted for it: the payload of a data url is exempted there, by the range of the url() term
+        return probe.contains("url(") || probe.contains("@import") || namesAnAbsoluteAddress(probe);
+    }
+
+    /**
+     * Tells whether a text names an address at all. Nothing is taken out of it here: the caller decides
+     * what its probe holds, and inside the backstop a url the parser read is already out of the way.
+     */
+    private boolean namesAnAbsoluteAddress(@NotNull String css) {
+        String probe = decodeCssEscapes(css).toLowerCase(Locale.ROOT);
+        // file: is the one scheme besides http and https which a conversion service here resolves
+        return probe.contains("http:") || probe.contains("https:") || probe.contains("file:")
+                || probe.contains(NETWORK_PATH_PREFIX);
+    }
+
+    /**
+     * Tells whether a stylesheet names an absolute address which nothing accounted for.
+     * <p>
+     * What is accounted for is taken out of the text first: a url and an import the parser read, a
+     * namespace rule, the selector of every rule, the strings the parser read as values, the comments
+     * and the data urls. None of those makes the renderer fetch an unchecked address. Whatever names an
+     * address after that, an escaped at-keyword, a value the parser dropped, a function it does not
+     * know, was read by nothing, and the renderer may well read it.
+     * </p>
+     */
+    private boolean namesAnAddressNothingAccountedFor(@NotNull String css, @NotNull CascadingStyleSheet stylesheet,
+                                                      int[] lineStarts, @NotNull List<CssRange> accounted) {
+        List<CssRange> ranges = new ArrayList<>(accounted);
+        stylesheet.getAllNamespaceRules().stream()
+                .map(rule -> rangeOf(lineStarts, css, rule.getSourceLocation()))
+                .filter(Objects::nonNull)
+                .forEach(ranges::add);
+        stylesheet.getAllRules().stream()
+                // an unknown rule is one the parser could not read, and that is what this looks for
+                .filter(rule -> !(rule instanceof CSSUnknownRule))
+                .filter(ICSSSourceLocationAware.class::isInstance)
+                .map(rule -> rangeOf(lineStarts, css, ((ICSSSourceLocationAware) rule).getSourceLocation()))
+                .filter(Objects::nonNull)
+                .map(range -> selectorOf(css, range))
+                .forEach(ranges::add);
+        ranges.addAll(textRangesOf(css, stylesheet, lineStarts));
+
+        // each range keeps its length, so one range never moves another and an overlap changes nothing
+        char[] probe = css.toCharArray();
+        ranges.forEach(range -> Arrays.fill(probe, range.start(), range.end(), ' '));
+        return namesAnAbsoluteAddress(stripCssComments(new String(probe)));
+    }
+
+    /**
+     * @return where the parser read something which fetches nothing: a string, and the selector or the
+     * prelude of a rule at any depth, which the top-level pass does not reach inside a grouping at-rule
+     */
+    private List<CssRange> textRangesOf(@NotNull String css, @NotNull CascadingStyleSheet stylesheet, int[] lineStarts) {
+        List<CssRange> ranges = new ArrayList<>();
+        CSSVisitor.visitCSS(stylesheet, new DefaultCSSVisitor() {
+            @Override
+            public void onBeginStyleRule(@NotNull CSSStyleRule styleRule) {
+                addPreludeOf(styleRule);
+            }
+
+            @Override
+            public void onBeginMediaRule(@NotNull CSSMediaRule mediaRule) {
+                addPreludeOf(mediaRule);
+            }
+
+            @Override
+            public void onBeginSupportsRule(@NotNull CSSSupportsRule supportsRule) {
+                addPreludeOf(supportsRule);
+            }
+
+            private void addPreludeOf(@NotNull ICSSSourceLocationAware rule) {
+                CssRange range = rangeOf(lineStarts, css, rule.getSourceLocation());
+                if (range != null) {
+                    ranges.add(selectorOf(css, range));
+                }
+            }
+
+            @Override
+            public void onDeclaration(@NotNull CSSDeclaration declaration) {
+                declaration.getExpression().getAllMembers().stream()
+                        .filter(CSSExpressionMemberTermSimple.class::isInstance)
+                        .map(CSSExpressionMemberTermSimple.class::cast)
+                        .filter(member -> member.getValue().startsWith("\"") || member.getValue().startsWith("'"))
+                        .map(member -> rangeOf(lineStarts, css, member.getSourceLocation()))
+                        .filter(Objects::nonNull)
+                        .forEach(ranges::add);
+            }
+        });
+        return ranges;
+    }
+
+    /**
+     * @return the part of a rule up to its body, the selector or the prelude, which fetches nothing
+     */
+    private CssRange selectorOf(@NotNull String css, @NotNull CssRange ruleRange) {
+        int body = css.indexOf('{', ruleRange.start());
+        return new CssRange(ruleRange.start(), body < 0 || body > ruleRange.end() ? ruleRange.end() : body);
+    }
+
+    @Nullable
+    private CssRange rangeOf(int[] lineStarts, @NotNull String css, @Nullable CSSSourceLocation location) {
+        if (location == null) {
+            return null;
+        }
+        int start = offsetOf(lineStarts, css, location.getFirstTokenBeginLineNumber(), location.getFirstTokenBeginColumnNumber() - 1);
+        int end = offsetOf(lineStarts, css, location.getLastTokenEndLineNumber(), location.getLastTokenEndColumnNumber());
+        return start < 0 || end < start || end > css.length() ? null : new CssRange(start, end);
+    }
+
+    /**
+     * Removes the comments of a stylesheet, for reading it only. A quoted string keeps what it holds,
+     * css starts no comment in there, and an unterminated comment runs to the end, as css says it does.
+     */
+    private String stripCssComments(@NotNull String css) {
+        StringBuilder result = new StringBuilder(css.length());
+        int i = 0;
+        while (i < css.length()) {
+            char current = css.charAt(i);
+            if (current == '"' || current == '\'') {
+                i = appendString(css, i, result);
+            } else if (isCommentStart(css, i)) {
+                i = endOfComment(css, i);
+            } else {
+                result.append(current);
+                i++;
+            }
+        }
+        return result.toString();
+    }
+
+    private boolean isCommentStart(@NotNull String css, int index) {
+        return css.charAt(index) == '/' && index + 1 < css.length() && css.charAt(index + 1) == '*';
+    }
+
+    private int endOfComment(@NotNull String css, int index) {
+        int end = css.indexOf("*/", index + 2);
+        return end < 0 ? css.length() : end + 2;
+    }
+
+    private int appendString(@NotNull String css, int index, @NotNull StringBuilder result) {
+        char quote = css.charAt(index);
+        result.append(quote);
+        int i = index + 1;
+        while (i < css.length()) {
+            char current = css.charAt(i++);
+            result.append(current);
+            if (current == '\\' && i < css.length()) {
+                result.append(css.charAt(i++));
+            } else if (current == quote) {
+                break;
+            }
+        }
+        return i;
+    }
+
+
+    /**
+     * Where a conversion service reads an address out of the markup, measured against the services this
+     * extension family drives: pandoc-service loads {@code img[src]} and {@code iframe[src]},
+     * weasyprint-service loads {@code img[src]}, {@code object[data]} and {@code embed[src]}. The image
+     * of an inline svg is not loaded by either of them today and is rewritten all the same, a data url
+     * being a valid href there.
+     */
+    private static final List<String[]> RESOURCE_ATTRIBUTES = List.of(
+            new String[]{"img[src]", "src"},
+            new String[]{"object[data]", "data"},
+            new String[]{"embed[src]", "src"},
+            new String[]{"iframe[src]", "src"},
+            new String[]{"image[href]", "href"},
+            new String[]{"image[xlink:href]", "xlink:href"});
+
+    /**
+     * Rewrites every resource an HTML document points at: the source of an image, the css of a style
+     * element and the css of a style attribute. JSoup says where each of them stands, so every form HTML
+     * allows is covered and nothing outside a tag is mistaken for one. JSoup does not write the document
+     * back, only the parts which changed are replaced in the original text.
+     */
+    private String processResourceRegions(@NotNull String html, @NotNull FileResourceProvider fileResourceProvider) {
+        Document document = Jsoup.parse(html, "", Parser.htmlParser().setTrackPosition(true));
+        List<Region> regions = new ArrayList<>();
+        for (String[] attribute : RESOURCE_ATTRIBUTES) {
+            for (Element element : document.select(attribute[0])) {
+                // the value of an attribute is read as the parser read it, entities resolved: that is the
+                // address the renderer sees, and the markup says nothing the renderer would not
+                addAttributeRegion(regions, element, attribute[1],
+                        url -> Optional.ofNullable(replacementFor(fileResourceProvider, url)).orElse(url));
+            }
+        }
+        for (Element styleElement : document.select("style")) {
+            // a style element holds raw text, so its source and its value are the same characters
+            styleElement.dataNodes().forEach(data ->
+                    addRegion(regions, data.sourceRange(), html, css -> inlineCssResources(css, fileResourceProvider), false));
+        }
+        for (Element element : document.select("[style]")) {
+            addAttributeRegion(regions, element, "style",
+                    css -> rewriteDeclarations(css, declarations -> inlineCssResources(declarations, fileResourceProvider)));
+        }
+
+        StringBuilder result = new StringBuilder(html);
+        regions.stream()
+                .sorted((left, right) -> Integer.compare(right.start(), left.start()))
+                .forEach(region -> {
+                    String rewritten = region.rewrite().apply(region.input());
+                    if (!rewritten.equals(region.input())) {
+                        // an attribute is written back as markup, so what goes in there is escaped again,
+                        // by settings of its own: the default ones of jsoup are shared and can be changed
+                        result.replace(region.start(), region.end(),
+                                region.escape() ? Entities.escape(rewritten, ATTRIBUTE_OUTPUT_SETTINGS) : rewritten);
+                    }
+                });
+        return result.toString();
+    }
+
+    private void addAttributeRegion(@NotNull List<Region> regions, @NotNull Element element, @NotNull String attribute,
+                                    @NotNull UnaryOperator<String> rewrite) {
+        Range range = element.attributes().sourceRange(attribute).valueRange();
+        if (range.isTracked() && range.startPos() >= 0 && range.endPos() >= range.startPos()) {
+            regions.add(new Region(range.startPos(), range.endPos(), element.attr(attribute), rewrite, true));
+        }
+    }
+
+    /**
+     * @param input   what the region says, as the parser read it
+     * @param escape  whether writing it back means writing markup
+     */
+    private record Region(int start, int end, @NotNull String input, @NotNull UnaryOperator<String> rewrite, boolean escape) {
+    }
+
+    private void addRegion(@NotNull List<Region> regions, @NotNull Range range, @NotNull String html,
+                           @NotNull UnaryOperator<String> rewrite, boolean escape) {
+        if (range.isTracked() && range.startPos() >= 0 && range.endPos() >= range.startPos()) {
+            regions.add(new Region(range.startPos(), range.endPos(), html.substring(range.startPos(), range.endPos()), rewrite, escape));
+        }
+    }
+
+    /**
+     * The value of a style attribute is a declaration list, not a stylesheet, so it is wrapped into a rule
+     * for the parser and unwrapped afterwards.
+     */
+    private String rewriteDeclarations(@NotNull String declarations, @NotNull UnaryOperator<String> rewrite) {
+        String rewritten = rewrite.apply("a{" + declarations + "}");
+        int open = rewritten.indexOf('{');
+        int close = rewritten.lastIndexOf('}');
+        // an empty or unexpected result means the declarations were dropped, they do not come back
+        return open < 0 || close < open ? "" : rewritten.substring(open + 1, close);
+    }
+
+    /**
+     * Normalizes a resource url the same way for the policy check and for the request itself.
+     */
+    public String normalizeUrl(@NotNull String url) {
+        return url.replace(" ", "%20").replace("%5F", "_");
+    }
+
+    /**
+     * Tells whether a converter would read this url from somewhere of its own, which here means an
+     * address in any scheme, and a network path reference, which takes the scheme of the base url.
+     * Measured against weasyprint-service: it reads a {@code file:} url through an {@code @import},
+     * while a path from the root goes to the base url the document carries, which is the Polarion
+     * server. A relative url is read from nowhere, and a data url carries its own content.
+     */
+    public boolean isReadElsewhere(@Nullable String url) {
+        if (url == null) {
+            return false;
+        }
+        String trimmed = url.trim();
+        boolean namesSomewhere = SCHEME_PATTERN.matcher(trimmed).find() || isNetworkPathReference(trimmed);
+        // a data url carries the resource itself, there is nowhere for it to be read from
+        return namesSomewhere && !isDataUrl(trimmed);
+    }
+
+    /**
+     * A network path reference like {@code //host/path} counts as well: the conversion service reads the
+     * document with a base url and gives such a reference the scheme of that base.
+     */
+    public boolean isAbsoluteHttpUrl(@Nullable String url) {
+        if (url == null) {
+            return false;
+        }
+        String lowerCased = url.trim().toLowerCase(Locale.ROOT);
+        return lowerCased.startsWith("http://") || lowerCased.startsWith("https://") || isNetworkPathReference(lowerCased);
+    }
+
+    public boolean isNetworkPathReference(@NotNull String url) {
+        String trimmed = url.trim();
+        return trimmed.startsWith(NETWORK_PATH_PREFIX) && trimmed.length() > NETWORK_PATH_PREFIX.length();
     }
 
     /**
@@ -371,7 +929,8 @@ public class MediaUtils {
         for (BiFunction<String, byte[], String> source : mimeSources) {
             try {
                 String mimeType = source.apply(resource, resourceBytes);
-                if (!StringUtils.isEmpty(mimeType)) {
+                // unknown bytes name no type, so the next source gets its turn
+                if (!StringUtils.isEmpty(mimeType) && !OCTET_STREAM.equals(mimeType)) {
                     return mimeType;
                 }
             } catch (Exception e) {

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProvider.java
@@ -1,5 +1,6 @@
 package ch.sbb.polarion.extension.pdf_exporter.util;
 
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
 import com.polarion.alm.shared.api.transaction.TransactionalExecutor;
 import com.polarion.alm.tracker.internal.url.GenericUrlResolver;
 import com.polarion.alm.tracker.internal.url.IAttachmentUrlResolver;
@@ -41,14 +42,51 @@ public class PdfExporterFileResourceProvider implements FileResourceProvider {
     private static final Logger logger = Logger.getLogger(PdfExporterFileResourceProvider.class);
 
     private final List<IUrlResolver> resolvers;
+    private final ResourceUrlPolicy policy;
 
     public PdfExporterFileResourceProvider() {
-        this.resolvers = Arrays.asList(getPolarionUrlResolverWithoutGenericUrlChildResolver(), new CustomResourceUrlResolver());
+        this(ResourceUrlPolicy.getInstance());
+    }
+
+    private PdfExporterFileResourceProvider(@NotNull ResourceUrlPolicy policy) {
+        this.policy = policy;
+        this.resolvers = Arrays.asList(getPolarionUrlResolverWithoutGenericUrlChildResolver(), new CustomResourceUrlResolver(policy));
     }
 
     @VisibleForTesting
     public PdfExporterFileResourceProvider(List<IUrlResolver> resolvers) {
+        this(resolvers, new ResourceUrlPolicy(ResourceUrlPolicy.Mode.ALLOW_ALL, null, null,
+                PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_MAX_SIZE_MB_DEFAULT_VALUE));
+    }
+
+    @VisibleForTesting
+    public PdfExporterFileResourceProvider(List<IUrlResolver> resolvers, @NotNull ResourceUrlPolicy policy) {
         this.resolvers = resolvers;
+        this.policy = policy;
+    }
+
+    /**
+     * Only an absolute http(s) url is checked. A relative url, a data url and an SVG fragment like
+     * {@code url(#gradient)} are never requested over the network, so they stay untouched.
+     */
+    @Override
+    public boolean isForbidden(@NotNull String resource) {
+        // the escapes go first: '\\68 ttp://host' names an address as much as 'http://host' does
+        String candidate = MediaUtils.decodeCssEscapes(resource).trim();
+        if (!MediaUtils.isAbsoluteHttpUrl(candidate)) {
+            return false;
+        }
+        try {
+            if (MediaUtils.isNetworkPathReference(candidate)) {
+                // '//host/path' has no scheme of its own and is loaded under both, so both decide here
+                return policy.isRefusedByOrigin(URI.create(MediaUtils.normalizeUrl("https:" + candidate)).toURL())
+                        && policy.isRefusedByOrigin(URI.create(MediaUtils.normalizeUrl("http:" + candidate)).toURL());
+            }
+            return policy.isRefusedByOrigin(URI.create(MediaUtils.normalizeUrl(candidate)).toURL());
+        } catch (Exception e) {
+            logger.warn("Cannot parse the resource url '" + resource + "', it is treated as forbidden");
+            return true;
+        }
     }
 
     @SneakyThrows

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicy.java
@@ -1,0 +1,478 @@
+package ch.sbb.polarion.extension.pdf_exporter.util;
+
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
+import com.polarion.core.boot.PolarionProperties;
+import com.polarion.core.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Decides which resource URLs the exporter may request while inlining images, fonts and stylesheets.
+ * <p>
+ * A document editor controls those URLs. Without a policy the Polarion server would fetch any address
+ * on behalf of the editor and the response body would end up in the exported document, which is a
+ * server side request forgery with full read access to the server's network.
+ * </p>
+ */
+public class ResourceUrlPolicy {
+
+    private static final Logger logger = Logger.getLogger(ResourceUrlPolicy.class);
+
+    private static final String HTTP = "http";
+    private static final String HTTPS = "https";
+    private static final String CSS = "text/css";
+
+    private static final List<String> ALLOWED_CONTENT_TYPE_PREFIXES = List.of(
+            "image/", "font/", "application/font", "application/x-font", CSS,
+            "application/octet-stream", "binary/octet-stream");
+
+    // What the content itself may turn out to be. This is the allowed list once more, without the
+    // generic types: those say nothing, and the question here is what the bytes are. Tika reports an
+    // SVG as image/svg+xml, so nothing has to be said about xml for an image's sake.
+    private static final List<String> ALLOWED_SNIFFED_TYPE_PREFIXES = List.of(
+            "image/", "font/", "application/font", "application/x-font", CSS);
+
+    // What a text looks like to a detector, and the two kinds of resource which are one. A stylesheet
+    // reads as plain text and an SVG without a namespace does too, so the sender has to name those.
+    private static final Set<String> TEXTUAL_CONTENT = Set.of("text/plain", "application/xml", "text/xml");
+    private static final Set<String> TEXTUAL_RESOURCE_TYPES = Set.of(CSS, "image/svg+xml");
+
+    private final Mode mode;
+    private final Set<AllowedOrigin> allowedOrigins;
+    private final String baseUrlHost;
+    private final String baseUrlScheme;
+    private final int baseUrlPort;
+    private final long maxResourceBytes;
+
+    public ResourceUrlPolicy(@NotNull Mode mode, @Nullable Collection<String> allowedOrigins, @Nullable String baseUrl, int maxSizeMB) {
+        this.mode = mode;
+        this.allowedOrigins = new HashSet<>();
+        if (allowedOrigins != null) {
+            allowedOrigins.stream()
+                    .filter(origin -> origin != null && !origin.isBlank())
+                    .map(AllowedOrigin::parse)
+                    .filter(Objects::nonNull)
+                    .forEach(this.allowedOrigins::add);
+        }
+        this.maxResourceBytes = (long) maxSizeMB * 1024 * 1024;
+
+        URI baseUri = parseBaseUrl(baseUrl);
+        this.baseUrlHost = baseUri == null || baseUri.getHost() == null ? null : baseUri.getHost().toLowerCase(Locale.ROOT);
+        this.baseUrlPort = baseUri == null ? -1 : effectivePort(baseUri.getScheme(), baseUri.getPort());
+        this.baseUrlScheme = baseUri != null && HTTPS.equalsIgnoreCase(baseUri.getScheme()) ? HTTPS : HTTP;
+    }
+
+    public static ResourceUrlPolicy getInstance() {
+        PdfExporterExtensionConfiguration configuration = PdfExporterExtensionConfiguration.getInstance();
+        String allowedOrigins = configuration.getExternalResourcesAllowedOrigins();
+        int maxSizeMB = configuration.getExternalResourcesMaxSizeMB();
+        return new ResourceUrlPolicy(
+                Mode.parse(configuration.getExternalResourcesPolicy()),
+                allowedOrigins == null ? List.of() : Arrays.asList(allowedOrigins.split(",")),
+                System.getProperty(PolarionProperties.BASE_URL),
+                maxSizeMB > 0 ? maxSizeMB : PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_MAX_SIZE_MB_DEFAULT_VALUE);
+    }
+
+    /**
+     * @return maximal size in bytes a single fetched resource may reach
+     */
+    public long getMaxResourceBytes() {
+        return maxResourceBytes;
+    }
+
+    /**
+     * Checks the content type a remote host reports for a resource. An internal service answers with
+     * its own media type, JSON as a rule, so this check stops most of the responses a forged request
+     * could return. An absent content type is accepted, the content is sniffed later anyway.
+     */
+    public boolean isAllowedContentType(@Nullable String contentType) {
+        if (contentType == null || contentType.isBlank()) {
+            return true;
+        }
+        String mediaType = mediaType(contentType);
+        return ALLOWED_CONTENT_TYPE_PREFIXES.stream().anyMatch(mediaType::startsWith);
+    }
+
+    /**
+     * Judges the content of a resource against what its sender called it. The header alone leaves the
+     * verdict to the sender, so the content has to agree with it: an image or a font has a shape, and
+     * text does not, which is why a stylesheet and an SVG are believed only where the sender named one.
+     *
+     * @param declaredType the content type the sender reported, null when it reported none
+     * @param sniffedType  the media type detected in the content, null when nothing was detected
+     * @return true if the resource may not be used
+     */
+    public boolean isRejectedContent(@Nullable String declaredType, @Nullable String sniffedType) {
+        boolean saidNothing = declaredType == null || declaredType.isBlank()
+                || mediaType(declaredType).endsWith("/octet-stream");
+        if (sniffedType == null) {
+            // nothing was read out of the content, so only a sender which named a kind is believed
+            return saidNothing;
+        }
+        String sniffed = mediaType(sniffedType);
+        if (ALLOWED_SNIFFED_TYPE_PREFIXES.stream().anyMatch(sniffed::startsWith)) {
+            return false;
+        }
+        return saidNothing || !TEXTUAL_CONTENT.contains(sniffed) || !TEXTUAL_RESOURCE_TYPES.contains(mediaType(declaredType));
+    }
+
+    private static String mediaType(@NotNull String contentType) {
+        return contentType.split(";")[0].trim().toLowerCase(Locale.ROOT);
+    }
+
+    public boolean isAllowed(@NotNull URL url) {
+        return vetAddresses(url) != null;
+    }
+
+    /**
+     * Tells whether the policy refuses this url whatever it resolves to: a scheme nothing may request,
+     * a url without a host, or an origin the configuration does not name where nothing else may be
+     * requested. What is left after that is the address of the host, and that question belongs to the
+     * request itself, which binds to the answer it got. A caller which only decides whether to try at
+     * all asks this one, so that a name only a proxy can resolve is not refused here.
+     */
+    public boolean isRefusedByOrigin(@NotNull URL url) {
+        String scheme = schemeOf(url);
+        if (!HTTP.equals(scheme) && !HTTPS.equals(scheme)) {
+            return true;
+        }
+        String host = hostOf(url);
+        if (host.isBlank()) {
+            return true;
+        }
+        return mode == Mode.ALLOWLIST_ONLY && !isExempt(scheme, host, effectivePort(scheme, url.getPort()));
+    }
+
+    /**
+     * @return the addresses the url may be requested from, null if the url may not be requested at all.
+     * The caller connects to exactly these addresses, which is what makes the check binding: a second
+     * name resolution cannot answer with an address this method did not see.
+     */
+    @Nullable
+    public InetAddress[] vetAddresses(@NotNull URL url) {
+        String protocol = schemeOf(url);
+        if (!HTTP.equals(protocol) && !HTTPS.equals(protocol)) {
+            return denyAddresses(url, "only http and https are supported");
+        }
+
+        String host = hostOf(url);
+        if (host.isBlank()) {
+            return denyAddresses(url, "no host");
+        }
+        int port = effectivePort(protocol, url.getPort());
+
+        boolean exempt = isExempt(protocol, host, port);
+        if (!exempt && mode == Mode.ALLOWLIST_ONLY) {
+            return denyAddresses(url, "the origin is not in " + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_ORIGINS);
+        }
+
+        return resolveAddresses(url, host, exempt);
+    }
+
+    /**
+     * Unless the host is exempt, every address it resolves to must be public. A host resolving to both a
+     * public and a private address is rejected, otherwise the private one stays reachable.
+     */
+    @Nullable
+    private InetAddress[] resolveAddresses(@NotNull URL url, @NotNull String host, boolean exempt) {
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            if (addresses.length == 0) {
+                return denyAddresses(url, "the host resolves to no address");
+            }
+            for (InetAddress address : addresses) {
+                if (!exempt && !isPublicAddress(address)) {
+                    return denyAddresses(url, "the host resolves to the non public address " + address.getHostAddress());
+                }
+            }
+            return addresses;
+        } catch (UnknownHostException e) {
+            return denyAddresses(url, "the host cannot be resolved");
+        }
+    }
+
+    /**
+     * Tells whether the configuration trusts the url as such, rather than its addresses: the Polarion
+     * server itself, a host the administrator listed, or any host when the policy is off. Only such a
+     * url may be requested through a proxy, where the connection cannot be pinned to a checked address.
+     */
+    public boolean isExplicitlyTrusted(@NotNull URL url) {
+        String host = hostOf(url);
+        String scheme = schemeOf(url);
+        return !host.isBlank() && isExempt(scheme, host, effectivePort(scheme, url.getPort()));
+    }
+
+    @NotNull
+    private static String schemeOf(@NotNull URL url) {
+        String protocol = url.getProtocol();
+        return protocol == null ? "" : protocol.toLowerCase(Locale.ROOT);
+    }
+
+    @NotNull
+    private static String hostOf(@NotNull URL url) {
+        String host = url.getHost();
+        return host == null ? "" : stripBrackets(host.trim().toLowerCase(Locale.ROOT));
+    }
+
+    private boolean isExempt(@NotNull String scheme, @NotNull String host, int port) {
+        return isBaseUrlOrigin(host, port) || isAllowedOrigin(scheme, host, port) || mode == Mode.ALLOW_ALL;
+    }
+
+    /**
+     * Tells whether a refusal of this url turned on its scheme. An allowed origin may name one,
+     * {@code https://cdn.example.com} allows that spelling of the host and no other, so the same
+     * reference under the other scheme is a question of its own.
+     *
+     * @return true when the url is not exempt as it stands, while the other scheme of it is
+     */
+    public boolean isRefusalSchemeSpecific(@NotNull URL url) {
+        String host = hostOf(url);
+        if (host.isBlank()) {
+            return false;
+        }
+        String scheme = schemeOf(url);
+        String otherScheme = HTTPS.equals(scheme) ? HTTP : HTTPS;
+        return !isExempt(scheme, host, effectivePort(scheme, url.getPort()))
+                && isExempt(otherScheme, host, effectivePort(otherScheme, url.getPort()));
+    }
+
+    /**
+     * @return the scheme a network path reference like {@code //host/path} gets, taken from the Polarion
+     * base url the conversion service reads the document with
+     */
+    @NotNull
+    public String getBaseUrlScheme() {
+        return baseUrlScheme;
+    }
+
+    private static String stripBrackets(@NotNull String host) {
+        return host.startsWith("[") && host.endsWith("]") ? host.substring(1, host.length() - 1) : host;
+    }
+
+    private boolean isBaseUrlOrigin(@NotNull String host, int port) {
+        return host.equals(baseUrlHost) && port == baseUrlPort;
+    }
+
+    private boolean isAllowedOrigin(@NotNull String scheme, @NotNull String host, int port) {
+        return allowedOrigins.stream().anyMatch(origin -> origin.matches(scheme, host, port));
+    }
+
+    /**
+     * One entry of the allowed origins. What the entry does not write is not compared: a bare host
+     * allows the resource under either scheme and on any port, {@code cdn.example.com:8443} on that
+     * port under either scheme, {@code https://cdn.example.com} on the port https implies and under
+     * https alone, and {@code https://cdn.example.com:8443} on exactly that origin.
+     *
+     * @param scheme the scheme the entry names, null where it names none
+     * @param host   the host the entry names, never null
+     * @param port   the port the entry names, -1 where it names none
+     */
+    private record AllowedOrigin(@Nullable String scheme, @NotNull String host, int port) {
+
+        private static final Pattern ENTRY_PATTERN = Pattern.compile(
+                "^(?:(?<scheme>[a-z][a-z\\d+.-]*)://)?(?<host>\\[[^\\]]+]|[^:/?#\\[\\]]+)(?::(?<port>\\d{1,5}))?$");
+
+        @Nullable
+        private static AllowedOrigin parse(@NotNull String entry) {
+            Matcher matcher = ENTRY_PATTERN.matcher(entry.trim().toLowerCase(Locale.ROOT));
+            if (!matcher.matches()) {
+                return ignored(entry, "it names no origin of the form [scheme://]host[:port]");
+            }
+            String scheme = matcher.group("scheme");
+            if (scheme != null && !HTTP.equals(scheme) && !HTTPS.equals(scheme)) {
+                return ignored(entry, "only http and https can be requested");
+            }
+            String port = matcher.group("port");
+            int portNumber = port == null ? -1 : Integer.parseInt(port);
+            if (portNumber > 65535) {
+                return ignored(entry, port + " is no port");
+            }
+            // a scheme without a port names the port that scheme implies, which is what an origin is
+            int effective = scheme != null && portNumber == -1 ? effectivePort(scheme, -1) : portNumber;
+            return new AllowedOrigin(scheme, stripBrackets(matcher.group("host")), effective);
+        }
+
+        @Nullable
+        private static AllowedOrigin ignored(@NotNull String entry, @NotNull String reason) {
+            logger.warn("Ignored the entry '" + entry.trim() + "' of the property "
+                    + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_ORIGINS + ", " + reason);
+            return null;
+        }
+
+        private boolean matches(@NotNull String scheme, @NotNull String host, int port) {
+            return this.host.equals(host)
+                    && (this.scheme == null || this.scheme.equals(scheme))
+                    && (this.port == -1 || this.port == port);
+        }
+    }
+
+    @VisibleForTesting
+    static boolean isPublicAddress(@NotNull InetAddress address) {
+        if (address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress() || address.isMulticastAddress()) {
+            return false;
+        }
+        byte[] bytes = address.getAddress();
+        return bytes.length == 4 ? isPublicIpv4(bytes) : isPublicIpv6(bytes);
+    }
+
+    @SuppressWarnings("java:S3776") // the ranges read better as a flat list of guards
+    private static boolean isPublicIpv4(byte[] bytes) {
+        int first = bytes[0] & 0xFF;
+        int second = bytes[1] & 0xFF;
+        int third = bytes[2] & 0xFF;
+
+        if (first == 0) { // 0.0.0.0/8, "this network"
+            return false;
+        }
+        if (first == 10 || first == 127) { // 10.0.0.0/8 private, 127.0.0.0/8 loopback
+            return false;
+        }
+        if (first == 172 && second >= 16 && second <= 31) { // 172.16.0.0/12, private
+            return false;
+        }
+        if (first == 192 && second == 168) { // 192.168.0.0/16, private
+            return false;
+        }
+        if (first == 169 && second == 254) { // 169.254.0.0/16, link local, holds the cloud metadata address
+            return false;
+        }
+        if (first >= 224 && first <= 239) { // 224.0.0.0/4, multicast
+            return false;
+        }
+        if (first == 100 && second >= 64 && second <= 127) { // 100.64.0.0/10, carrier grade NAT
+            return false;
+        }
+        if (first == 192 && second == 0 && third == 0) { // 192.0.0.0/24, IETF protocol assignments
+            return false;
+        }
+        if (first == 198 && (second == 18 || second == 19)) { // 198.18.0.0/15, benchmarking
+            return false;
+        }
+        return first < 240; // 240.0.0.0/4, reserved, includes the broadcast address
+    }
+
+    private static boolean isPublicIpv6(byte[] bytes) {
+        int first = bytes[0] & 0xFF;
+        int second = bytes[1] & 0xFF;
+
+        if ((first & 0xFE) == 0xFC) { // fc00::/7, unique local
+            return false;
+        }
+        if (isIpv4Embedded(bytes)) { // ::ffff:0:0/96 and ::/96, an IPv4 address in IPv6 form
+            return isPublicIpv4(Arrays.copyOfRange(bytes, 12, 16));
+        }
+        if (isNat64WellKnown(bytes)) { // 64:ff9b::/96, DNS64 answers with it and NAT64 forwards to the IPv4 address
+            return isPublicIpv4(Arrays.copyOfRange(bytes, 12, 16));
+        }
+        if (isNat64LocalUse(bytes)) { // 64:ff9b:1::/48, the IPv4 address can sit at several offsets in there
+            return false;
+        }
+        if (first == 0x20 && second == 0x02) { // 2002::/16, 6to4 carries the IPv4 address in the prefix
+            return isPublicIpv4(Arrays.copyOfRange(bytes, 2, 6));
+        }
+        return first != 0x20 || second != 0x01 || bytes[2] != 0 || bytes[3] != 0; // 2001:0::/32, Teredo
+    }
+
+    private static boolean isNat64WellKnown(byte[] bytes) {
+        if (bytes[0] != 0 || (bytes[1] & 0xFF) != 0x64 || (bytes[2] & 0xFF) != 0xFF || (bytes[3] & 0xFF) != 0x9B) {
+            return false;
+        }
+        for (int i = 4; i < 12; i++) {
+            if (bytes[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isNat64LocalUse(byte[] bytes) {
+        return bytes[0] == 0 && (bytes[1] & 0xFF) == 0x64 && (bytes[2] & 0xFF) == 0xFF && (bytes[3] & 0xFF) == 0x9B
+                && bytes[4] == 0 && (bytes[5] & 0xFF) == 0x01;
+    }
+
+    private static boolean isIpv4Embedded(byte[] bytes) {
+        for (int i = 0; i < 10; i++) {
+            if (bytes[i] != 0) {
+                return false;
+            }
+        }
+        int eleventh = bytes[10] & 0xFF;
+        int twelfth = bytes[11] & 0xFF;
+        return (eleventh == 0 && twelfth == 0) || (eleventh == 0xFF && twelfth == 0xFF);
+    }
+
+    @Nullable
+    private static InetAddress[] denyAddresses(@NotNull URL url, @NotNull String reason) {
+        logger.warn("Blocked the request to '" + url + "': " + reason
+                + ". See the '" + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY + "' property.");
+        return null;
+    }
+
+    @Nullable
+    private static URI parseBaseUrl(@Nullable String baseUrl) {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            return null;
+        }
+        try {
+            return URI.create(baseUrl.trim());
+        } catch (IllegalArgumentException e) {
+            logger.warn("Cannot parse the Polarion base url '" + baseUrl + "'");
+            return null;
+        }
+    }
+
+    private static int effectivePort(@Nullable String scheme, int port) {
+        if (port != -1) {
+            return port;
+        }
+        return HTTPS.equalsIgnoreCase(scheme) ? 443 : 80;
+    }
+
+    public enum Mode {
+        /**
+         * Requests to loopback, private, link local and other non public addresses are rejected.
+         */
+        BLOCK_INTERNAL,
+        /**
+         * Only the Polarion base url and the explicitly allowed hosts may be requested.
+         */
+        ALLOWLIST_ONLY,
+        /**
+         * No restriction. The behavior before the policy existed, it exposes the server's network.
+         */
+        ALLOW_ALL;
+
+        /**
+         * Reads the property. The value is one of the names above, written exactly as they are: a
+         * setting which is nearly right is a setting whose author expects something else to happen.
+         */
+        public static Mode parse(@Nullable String value) {
+            if (value != null && !value.isBlank()) {
+                for (Mode mode : values()) {
+                    if (mode.name().equals(value.trim())) {
+                        return mode;
+                    }
+                }
+                logger.warn("Unknown value '" + value + "' of the property "
+                        + PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY + ", falling back to " + BLOCK_INTERNAL);
+            }
+            return BLOCK_INTERNAL;
+        }
+    }
+}

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/TikaMimeTypeResolver.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/TikaMimeTypeResolver.java
@@ -3,7 +3,6 @@ package ch.sbb.polarion.extension.pdf_exporter.util;
 import ch.sbb.polarion.extension.generic.util.BundleJarsPrioritizingRunnable;
 import com.polarion.core.util.logging.Logger;
 import org.apache.tika.Tika;
-import org.apache.tika.mime.MimeTypes;
 
 import java.util.Map;
 import java.util.Optional;
@@ -28,10 +27,10 @@ public class TikaMimeTypeResolver implements BundleJarsPrioritizingRunnable {
         try {
             Object value = map.get(PARAM_VALUE);
             String detected = value instanceof String stringValue ? tika.detect(stringValue) : tika.detect((byte[]) value);
-            // Ignore 'application/octet-stream' fallback
-            if (!MimeTypes.OCTET_STREAM.equals(detected)) {
-                detectedMimeType = Optional.ofNullable(detected);
-            }
+            // 'application/octet-stream' is an answer as well: it says the content is unknown bytes,
+            // which the caller deciding whether a resource may be used has to be able to tell from a
+            // detector which did not run. A caller looking for a usable mime type skips it itself.
+            detectedMimeType = Optional.ofNullable(detected);
         } catch (Exception e) {
             logger.warn("Tika failed to detect mime type", e);
         }

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizer.java
@@ -4,18 +4,25 @@ import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.pdf_exporter.util.FileResourceProvider;
 import ch.sbb.polarion.extension.pdf_exporter.util.MediaUtils;
 import com.polarion.core.util.StringUtils;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Entities;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Locale;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 public class ExternalCssInternalizer implements LinkInternalizer {
 
     private static final String DATA_PRECEDENCE = "data-precedence";
+    private static final Pattern CLOSING_STYLE_PATTERN = Pattern.compile("</style", Pattern.CASE_INSENSITIVE);
+    private static final Document.OutputSettings ATTRIBUTE_OUTPUT_SETTINGS =
+            new Document.OutputSettings().escapeMode(Entities.EscapeMode.xhtml);
     private static final String HREF = "href";
     private final FileResourceProvider fileResourceProvider;
 
@@ -32,10 +39,12 @@ public class ExternalCssInternalizer implements LinkInternalizer {
         }
         StringBuilder inlinedContent = new StringBuilder("<style");
         if (attributes.containsKey(DATA_PRECEDENCE)) {
+            // the value comes from the document, and it is written back as markup: an unescaped quote
+            // in it would end the attribute and everything after it would be read as markup of its own
             inlinedContent.append(" ")
                     .append(DATA_PRECEDENCE)
                     .append("=\"")
-                    .append(attributes.get(DATA_PRECEDENCE))
+                    .append(Entities.escape(attributes.get(DATA_PRECEDENCE), ATTRIBUTE_OUTPUT_SETTINGS))
                     .append("\"");
         }
         inlinedContent.append(">");
@@ -43,7 +52,7 @@ public class ExternalCssInternalizer implements LinkInternalizer {
         String cssContent = new String(fileResourceProvider.getResourceAsBytes(url));
         cssContent = processRelativeUrls(url, cssContent);
         cssContent = MediaUtils.inlineCssResources(cssContent, fileResourceProvider);
-        inlinedContent.append(cssContent);
+        inlinedContent.append(keepInsideStyleElement(cssContent));
         inlinedContent.append("</style>");
 
         return Optional.of(inlinedContent.toString());
@@ -75,4 +84,13 @@ public class ExternalCssInternalizer implements LinkInternalizer {
         }
         List<String> tokens = Arrays.asList(rel.trim().toLowerCase(Locale.ROOT).split("\\s+"));
         return tokens.contains("stylesheet") && !tokens.contains("alternate");
-    }}
+    }
+    /**
+     * A style element holds raw text, which ends at the first {@code </style}: a stylesheet carrying
+     * those characters would close the element and have the rest of itself read as markup. The slash
+     * is escaped, which css reads as the slash itself wherever such a sequence can legally stand.
+     */
+    private String keepInsideStyleElement(@NotNull String cssContent) {
+        return CLOSING_STYLE_PATTERN.matcher(cssContent).replaceAll("<\\\\/style");
+    }
+}

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizer.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizer.java
@@ -4,7 +4,11 @@ import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.pdf_exporter.util.FileResourceProvider;
 import ch.sbb.polarion.extension.pdf_exporter.util.MediaUtils;
 import com.polarion.core.util.StringUtils;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -22,7 +26,7 @@ public class ExternalCssInternalizer implements LinkInternalizer {
     @Override
     public Optional<String> inline(Map<String, String> attributes) {
         String url = attributes.get(HREF);
-        if (!"stylesheet".equals(attributes.get("rel"))
+        if (!namesAStylesheet(attributes.get("rel"))
                 || StringUtils.isEmptyTrimmed(url)) {
             return Optional.empty();
         }
@@ -38,7 +42,7 @@ public class ExternalCssInternalizer implements LinkInternalizer {
 
         String cssContent = new String(fileResourceProvider.getResourceAsBytes(url));
         cssContent = processRelativeUrls(url, cssContent);
-        cssContent = MediaUtils.inlineBase64Resources(cssContent, fileResourceProvider);
+        cssContent = MediaUtils.inlineCssResources(cssContent, fileResourceProvider);
         inlinedContent.append(cssContent);
         inlinedContent.append("</style>");
 
@@ -53,8 +57,22 @@ public class ExternalCssInternalizer implements LinkInternalizer {
         String resourcePath = resourceUrl.substring(0, lastSlashPosition + 1);
         return RegexMatcher.get(MediaUtils.URL_REGEX).useJavaUtil().replace(cssContent, engine -> {
             String url = engine.group("url");
-            return Stream.of("/", "http:", "https:", MediaUtils.DATA_URL_PREFIX).anyMatch(url::startsWith) ? null :
+            // the pattern reads a url in any case, so the prefixes are compared in one
+            String lowerCased = url.toLowerCase(Locale.ROOT);
+            return Stream.of("/", "http:", "https:", MediaUtils.DATA_URL_PREFIX).anyMatch(lowerCased::startsWith) ? null :
                     "url(%s%s)".formatted(resourcePath, url);
         });
     }
-}
+    /**
+     * Reads the rel of a link the way a renderer reads it: a list of tokens, separated by whitespace,
+     * each of them case insensitive. An exact comparison misses {@code rel="Stylesheet"}, which a
+     * renderer loads all the same. An alternative style sheet is left alone, since nothing selects one
+     * in an export and inlining it would apply a stylesheet the renderer would have skipped.
+     */
+    private boolean namesAStylesheet(@Nullable String rel) {
+        if (rel == null) {
+            return false;
+        }
+        List<String> tokens = Arrays.asList(rel.trim().toLowerCase(Locale.ROOT).split("\\s+"));
+        return tokens.contains("stylesheet") && !tokens.contains("alternate");
+    }}

--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/HtmlLinksHelper.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/html/HtmlLinksHelper.java
@@ -1,16 +1,22 @@
 package ch.sbb.polarion.extension.pdf_exporter.util.html;
 
-import ch.sbb.polarion.extension.generic.regex.RegexMatcher;
 import ch.sbb.polarion.extension.pdf_exporter.util.FileResourceProvider;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Range;
+import org.jsoup.parser.Parser;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 public class HtmlLinksHelper {
-    private static final String LINK_REGEX = "<link\\s*[^<>]*>";
-    private static final String ATTRIBUTE_REGEX = "([\\w-]+)\\s*=\\s*(['\"])(.*?)\\2";
 
     private final Set<LinkInternalizer> linkInliners;
 
@@ -24,32 +30,57 @@ public class HtmlLinksHelper {
         this.linkInliners = linkInliners;
     }
 
+    /**
+     * @return the attributes of a link tag, as the html parser reads them: the names lowercased, the
+     * values with their entities resolved, and a value which carries no quotes read like any other
+     */
     public static Map<String, String> parseLinkTagAttributes(String linkTag) {
+        Element link = Jsoup.parse(linkTag).selectFirst("link");
+        return link == null ? Map.of() : attributesOf(link);
+    }
+
+    private static Map<String, String> attributesOf(Element link) {
         Map<String, String> attributes = new LinkedHashMap<>();
-
-        RegexMatcher.get(ATTRIBUTE_REGEX).useJavaUtil().processEntry(linkTag, regexEngine -> {
-            String attributeName = regexEngine.group(1);
-            String attributeValue = regexEngine.group(3);
-            attributes.put(attributeName.toLowerCase(), attributeValue);
-        });
-
+        for (Attribute attribute : link.attributes()) {
+            attributes.put(attribute.getKey().toLowerCase(Locale.ROOT), attribute.getValue());
+        }
         return attributes;
     }
 
+    /**
+     * Replaces every link tag an inliner answers for. The tags are located by the html parser at the
+     * positions it reports, so a value without quotes, a value carrying a {@code >} and an attribute
+     * written in any case are read the way the renderer reads them, and the rest of the document is
+     * left exactly as it came.
+     */
     public String internalizeLinks(String htmlContent) {
-        return RegexMatcher.get(LINK_REGEX, RegexMatcher.CASE_INSENSITIVE).replace(htmlContent, regexEngine -> {
-            String linkTag = regexEngine.group(0);
-            Map<String, String> attributesMap = parseLinkTagAttributes(linkTag);
-            return inlineLinkTag(linkTag, attributesMap);
-        });
+        Document document = Jsoup.parse(htmlContent, "", Parser.htmlParser().setTrackPosition(true));
+        List<int[]> replaced = new ArrayList<>();
+        List<String> replacements = new ArrayList<>();
+        for (Element link : document.select("link")) {
+            Range range = link.sourceRange();
+            if (!range.isTracked() || range.startPos() < 0 || range.endPos() < range.startPos()) {
+                continue;
+            }
+            Optional<String> inlined = inlineLinkTag(attributesOf(link));
+            if (inlined.isPresent()) {
+                replaced.add(new int[]{range.startPos(), range.endPos()});
+                replacements.add(inlined.get());
+            }
+        }
+
+        StringBuilder result = new StringBuilder(htmlContent);
+        for (int i = replaced.size() - 1; i >= 0; i--) {
+            result.replace(replaced.get(i)[0], replaced.get(i)[1], replacements.get(i));
+        }
+        return result.toString();
     }
 
-    private String inlineLinkTag(String linkTag, Map<String, String> attributesMap) {
+    private Optional<String> inlineLinkTag(Map<String, String> attributesMap) {
         return linkInliners.stream()
                 .map(i -> i.inline(attributesMap))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .findFirst()
-                .orElse(linkTag);
+                .findFirst();
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessorTest.java
@@ -129,7 +129,7 @@ class CoverPageProcessorTest {
         when(coverPageSettings.processImagePlaceholders("test template css")).thenCallRealMethod();
         when(pdfTemplateProcessor.processUsing(eq(exportParams), eq("test document"), eq("test template css"), eq("replaced template html"), eq(""), any())).thenReturn("result title html");
         when(htmlProcessor.replaceResourcesAsBase64Encoded("replaced template html")).thenReturn("replaced template html");
-        when(htmlProcessor.replaceResourcesAsBase64Encoded("test template css")).thenReturn("test template css");
+        when(htmlProcessor.replaceCssResourcesAsBase64Encoded("test template css")).thenReturn("test template css");
         return documentData;
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/CoverPageProcessorTest.java
@@ -113,6 +113,9 @@ class CoverPageProcessorTest {
 
         // Assert
         assertThat(result).isEqualTo("result title html");
+        // the composed cover page goes through the same link handling as the body of a document, so a
+        // stylesheet it names is fetched by this extension and not by the conversion service
+        verify(htmlProcessor).internalizeLinks("result title html");
     }
 
     private DocumentData<IModule> prepareMocks(CoverPageModel coverPageModel, ExportParams exportParams) {
@@ -130,6 +133,7 @@ class CoverPageProcessorTest {
         when(pdfTemplateProcessor.processUsing(eq(exportParams), eq("test document"), eq("test template css"), eq("replaced template html"), eq(""), any())).thenReturn("result title html");
         when(htmlProcessor.replaceResourcesAsBase64Encoded("replaced template html")).thenReturn("replaced template html");
         when(htmlProcessor.replaceCssResourcesAsBase64Encoded("test template css")).thenReturn("test template css");
+        lenient().when(htmlProcessor.internalizeLinks("result title html")).thenReturn("result title html");
         return documentData;
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/converter/PdfConverterTest.java
@@ -117,6 +117,7 @@ class PdfConverterTest {
         when(weasyPrintServiceConnector.convertToPdf(eq("test html content"), any(WeasyPrintOptions.class), any(), any())).thenReturn("test document content".getBytes());
         when(htmlProcessor.internalizeLinks(anyString())).thenAnswer(a -> a.getArgument(0));
         when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
+        lenient().when(htmlProcessor.replaceCssResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
 
         // Act
         byte[] result = pdfConverter.convertToPdf(exportParams, null);
@@ -151,7 +152,7 @@ class PdfConverterTest {
         when(pdfExporterPolarionService.getPolarionProductName()).thenReturn("testProductName");
         when(pdfExporterPolarionService.getPolarionVersion()).thenReturn("testVersion");
         lenient().when(module.getCustomField("customField")).thenReturn("customValue");
-        when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
+        when(htmlProcessor.replaceCssResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
 
         String cssContent = pdfConverter.getCssContent(documentData, exportParams);
 
@@ -194,6 +195,7 @@ class PdfConverterTest {
 
         when(velocityEvaluator.evaluateVelocityExpressions(eq(documentData), anyString())).thenAnswer(a -> a.getArguments()[1]);
         when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
+        lenient().when(htmlProcessor.replaceCssResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
 
         // Act
         PdfConverter pdfConverter = new PdfConverter(null, headerFooterSettings, null, placeholderProcessor, velocityEvaluator, null, null, htmlProcessor, null);
@@ -419,6 +421,7 @@ class PdfConverterTest {
         when(velocityEvaluator.evaluateVelocityExpressions(eq(documentData), anyString())).thenAnswer(a -> a.getArguments()[1]);
         when(htmlProcessor.internalizeLinks(anyString())).thenAnswer(a -> a.getArgument(0));
         when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
+        lenient().when(htmlProcessor.replaceCssResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
 
         when(module.getValue("field1")).thenReturn("Value & <one>");
         when(module.getValue("my_field")).thenReturn("Quote\"Val");
@@ -472,6 +475,7 @@ class PdfConverterTest {
         when(velocityEvaluator.evaluateVelocityExpressions(eq(documentData), anyString())).thenAnswer(a -> a.getArguments()[1]);
         when(htmlProcessor.internalizeLinks(anyString())).thenAnswer(a -> a.getArgument(0));
         when(htmlProcessor.replaceResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
+        lenient().when(htmlProcessor.replaceCssResourcesAsBase64Encoded(anyString())).thenAnswer(a -> a.getArgument(0));
 
         ArgumentCaptor<String> metaCaptor = ArgumentCaptor.forClass(String.class);
         when(pdfTemplateProcessor.processUsing(any(ExportParams.class), anyString(), anyString(), anyString(), metaCaptor.capture(), any()))

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfigurationTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/properties/PdfExporterExtensionConfigurationTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -127,11 +128,45 @@ class PdfExporterExtensionConfigurationTest {
     }
 
     @Test
+    void getExternalResourcesPolicyReturnsConfiguredValue() {
+        when(systemValueReader.readString(anyString(), anyString())).thenReturn("allowlistOnly");
+
+        assertEquals("allowlistOnly", configuration.getExternalResourcesPolicy());
+    }
+
+    @Test
+    void getExternalResourcesAllowedOriginsReturnsConfiguredValue() {
+        when(systemValueReader.readString(anyString(), anyString())).thenReturn("cdn.intranet");
+
+        assertEquals("cdn.intranet", configuration.getExternalResourcesAllowedOrigins());
+    }
+
+    @Test
+    void getExternalResourcesMaxSizeMBReturnsConfiguredValue() {
+        when(systemValueReader.readInt(anyString(), anyInt())).thenReturn(32);
+
+        assertEquals(32, configuration.getExternalResourcesMaxSizeMB());
+    }
+
+    @Test
+    void getExternalResourcesDescriptionsAndDefaultsReturnConstants() {
+        assertEquals(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY_DESCRIPTION, configuration.getExternalResourcesPolicyDescription());
+        assertEquals(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY_DEFAULT_VALUE, configuration.getExternalResourcesPolicyDefaultValue());
+        assertEquals(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_ORIGINS_DESCRIPTION, configuration.getExternalResourcesAllowedOriginsDescription());
+        assertEquals(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_ORIGINS_DEFAULT_VALUE, configuration.getExternalResourcesAllowedOriginsDefaultValue());
+        assertEquals(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_MAX_SIZE_MB_DESCRIPTION, configuration.getExternalResourcesMaxSizeMBDescription());
+        assertEquals("16", configuration.getExternalResourcesMaxSizeMBDefaultValue());
+    }
+
+    @Test
     void getSupportedPropertiesContainsAllProperties() {
         var properties = configuration.getSupportedProperties();
 
         assertTrue(properties.contains(PdfExporterExtensionConfiguration.WEASYPRINT_SERVICE));
         assertTrue(properties.contains(PdfExporterExtensionConfiguration.WEBHOOKS_ENABLED));
         assertTrue(properties.contains(PdfExporterExtensionConfiguration.RENDERABLE_IMAGE_EXTENSIONS));
+        assertTrue(properties.contains(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_POLICY));
+        assertTrue(properties.contains(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_ALLOWED_ORIGINS));
+        assertTrue(properties.contains(PdfExporterExtensionConfiguration.EXTERNAL_RESOURCES_MAX_SIZE_MB));
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/CustomResourceUrlResolverTest.java
@@ -1,20 +1,117 @@
 package ch.sbb.polarion.extension.pdf_exporter.util;
 
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
+import ch.sbb.polarion.extension.pdf_exporter.util.ResourceUrlPolicy.Mode;
+import ch.sbb.polarion.extension.generic.test_extensions.BundleJarsPrioritizingRunnableMockExtension;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 import lombok.SneakyThrows;
+import org.apache.http.HttpHost;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
 import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, BundleJarsPrioritizingRunnableMockExtension.class})
 class CustomResourceUrlResolverTest {
+
+    // the content has to be what its sender calls it, so the bytes of the tests are the bytes of a png
+    private static final byte[] PNG_CONTENT = {(byte) 0x89, 'P', 'N', 'G', 13, 10, 26, 10, 0, 0, 0, 13, 'I', 'H', 'D', 'R'};
+
+    private HttpServer server;
+    private final AtomicInteger requestCount = new AtomicInteger();
+
+    @BeforeEach
+    @SneakyThrows
+    void startServer() {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private String url(String path) {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+    }
+
+    @SneakyThrows
+    private URL toUrl(String value) {
+        return URI.create(value).toURL();
+    }
+
+    private void respond(String path, String contentType, byte[] body, boolean chunked) {
+        server.createContext(path, exchange -> {
+            requestCount.incrementAndGet();
+            if (contentType != null) {
+                exchange.getResponseHeaders().add("Content-Type", contentType);
+            }
+            exchange.sendResponseHeaders(200, chunked ? 0 : body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+    }
+
+    private void redirect(String path, String location) {
+        server.createContext(path, exchange -> {
+            requestCount.incrementAndGet();
+            exchange.getResponseHeaders().add("Location", location);
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+    }
+
+    private void status(String path, int code) {
+        server.createContext(path, (HttpExchange exchange) -> {
+            requestCount.incrementAndGet();
+            exchange.sendResponseHeaders(code, -1);
+            exchange.close();
+        });
+    }
+
+    private CustomResourceUrlResolver resolver(int maxSizeMB) {
+        return new CustomResourceUrlResolver(new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), null, maxSizeMB));
+    }
 
     @Test
     @SneakyThrows
@@ -24,10 +121,527 @@ class CustomResourceUrlResolverTest {
         when(resolver.resolve(any())).thenCallRealMethod();
         when(resolver.resolveImpl(any())).thenReturn(is);
         try (InputStream is1 = resolver.resolve("http://localhost/some path/img%5Fname.png")) {
-            try (InputStream is2 = verify(resolver, times(1)).resolveImpl(URI.create("http://localhost/some%20path/img_name.png").toURL())){
+            try (InputStream is2 = verify(resolver, times(1)).resolveImpl(URI.create("http://localhost/some%20path/img_name.png").toURL())) {
                 assertEquals(is, is1);
                 assertNull(is2);
             }
         }
+    }
+
+    @Test
+    @SneakyThrows
+    void readsAllowedResource() {
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        try (InputStream stream = resolver(16).resolveImpl(toUrl(url("/img.png")))) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+        }
+    }
+
+    @Test
+    void skipsResourceRejectedByPolicy() {
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), null, 16);
+        assertNull(new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/img.png"))));
+        assertEquals(0, requestCount.get());
+    }
+
+    @Test
+    void skipsForeignContentType() {
+        respond("/secret", "application/json", "{\"internal\":\"api response\"}".getBytes(StandardCharsets.UTF_8), false);
+        assertNull(resolver(16).resolveImpl(toUrl(url("/secret"))));
+    }
+
+    @Test
+    void skipsDocumentDisguisedAsOctetStream() {
+        respond("/secret", "application/octet-stream", "<html><body>internal page</body></html>".getBytes(StandardCharsets.UTF_8), false);
+        assertNull(resolver(16).resolveImpl(toUrl(url("/secret"))));
+    }
+
+    @Test
+    @SneakyThrows
+    void readsImageWithoutContentType() {
+        respond("/img.png", null, PNG_CONTENT, false);
+        try (InputStream stream = resolver(16).resolveImpl(toUrl(url("/img.png")))) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void skipsContentWhichIsNoResourceWhenNothingWasSaidAboutIt() {
+        // an internal service answering a forged request tends to say nothing, or to say octet-stream,
+        // and to hand over a text: neither an image, nor a font, nor a stylesheet
+        respond("/secrets", null, "the answer of an internal service, plain text\n".getBytes(StandardCharsets.UTF_8), false);
+        respond("/blob", "application/octet-stream", "id,name\n1,admin\n".getBytes(StandardCharsets.UTF_8), false);
+
+        assertNull(resolver(16).resolveImpl(toUrl(url("/secrets"))));
+        assertNull(resolver(16).resolveImpl(toUrl(url("/blob"))));
+    }
+
+    @Test
+    @SneakyThrows
+    void skipsUnknownBytesWhateverTheSenderCalledThem() {
+        // a detector which recognizes nothing in the content has answered, and the answer is no
+        respond("/img.png", "image/png", new byte[]{7, 7, 7, 7, 7, 7, 7, 7}, false);
+
+        assertNull(resolver(16).resolveImpl(toUrl(url("/img.png"))));
+    }
+
+    @Test
+    void skipsResourceExceedingDeclaredSize() {
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        assertNull(resolver(0).resolveImpl(toUrl(url("/img.png"))));
+    }
+
+    @Test
+    void skipsResourceExceedingStreamedSize() {
+        respond("/img.png", "image/png", PNG_CONTENT, true);
+        assertNull(resolver(0).resolveImpl(toUrl(url("/img.png"))));
+    }
+
+    @Test
+    @SneakyThrows
+    void followsRedirect() {
+        redirect("/old.png", "/img.png");
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        try (InputStream stream = resolver(16).resolveImpl(toUrl(url("/old.png")))) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+            assertEquals(2, requestCount.get());
+        }
+    }
+
+    @Test
+    void stopsOnRedirectLoop() {
+        redirect("/loop.png", url("/loop.png"));
+        assertNull(resolver(16).resolveImpl(toUrl(url("/loop.png"))));
+        assertEquals(6, requestCount.get());
+    }
+
+    @Test
+    void skipsRedirectWithoutLocation() {
+        server.createContext("/no-location.png", exchange -> {
+            requestCount.incrementAndGet();
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+        assertNull(resolver(16).resolveImpl(toUrl(url("/no-location.png"))));
+    }
+
+    @Test
+    @SneakyThrows
+    void followsPermanentRedirect() {
+        server.createContext("/old.png", exchange -> {
+            requestCount.incrementAndGet();
+            exchange.getResponseHeaders().add("Location", "/img.png");
+            exchange.sendResponseHeaders(301, -1);
+            exchange.close();
+        });
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        try (InputStream stream = resolver(16).resolveImpl(toUrl(url("/old.png")))) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+        }
+    }
+
+    @Test
+    void skipsRedirectWithBlankLocation() {
+        redirect("/blank.png", "  ");
+        assertNull(resolver(16).resolveImpl(toUrl(url("/blank.png"))));
+    }
+
+    @Test
+    void takesItsPolicyFromTheConfiguration() {
+        PdfExporterExtensionConfiguration configuration = mock(PdfExporterExtensionConfiguration.class);
+        when(configuration.getExternalResourcesPolicy()).thenReturn("ALLOW_ALL");
+
+        try (MockedStatic<PdfExporterExtensionConfiguration> mocked = mockStatic(PdfExporterExtensionConfiguration.class)) {
+            mocked.when(PdfExporterExtensionConfiguration::getInstance).thenReturn(configuration);
+            respond("/img.png", "image/png", PNG_CONTENT, false);
+
+            assertNotNull(new CustomResourceUrlResolver().resolveImpl(toUrl(url("/img.png"))));
+        }
+    }
+
+    @Test
+    void skipsRedirectToBlockedTarget() {
+        redirect("/old.png", "http://169.254.169.254/latest/meta-data/");
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of("127.0.0.1:" + server.getAddress().getPort()), null, 16);
+        assertNull(new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/old.png"))));
+        assertEquals(1, requestCount.get());
+    }
+
+    @Test
+    @SneakyThrows
+    void resolvesANetworkPathReferenceAgainstItsOwnHost() {
+        // '//127.0.0.1:port/img.png' names its own host, only the scheme comes from the base url
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), "http://localhost", 16);
+        CustomResourceUrlResolver resolver = new CustomResourceUrlResolver(policy);
+
+        try (InputStream stream = resolver.resolve("//127.0.0.1:" + server.getAddress().getPort() + "/img.png")) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void fallsBackToTheOtherSchemeOfANetworkPathReference() {
+        // the base url says https, the server speaks http: the second attempt has to find it
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), "https://localhost", 16);
+        CustomResourceUrlResolver resolver = new CustomResourceUrlResolver(policy);
+
+        try (InputStream stream = resolver.resolve("//127.0.0.1:" + server.getAddress().getPort() + "/img.png")) {
+            assertNotNull(stream);
+            assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void keepsTheAnswerOfTheFirstSchemeOfANetworkPathReference() {
+        // the host answered, and 404 is an answer: asking it again over the other scheme adds nothing
+        status("/missing.png", 404);
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), "http://localhost", 16);
+        CustomResourceUrlResolver resolver = spy(new CustomResourceUrlResolver(policy));
+
+        assertNull(resolver.resolve("//127.0.0.1:" + server.getAddress().getPort() + "/missing.png"));
+
+        verify(resolver, times(1)).resolveImpl(any());
+    }
+
+    @Test
+    void skipsAProxiedResourceWhichIsNotExplicitlyTrusted() {
+        // a proxy resolves the host name itself, so the vetted addresses would decide nothing
+        System.setProperty("http.proxyHost", "proxy.invalid");
+        System.setProperty("http.proxyPort", "3128");
+        try {
+            ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), null, 16);
+
+            assertNull(new CustomResourceUrlResolver(policy).resolveImpl(toUrl("http://8.8.8.8/img.png")));
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
+    }
+
+    @Test
+    void triesTheOtherSchemeWhereTheHostDoesNotSpeakTlsAtAll() {
+        CustomResourceUrlResolver resolver = resolver(16);
+
+        // a peer which is not speaking tls answered nothing, and the other scheme is the next question
+        assertFalse(resolver.isCertificateFailure(new SSLException("Unrecognized SSL message, plaintext connection?")));
+        // a refused certificate is an answer, and never one to repeat in the clear
+        assertTrue(resolver.isCertificateFailure(new SSLHandshakeException("failed") {
+            @Override
+            public synchronized Throwable getCause() {
+                return new CertificateException("no trusted certificate found");
+            }
+        }));
+        assertTrue(resolver.isCertificateFailure(new SSLPeerUnverifiedException("hostname mismatch")));
+    }
+
+    @Test
+    @SneakyThrows
+    void fetchesATrustedHostThroughAProxyWhichResolvesItsName() {
+        // the egress of such a server is the proxy, and the names it fetches are the proxy's to resolve:
+        // a host the configuration trusts must not need an address of its own here
+        try (ServerSocket proxy = new ServerSocket(0)) {
+            AtomicBoolean reached = new AtomicBoolean();
+            Thread listener = new Thread(() -> {
+                try (Socket accepted = proxy.accept()) {
+                    reached.set(accepted.getInputStream().read() >= 0);
+                } catch (IOException e) {
+                    // the test asks whether the request arrived at the proxy, and nothing else
+                }
+            });
+            listener.setDaemon(true);
+            listener.start();
+            System.setProperty("http.proxyHost", "127.0.0.1");
+            System.setProperty("http.proxyPort", String.valueOf(proxy.getLocalPort()));
+            try {
+                ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOWLIST_ONLY, List.of("cdn.invalid"), null, 16);
+
+                assertNull(new CustomResourceUrlResolver(policy).resolve("http://cdn.invalid/img.png"));
+
+                listener.join(5000);
+                assertTrue(reached.get());
+            } finally {
+                System.clearProperty("http.proxyHost");
+                System.clearProperty("http.proxyPort");
+            }
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void keepsFetchingWhenOnlyASocksProxyIsConfigured() {
+        // the route planner of the client ignores a socks proxy, so the request stays direct and pinned
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        System.setProperty("socksProxyHost", "socks.invalid");
+        System.setProperty("socksProxyPort", "1080");
+        try {
+            ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), null, 16);
+
+            try (InputStream stream = new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/img.png")))) {
+                assertNotNull(stream);
+                assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+            }
+            // and the classification itself, asked about an address no default non-proxy list covers
+            assertFalse(new CustomResourceUrlResolver(policy).decideProxy(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")).proxied());
+        } finally {
+            System.clearProperty("socksProxyHost");
+            System.clearProperty("socksProxyPort");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void sendsARequestThroughASocksProxyAtTheSocket() {
+        // the client plans no route to a socks proxy, the jvm applies it under the connection, so a
+        // socks setup keeps working: the request reaches the proxy rather than the host directly
+        try (ServerSocket socksProxy = new ServerSocket(0)) {
+            SocksRequest seen = new SocksRequest();
+            Thread listener = readSocksRequest(socksProxy, seen);
+            System.setProperty("socksProxyHost", "127.0.0.1");
+            System.setProperty("socksProxyPort", String.valueOf(socksProxy.getLocalPort()));
+            try {
+                ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), null, 16);
+
+                assertNull(new CustomResourceUrlResolver(policy).resolve("http://8.8.8.8/img.png"));
+
+                listener.join(5000);
+                assertTrue(seen.reached.get());
+                // and it names an address, never a host name the proxy would resolve on its own
+                assertEquals(SOCKS_ADDRESS_TYPE_IPV4, seen.addressType.get());
+                assertEquals("8.8.8.8", seen.address.get());
+            } finally {
+                System.clearProperty("socksProxyHost");
+                System.clearProperty("socksProxyPort");
+            }
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void namesTheVettedAddressToASocksProxyRatherThanTheHost() {
+        // a proxy which resolves the host name itself would decide the address, and that is what this
+        // asks: the request names an address, so the name never reaches the proxy
+        try (ServerSocket socksProxy = new ServerSocket(0)) {
+            SocksRequest seen = new SocksRequest();
+            Thread listener = readSocksRequest(socksProxy, seen);
+            System.setProperty("socksProxyHost", "127.0.0.1");
+            System.setProperty("socksProxyPort", String.valueOf(socksProxy.getLocalPort()));
+            // the jvm keeps loopback out of every proxy by default, and here the proxy is the point
+            System.setProperty("socksNonProxyHosts", "");
+            try {
+                ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), null, 16);
+
+                assertNull(new CustomResourceUrlResolver(policy).resolve("http://localhost:" + server.getAddress().getPort() + "/img.png"));
+
+                listener.join(5000);
+                assertTrue(seen.reached.get());
+                assertEquals(SOCKS_ADDRESS_TYPE_IPV4, seen.addressType.get());
+                assertEquals("127.0.0.1", seen.address.get());
+            } finally {
+                System.clearProperty("socksProxyHost");
+                System.clearProperty("socksProxyPort");
+                System.clearProperty("socksNonProxyHosts");
+            }
+        }
+    }
+
+    /**
+     * Answers the greeting of a socks 5 client and keeps what its request names, then closes.
+     */
+    private Thread readSocksRequest(ServerSocket socksProxy, SocksRequest seen) {
+        Thread listener = new Thread(() -> {
+            try (Socket accepted = socksProxy.accept()) {
+                InputStream in = accepted.getInputStream();
+                in.read();
+                int methods = in.read();
+                in.readNBytes(Math.max(methods, 0));
+                accepted.getOutputStream().write(new byte[]{5, 0});
+                accepted.getOutputStream().flush();
+                byte[] head = in.readNBytes(4);
+                seen.reached.set(head.length == 4);
+                seen.addressType.set(head.length == 4 ? head[3] : -1);
+                if (head.length == 4 && head[3] == SOCKS_ADDRESS_TYPE_IPV4) {
+                    seen.address.set(InetAddress.getByAddress(in.readNBytes(4)).getHostAddress());
+                }
+            } catch (IOException e) {
+                // the test asks what the request named, and a closed connection names nothing
+            }
+        });
+        listener.setDaemon(true);
+        listener.start();
+        return listener;
+    }
+
+    private static final int SOCKS_ADDRESS_TYPE_IPV4 = 1;
+
+    private static final class SocksRequest {
+        private final AtomicBoolean reached = new AtomicBoolean();
+        private final AtomicInteger addressType = new AtomicInteger(-1);
+        private final AtomicReference<String> address = new AtomicReference<>();
+    }
+
+    @Test
+    @SneakyThrows
+    void treatsASelectorWhichCannotAnswerAsAProxy() {
+        // a check which cannot be made is not a check that passed, so such a url is skipped as proxied
+        ProxySelector previous = ProxySelector.getDefault();
+        ProxySelector.setDefault(new ProxySelector() {
+            @Override
+            public List<Proxy> select(URI uri) {
+                throw new IllegalStateException("no answer");
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress address, java.io.IOException failure) {
+                // nothing to report, this selector never answers in the first place
+            }
+        });
+        try {
+            ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), null, 16);
+            CustomResourceUrlResolver resolver = new CustomResourceUrlResolver(policy);
+
+            assertTrue(resolver.decideProxy(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")).proxied());
+            assertNull(resolver.resolveImpl(toUrl("http://8.8.8.8/img.png")));
+
+            // and a trusted host is no reason to send the request past the route the configuration names
+            ResourceUrlPolicy trusting = new ResourceUrlPolicy(Mode.ALLOWLIST_ONLY, List.of("8.8.8.8"), null, 16);
+            assertNull(new CustomResourceUrlResolver(trusting).resolveImpl(toUrl("http://8.8.8.8/img.png")));
+        } finally {
+            ProxySelector.setDefault(previous);
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void routesByTheSelectorAndNotByTheProperty() {
+        // the check reads the selector, so the routes have to come from there too: a selector answering
+        // no proxy wins over http.proxyHost, and a request under it stays direct as the check said
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        System.setProperty("http.proxyHost", "proxy.invalid");
+        System.setProperty("http.proxyPort", "3128");
+        ProxySelector previous = ProxySelector.getDefault();
+        ProxySelector.setDefault(new ProxySelector() {
+            @Override
+            public List<Proxy> select(URI uri) {
+                return List.of(Proxy.NO_PROXY);
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress address, java.io.IOException failure) {
+                // nothing to report, the test asks for a route and never for a failure
+            }
+        });
+        try {
+            ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOW_ALL, List.of(), null, 16);
+
+            try (InputStream stream = new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/img.png")))) {
+                assertNotNull(stream);
+                assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+            }
+        } finally {
+            ProxySelector.setDefault(previous);
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
+    }
+
+    @Test
+    void readsTheProxyListAsTheJvmReadsIt() {
+        // a pac file writing 'DIRECT; PROXY host:port' means direct, and the entry after it is a fallback
+        CustomResourceUrlResolver resolver = resolver(16);
+        HttpHost proxyHost = new HttpHost("proxy.invalid", 3128);
+
+        assertFalse(resolver.decideProxy(selectorOf(Proxy.NO_PROXY, httpProxy()), toUrl("http://8.8.8.8/i.png")).proxied());
+        assertTrue(resolver.decideProxy(selectorOf(httpProxy(), Proxy.NO_PROXY), toUrl("http://8.8.8.8/i.png")).proxied());
+        // a socks entry is no route the client plans, so it decides nothing either way
+        assertEquals(proxyHost.toHostString(),
+                resolver.decideProxy(selectorOf(socksProxy(), httpProxy()), toUrl("http://8.8.8.8/i.png")).host().toHostString());
+        assertFalse(resolver.decideProxy(selectorOf(socksProxy()), toUrl("http://8.8.8.8/i.png")).proxied());
+    }
+
+    private Proxy httpProxy() {
+        return new Proxy(Proxy.Type.HTTP, InetSocketAddress.createUnresolved("proxy.invalid", 3128));
+    }
+
+    private Proxy socksProxy() {
+        return new Proxy(Proxy.Type.SOCKS, InetSocketAddress.createUnresolved("socks.invalid", 1080));
+    }
+
+    private ProxySelector selectorOf(Proxy... proxies) {
+        return new ProxySelector() {
+            @Override
+            public List<Proxy> select(URI uri) {
+                return List.of(proxies);
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress address, IOException failure) {
+                // the test asks what the list says, and never reports a failure to it
+            }
+        };
+    }
+
+    @Test
+    void classifiesAnHttpProxyAsARoute() {
+        System.setProperty("http.proxyHost", "proxy.invalid");
+        System.setProperty("http.proxyPort", "3128");
+        try {
+            CustomResourceUrlResolver resolver = resolver(16);
+
+            assertTrue(resolver.decideProxy(ProxySelector.getDefault(), toUrl("http://8.8.8.8/img.png")).proxied());
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void keepsFetchingAHostTheProxyIsNotUsedFor() {
+        respond("/img.png", "image/png", PNG_CONTENT, false);
+        System.setProperty("http.proxyHost", "proxy.invalid");
+        System.setProperty("http.proxyPort", "3128");
+        try {
+            ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL,
+                    List.of("127.0.0.1:" + server.getAddress().getPort()), null, 16);
+
+            try (InputStream stream = new CustomResourceUrlResolver(policy).resolveImpl(toUrl(url("/img.png")))) {
+                assertNotNull(stream);
+                assertArrayEquals(PNG_CONTENT, stream.readAllBytes());
+            }
+        } finally {
+            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
+        }
+    }
+
+    @Test
+    void skipsErrorResponse() {
+        status("/missing.png", 404);
+        assertNull(resolver(16).resolveImpl(toUrl(url("/missing.png"))));
+    }
+
+    @Test
+    void resolveReturnsNullOnFailure() {
+        assertNull(resolver(16).resolve("http://"));
+    }
+
+    @Test
+    void canResolveOnlyHttpAndAbsolutePaths() {
+        CustomResourceUrlResolver resolver = resolver(16);
+        assertTrue(resolver.canResolve("/polarion/img.png"));
+        assertTrue(resolver.canResolve("http://example.com/img.png"));
+        assertTrue(resolver.canResolve("https://example.com/img.png"));
+        assertFalse(resolver.canResolve("data:image/png;base64,AAAA"));
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/HtmlProcessorTest.java
@@ -3,6 +3,7 @@ package ch.sbb.polarion.extension.pdf_exporter.util;
 import ch.sbb.polarion.extension.generic.settings.SettingId;
 import ch.sbb.polarion.extension.generic.test_extensions.BundleJarsPrioritizingRunnableMockExtension;
 import ch.sbb.polarion.extension.pdf_exporter.configuration.PdfExporterExtensionConfigurationExtension;
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
 import ch.sbb.polarion.extension.pdf_exporter.TestStringUtils;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.ConversionParams;
 import ch.sbb.polarion.extension.pdf_exporter.rest.model.conversion.DocumentType;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,6 +40,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -77,6 +80,9 @@ class HtmlProcessorTest {
         LocalizationModel localizationModel = new LocalizationModel(deTranslations, frTranslations, itTranslations);
 
         lenient().when(localizationSettings.load(anyString(), any(SettingId.class))).thenReturn(localizationModel);
+        // by default every resource inlines to itself, so that a test which is not about resources
+        // keeps its urls. A url which does not inline is replaced by a placeholder, see inlineBase64Resources.
+        lenient().when(fileResourceProvider.getResourceAsBase64String(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test
@@ -512,6 +518,423 @@ class HtmlProcessorTest {
         when(fileResourceProvider.getResourceAsBase64String(any())).thenReturn("base64Data");
         String result = processor.replaceResourcesAsBase64Encoded(html);
         assertEquals("<div><img id=\"image\" src=\"base64Data\"/></div>", result);
+    }
+
+    @Test
+    @SneakyThrows
+    void replaceForbiddenImageWithPlaceholderTest() {
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String html = "<div><img id=\"image\" src=\"" + url + "\"/></div>";
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+        assertEquals("<div><img id=\"image\" src=\"" + MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER + "\"/></div>", result);
+    }
+
+    @Test
+    @SneakyThrows
+    void replaceNotInlinedAbsoluteUrlWithPlaceholderTest() {
+        // the resolver refused the resource, for instance by its content type: the url must not survive
+        String html = "<div><img id=\"image\" src=\"http://example.com/img.png\"/></div>";
+        when(fileResourceProvider.getResourceAsBase64String(any())).thenReturn(null);
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+        assertEquals("<div><img id=\"image\" src=\"" + MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER + "\"/></div>", result);
+    }
+
+    @Test
+    @SneakyThrows
+    void keepNotInlinedRelativeUrlsTest() {
+        // a relative url and an SVG fragment cannot be loaded by WeasyPrint, leave them alone
+        String html = "<div style=\"fill: url(#gradient)\"><img id=\"image\" src=\"images/local.png\"/></div>";
+        when(fileResourceProvider.getResourceAsBase64String(any())).thenReturn(null);
+        assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "@import \"URL\";",
+            "@import \"URL\" screen and (min-width:1px);",   // a media condition must not save the at-rule
+            "@import url(\"URL\") print;",                    // the url() form goes as a whole too
+            "@import/*sneaky*/\"URL\";",                      // CSS allows a comment between the at-keyword and its target
+            "@import\"URL\";",                                // and it allows no separator at all
+            "@import url(/*sneaky*/\"URL\");",                 // a comment inside url() too
+            "@import url( \"URL\" /*sneaky*/ );",
+            "@import \"http\\3a //169.254.169.254/latest/meta-data/\";",  // a css escape hides the scheme
+            "@import url(/* ) */\"URL\");",                    // a ')' inside a comment used to cut the match
+            "@import/* ; */\"URL\";",                          // and a ';' inside one
+            "@\\69mport \"URL\";",                              // an escaped at-keyword
+            "@\\69mport \\75rl(\"URL\");"                        // an escaped at-keyword and function
+    })
+    @SneakyThrows
+    void dropAbsoluteCssImportTest(String atRule) {
+        String html = "<style>" + atRule.replace("URL", "http://169.254.169.254/latest/meta-data/") + " body { color: red; }</style>";
+
+        // either the at-rule goes, or the whole stylesheet does when nothing could read it
+        assertFalse(processor.replaceResourcesAsBase64Encoded(html).contains("169.254.169.254"));
+    }
+
+
+    @Test
+    @SneakyThrows
+    void replaceForbiddenNetworkPathReferenceTest() {
+        String html = "<style>body { background: url(//169.254.169.254/latest/meta-data/); }</style>";
+        when(fileResourceProvider.isForbidden("//169.254.169.254/latest/meta-data/")).thenReturn(true);
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
+    }
+
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "url(/*sneaky*/\"ADDRESS\")",
+            "url(/* ) */\"ADDRESS\")",
+            "url(\"ADDRESS\" /*sneaky*/)",
+            "\\75rl(\"ADDRESS\")"
+    })
+    @SneakyThrows
+    void keepAForbiddenCssUrlOutOfTheDocumentTest(String value) {
+        String address = "http://169.254.169.254/latest/meta-data/";
+        String html = "<style>body { background: " + value.replace("ADDRESS", address) + "; }</style>";
+        lenient().when(fileResourceProvider.isForbidden(address)).thenReturn(true);
+
+        assertFalse(processor.replaceResourcesAsBase64Encoded(html).contains("169.254.169.254"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "style=\"background: url(ADDRESS)\"",
+            "style = \"background: url(ADDRESS)\"",
+            "style='background: url(ADDRESS)'",
+            "style=background:url(ADDRESS)"
+    })
+    @SneakyThrows
+    void keepAForbiddenUrlOutOfEveryFormOfAStyleAttributeTest(String attribute) {
+        String address = "http://169.254.169.254/latest/meta-data/";
+        String html = "<div " + attribute.replace("ADDRESS", address) + "></div>";
+        lenient().when(fileResourceProvider.isForbidden(address)).thenReturn(true);
+
+        assertFalse(processor.replaceResourcesAsBase64Encoded(html).contains("169.254.169.254"));
+    }
+
+    @Test
+    @SneakyThrows
+    void inlineAnImageWrittenWithWhitespaceAroundItsUrlTest() {
+        String url = "//cdn.example/image.png";
+        String html = "<div><img src=\" " + url + " \"/></div>";
+        when(fileResourceProvider.getResourceAsBase64String(url)).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertTrue(result.contains("data:image/png;base64,AAAA"));
+        assertFalse(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
+    }
+
+    @Test
+    @SneakyThrows
+    void inlineARelativeCssUrlTest() {
+        // a stylesheet whose urls are all relative is inlined as well, it names no address to check
+        String html = "<style>body { background: url(images/logo.png); }</style>";
+        when(fileResourceProvider.getResourceAsBase64String("images/logo.png")).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertTrue(result.contains("url(data:image/png;base64,AAAA)"));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepAStyleAttributeUsableAfterInliningTest() {
+        // a quote around the value would end the attribute early, so the data url goes in bare
+        String html = "<div style=\"background: url(images/logo.png)\"></div>";
+        when(fileResourceProvider.getResourceAsBase64String("images/logo.png")).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertEquals("<div style=\"background: url(data:image/png;base64,AAAA)\"></div>", result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // pandoc-service loads the src of an image and of a frame, weasyprint-service the src of an
+            // image, the data of an object and the src of an embed. The image of an inline svg is
+            // rewritten as well, a data url being a valid href there
+            "<img src=\"http://169.254.169.254/latest/meta-data/\">",
+            "<object data=\"http://169.254.169.254/latest/meta-data/\"></object>",
+            "<embed src=\"http://169.254.169.254/latest/meta-data/\">",
+            "<iframe src=\"http://169.254.169.254/latest/meta-data/\"></iframe>",
+            "<svg><image href=\"http://169.254.169.254/latest/meta-data/\"/></svg>",
+            "<svg><image xlink:href=\"http://169.254.169.254/latest/meta-data/\"/></svg>"
+    })
+    @SneakyThrows
+    void blockAnAddressInEveryAttributeAConverterReadsTest(String html) {
+        when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains("data:image/png;base64,"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"\n", "\r\n", "\r"})
+    @SneakyThrows
+    void readAUrlAtItsPositionWhateverEndsTheLineBeforeItTest(String lineBreak) {
+        // the parser ends a line on a carriage return as well, so the positions it reports are counted
+        // that way here too, and a rewrite lands where the url stands and nowhere else
+        String html = "<style>a { color: red }" + lineBreak + "b { background: url(images/logo.png) }</style>";
+        when(fileResourceProvider.getResourceAsBase64String("images/logo.png")).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertEquals("<style>a { color: red }" + lineBreak + "b { background: url(data:image/png;base64,AAAA) }</style>", result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // weasyprint-service reads a file url through an import, and a path from the root of the
+            // file system goes to the base url of the document, so only the scheme names somewhere else
+            "<img src=\"file:///etc/hostname\">",
+            "<div style=\"background: url(file:///etc/hostname)\"></div>",
+            "<style>a { background: url(file:///etc/hostname) }</style>"
+    })
+    @SneakyThrows
+    void replaceAUrlAConverterWouldReadElsewhereTest(String html) {
+        // nothing here can be loaded by the extension, which is exactly why it must not stay
+        when(fileResourceProvider.getResourceAsBase64String(anyString())).thenReturn(null);
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertFalse(result.contains("/etc/hostname"));
+    }
+
+    @Test
+    @SneakyThrows
+    void dropAnImportOfAFileUrlTest() {
+        // an at-rule is never inlined, so its target is removed whatever the provider would answer
+        String result = processor.replaceResourcesAsBase64Encoded(
+                "<style>@import \"file:///etc/hostname\"; a { color: red }</style>");
+
+        assertFalse(result.contains("/etc/hostname"));
+    }
+
+    @Test
+    @SneakyThrows
+    void readAUrlOfATabIndentedDeclarationTest() {
+        // the parser counts a tab as one column here, so its columns are the offsets of the text
+        String html = "<style>a {\n\tbackground: url(images/logo.png);\n}</style>";
+        when(fileResourceProvider.getResourceAsBase64String("images/logo.png")).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertEquals("<style>a {\n\tbackground: url(data:image/png;base64,AAAA);\n}</style>", result);
+    }
+
+    @Test
+    @SneakyThrows
+    void askForARenderableImageWithoutItsThumbnailTest() {
+        // a thumbnail is what Polarion answers for a document, and an image is wanted at its full size
+        when(PdfExporterExtensionConfiguration.getInstance().getRenderableImageExtensions()).thenReturn(Set.of("png"));
+        when(fileResourceProvider.getResourceAsBase64String("/polarion/attachment/img.png?revision=2"))
+                .thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(
+                "<img src=\"/polarion/attachment/img.png?revision=2&thumbnail=true\">");
+
+        assertTrue(result.contains("data:image/png;base64,AAAA"));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepAnApostropheOfAStyleAttributeEscapedTest() {
+        // the value is written back as markup, so a quote in it may not end the attribute it sits in
+        when(fileResourceProvider.getResourceAsBase64String("/a.png")).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(
+                "<img style='background:url(/a.png);font-family:&#39; src=http://169.254.169.254/x &#39;' src='/b.png'>");
+
+        assertFalse(result.contains("' src=http://169.254.169.254/x '"));
+        assertTrue(result.contains("data:image/png;base64,AAAA"));
+    }
+
+    @Test
+    @SneakyThrows
+    void blockAnEscapedSchemeOfAForbiddenAddressInAStyleAttributeTest() {
+        // the gate resolves the escapes, so the decision which follows it reads the same address
+        when(fileResourceProvider.isForbidden(anyString())).thenReturn(true);
+
+        String result = processor.replaceResourcesAsBase64Encoded(
+                "<div style=\"background: url(http\\3a //169.254.169.254/latest/meta-data/)\"></div>");
+
+        assertFalse(result.contains("169.254.169.254"));
+    }
+
+    @Test
+    @SneakyThrows
+    void blockAnAddressWrittenWithHtmlEntitiesInAnAttributeTest() {
+        // the renderer reads an attribute after the html parser resolved its entities, and so does this
+        when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+
+        String style = processor.replaceResourcesAsBase64Encoded(
+                "<div style=\"background: url(&quot;http://169.254.169.254/latest/meta-data/&quot;)\"></div>");
+        String image = processor.replaceResourcesAsBase64Encoded(
+                "<img src=\"&#104;ttp://169.254.169.254/latest/meta-data/\">");
+
+        assertFalse(style.contains("169.254.169.254"));
+        assertFalse(image.contains("169.254.169.254"));
+        assertTrue(style.contains("data:image/png;base64,"));
+        assertTrue(image.contains("data:image/png;base64,"));
+    }
+
+    @Test
+    @SneakyThrows
+    void blockAnEscapedSchemeOfAForbiddenAddressTest() {
+        // the parser resolves the escape, so the policy is asked about the address the renderer would read
+        String html = "<style>a { background: url(\"http\\3a //169.254.169.254/latest/meta-data/\") }</style>";
+        when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains("data:image/png;base64,"));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepAStylesheetHoldingAnUnencodedSvgDataUrlTest() {
+        // the payload of such a data url carries quotes and the namespace of SVG, neither is an address
+        String html = "<style>body { background: url(\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>\"); color: red; }</style>";
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertTrue(result.contains("color"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // a data url token which no url() holds must not hide what stands after it
+            "a { --x: data: } @\\69mport \"http://169.254.169.254/latest/meta-data/\";",
+            // an import inside a media rule is dropped by the parser, and the renderer would read it
+            "@media print { @import url(http://169.254.169.254/latest/meta-data/); }",
+            // the same characters read as a string in one rule, and read by nothing in the next
+            "a { content: \"http://169.254.169.254/\" } @\\69mport \"http://169.254.169.254/\";"
+    })
+    @SneakyThrows
+    void dropAStylesheetNamingAnAddressNothingAccountedForTest(String css) {
+        String result = processor.replaceResourcesAsBase64Encoded("<style>" + css + "</style>");
+
+        assertFalse(result.contains("169.254.169.254"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "a[href^=\"https://example.com\"] { color: red; }",          // an address in a selector fetches nothing
+            "@namespace url(http://www.w3.org/1999/xhtml); a { color: red; }", // nor one in an at-rule prelude
+            "a { content: \"https://example.com\"; color: red; }",         // nor one in a string value
+            // nor one in a selector nested in a grouping at-rule, the print-stylesheet idiom
+            "@media print { a[href^=\"https://example.com\"]::after { color: red; } }",
+            // nor one in the prelude of an at-rule nested in another one
+            "@media print { @supports (background: url(\"https://example.com/x.png\")) { a { color: red; } } }"
+    })
+    @SneakyThrows
+    void keepAStylesheetWhoseAddressIsNotAResourceTest(String css) {
+        String html = "<style>" + css + "</style>";
+
+        assertTrue(processor.replaceResourcesAsBase64Encoded(html).contains("color"));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepTextWhichOnlyLooksLikeAStyleAttributeTest() {
+        // neither the text of the document nor the value of another attribute is a style attribute
+        String html = "<p>the style = big</p><div title=\"style=background:url(http://169.254.169.254/x)\">t</div>";
+
+        assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepACssStringHoldingAnAddressTest() {
+        // a string value is text, css fetches nothing from it, so the stylesheet stays usable
+        String html = "<style>/* see http://example.com */ body { content: \"https://example.com\"; color: red; }</style>";
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertTrue(result.contains("https://example.com"));
+        assertTrue(result.contains("color"));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepAForbiddenUrlOutOfAStyleAttributeTest() {
+        String address = "http://169.254.169.254/latest/meta-data/";
+        String html = "<div style=\"background: url(/*sneaky*/'" + address + "')\"></div>";
+        lenient().when(fileResourceProvider.isForbidden(address)).thenReturn(true);
+
+        assertFalse(processor.replaceResourcesAsBase64Encoded(html).contains("169.254.169.254"));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepsCommentLikeCharactersInsideAUrlTest() {
+        // '/*' and '*/' are legal inside a path, only a leading or a trailing comment is stripped
+        String url = "http://example.com/a/*b*/c.png";
+        String html = "<style>body { background: url(\"" + url + "\"); }</style>";
+        when(fileResourceProvider.getResourceAsBase64String(url)).thenReturn("data:image/png;base64,AAAA");
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        // the parser hands over the url as it stands, '/*' and '*/' in a path are part of it
+        verify(fileResourceProvider).getResourceAsBase64String(url);
+        assertTrue(result.contains("data:image/png;base64,AAAA"));
+    }
+
+    @Test
+    @SneakyThrows
+    void replaceForbiddenImageWrittenInUppercaseTest() {
+        // the base64 pass always runs on JSoup output, which lowercases the tag and quotes the attribute
+        String url = "http://169.254.169.254/latest/meta-data/";
+        String normalized = JSoupUtils.parseHtml("<div><IMG SRC=" + url + "></div>").body().html();
+        when(fileResourceProvider.isForbidden(url)).thenReturn(true);
+
+        String result = processor.replaceResourcesAsBase64Encoded(normalized);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
+    }
+
+    @Test
+    @SneakyThrows
+    void dropExternalCssImportEvenWhenAllowedTest() {
+        // the at-rule is never inlined, so WeasyPrint would load it itself, unchecked
+        String html = "<style>@import \"http://example.com/theme.css\" screen; body { color: red; }</style>";
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertFalse(result.contains("theme.css"));
+        assertTrue(result.contains("color"));
+    }
+
+    @Test
+    @SneakyThrows
+    void keepRelativeCssImportTest() {
+        // WeasyPrint cannot resolve a relative import, and it names no address, so it stays
+        String html = "<style>@import \"theme.css\"; body { color: red; }</style>";
+        assertEquals(html, processor.replaceResourcesAsBase64Encoded(html));
+    }
+
+    @Test
+    @SneakyThrows
+    void replaceUppercaseCssUrlTest() {
+        String html = "<style>body { background: URL(http://169.254.169.254/latest/meta-data/); }</style>";
+        lenient().when(fileResourceProvider.isForbidden("http://169.254.169.254/latest/meta-data/")).thenReturn(true);
+
+        String result = processor.replaceResourcesAsBase64Encoded(html);
+
+        assertFalse(result.contains("169.254.169.254"));
+        assertTrue(result.contains(MediaUtils.BLOCKED_RESOURCE_PLACEHOLDER));
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -18,10 +18,25 @@ import java.util.Set;
 
 import static ch.sbb.polarion.extension.pdf_exporter.util.MediaUtils.THUMBNAIL_PARAMETER;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, BundleJarsPrioritizingRunnableMockExtension.class, PdfExporterExtensionConfigurationExtension.class})
 class MediaUtilsTest {
+
+    @Test
+    void anUnplaceableRewriteIsNotClearedByALaterOneTest() {
+        // the flag answers "was every rewrite placed", so one that was not stands whatever follows it
+        MediaUtils.CssRewrite rewrite = new MediaUtils.CssRewrite();
+        assertTrue(rewrite.complete());
+
+        rewrite.missed(false);
+        rewrite.missed(true);
+
+        assertFalse(rewrite.complete());
+    }
+
 
     @Test
     void dataUrlTest() {
@@ -201,5 +216,49 @@ class MediaUtilsTest {
         g2d.fillRect(0, 0, image.getWidth(), image.getHeight());
         g2d.dispose();
     }
+
+
+    @Test
+    void recognizesAbsoluteHttpUrls() {
+        assertTrue(MediaUtils.isAbsoluteHttpUrl("http://example.com/img.png"));
+        assertTrue(MediaUtils.isAbsoluteHttpUrl(" HTTPS://example.com/img.png"));
+        assertFalse(MediaUtils.isAbsoluteHttpUrl(null));
+        assertTrue(MediaUtils.isAbsoluteHttpUrl("//example.com/img.png"));
+        assertFalse(MediaUtils.isAbsoluteHttpUrl("/polarion/img.png"));
+        assertFalse(MediaUtils.isAbsoluteHttpUrl("//"));
+        assertFalse(MediaUtils.isAbsoluteHttpUrl("data:image/png;base64,AAAA"));
+    }
+
+    @Test
+    void keepsDataUrlsWhileInlining() {
+        FileResourceProvider provider = mock(FileResourceProvider.class);
+        String html = "<div><img src=\"data:image/png;base64,AAAA\"/></div>";
+
+        assertEquals(html, MediaUtils.inlineBase64Resources(html, provider));
+        verifyNoInteractions(provider);
+    }
+
+    @Test
+    void normalizesUrlForTheRequestAndTheCheck() {
+        assertEquals("http://example.com/some%20path/img_name.png",
+                MediaUtils.normalizeUrl("http://example.com/some path/img%5Fname.png"));
+    }
+
+
+    @Test
+    void decodesCssEscapes() {
+        assertEquals("http://host/x", MediaUtils.decodeCssEscapes("http\\3a //host/x"));
+        assertEquals("http://host/x", MediaUtils.decodeCssEscapes("\\68 ttp\\3A //host/x"));
+        assertEquals("http://host/x", MediaUtils.decodeCssEscapes("http\\:" + "//host/x"));
+        assertEquals("plain", MediaUtils.decodeCssEscapes("plain"));
+    }
+
+    @Test
+    void turnsAnUnusableCssEscapeIntoTheReplacementCharacter() {
+        assertEquals("\uFFFD", MediaUtils.decodeCssEscapes("\\FFFFFF"));
+        assertEquals("\uFFFD", MediaUtils.decodeCssEscapes("\\0"));
+        assertEquals("\uFFFD", MediaUtils.decodeCssEscapes("\\D800"));
+    }
+
 
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/PdfExporterFileResourceProviderTest.java
@@ -1,5 +1,7 @@
 package ch.sbb.polarion.extension.pdf_exporter.util;
 
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
+
 import ch.sbb.polarion.extension.generic.test_extensions.PlatformContextMockExtension;
 import ch.sbb.polarion.extension.generic.test_extensions.TransactionalExecutorExtension;
 import com.polarion.alm.tracker.internal.url.GenericUrlResolver;
@@ -491,6 +493,66 @@ class PdfExporterFileResourceProviderTest {
             assertTrue(filteredResolvers.contains(mockResolver1));
             assertTrue(filteredResolvers.contains(mockResolver3));
             assertFalse(filteredResolvers.contains(mockResolver2));
+        }
+    }
+
+    @Test
+    void reportsUrlsRejectedByThePolicyAsForbidden() {
+        PdfExporterFileResourceProvider provider = new PdfExporterFileResourceProvider(
+                List.of(resolverMock), new ResourceUrlPolicy(ResourceUrlPolicy.Mode.BLOCK_INTERNAL, List.of(), null, 16));
+
+        // the address of a host is the request's own question, and the request binds to the answer:
+        // what is refused here is what stays refused whatever the host resolves to
+        assertFalse(provider.isForbidden("http://169.254.169.254/latest/meta-data/"));
+        assertFalse(provider.isForbidden("http://10.0.0.5/img.png"));
+        assertFalse(provider.isForbidden("HTTP://10.0.0.5/img.png"));
+        assertFalse(provider.isForbidden("https://8.8.8.8/img.png"));
+        // a url with a space is normalized the same way the resolver normalizes it before requesting
+        assertFalse(provider.isForbidden("https://8.8.8.8/some path/img.png"));
+        // nothing below is ever requested over the network, so nothing below may be replaced
+        assertFalse(provider.isForbidden("/polarion/wi-attachment/elibrary/EL-1/img.png"));
+        assertFalse(provider.isForbidden("data:image/png;base64,AAAA"));
+        assertFalse(provider.isForbidden("#gradient"));
+        assertFalse(provider.isForbidden("images/local.png"));
+        assertFalse(provider.isForbidden("//169.254.169.254/latest/meta-data/"));
+        assertFalse(provider.isForbidden("//8.8.8.8/img.png"));
+        // an absolute url which cannot be parsed at all must not reach WeasyPrint either
+        assertTrue(provider.isForbidden("http://[unterminated/img.png"));
+    }
+
+    @Test
+    void reportsUrlsRefusedByTheirOriginAsForbidden() {
+        // an allowlist refuses by the origin alone, and that answer holds before anything is resolved
+        PdfExporterFileResourceProvider provider = new PdfExporterFileResourceProvider(
+                List.of(resolverMock), new ResourceUrlPolicy(ResourceUrlPolicy.Mode.ALLOWLIST_ONLY, List.of("https://8.8.8.8"), null, 16));
+
+        assertFalse(provider.isForbidden("https://8.8.8.8/img.png"));
+        // the entry names https, and an entry names what it writes
+        assertTrue(provider.isForbidden("http://8.8.8.8/img.png"));
+        assertTrue(provider.isForbidden("https://8.8.4.4/img.png"));
+        // a network path reference is refused only where both of its spellings are
+        assertFalse(provider.isForbidden("//8.8.8.8/img.png"));
+        assertTrue(provider.isForbidden("//8.8.4.4/img.png"));
+        // and what is never requested over the network is never refused
+        assertFalse(provider.isForbidden("/polarion/wi-attachment/elibrary/EL-1/img.png"));
+        assertFalse(provider.isForbidden("images/local.png"));
+    }
+
+    @Test
+    void buildsItsResolversFromTheConfiguration() {
+        PdfExporterExtensionConfiguration configuration = mock(PdfExporterExtensionConfiguration.class);
+        IAttachmentUrlResolver parentUrlResolver = mock(IAttachmentUrlResolver.class);
+
+        try (MockedStatic<PdfExporterExtensionConfiguration> configurationMock = mockStatic(PdfExporterExtensionConfiguration.class);
+             MockedStatic<PolarionUrlResolver> polarionUrlResolverMock = mockStatic(PolarionUrlResolver.class)) {
+            configurationMock.when(PdfExporterExtensionConfiguration::getInstance).thenReturn(configuration);
+            polarionUrlResolverMock.when(PolarionUrlResolver::getInstance).thenReturn(parentUrlResolver);
+
+            PdfExporterFileResourceProvider provider = new PdfExporterFileResourceProvider();
+
+            // the default policy refuses nothing by its origin, it refuses by the address of the host
+            assertFalse(provider.isForbidden("http://10.0.0.5/img.png"));
+            assertFalse(provider.isForbidden("https://8.8.8.8/img.png"));
         }
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/ResourceUrlPolicyTest.java
@@ -1,0 +1,396 @@
+package ch.sbb.polarion.extension.pdf_exporter.util;
+
+import ch.sbb.polarion.extension.pdf_exporter.properties.PdfExporterExtensionConfiguration;
+import ch.sbb.polarion.extension.pdf_exporter.util.ResourceUrlPolicy.Mode;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class ResourceUrlPolicyTest {
+
+    private static final String BASE_URL = "http://localhost:80/polarion";
+
+    @SneakyThrows
+    private static URL url(String value) {
+        return URI.create(value).toURL();
+    }
+
+    private static ResourceUrlPolicy policy(Mode mode, List<String> allowedOrigins) {
+        return new ResourceUrlPolicy(mode, allowedOrigins, BASE_URL, 16);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://127.0.0.1:8080/secret",
+            "http://127.5.6.7/secret",
+            "http://[::1]/secret",
+            "http://10.0.0.5/secret",
+            "http://172.16.0.5/secret",
+            "http://192.168.1.5/secret",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[fd00::1]/secret",
+            "http://[fe80::1]/secret",
+            "http://100.64.0.1/secret",
+            "http://192.0.0.1/secret",
+            "http://198.18.0.1/secret",
+            "http://240.0.0.1/secret",
+            "http://0.0.0.0/secret",
+            "http://[::ffff:127.0.0.1]/secret",
+            "http://[2002:7f00:0001::]/secret",
+            "http://[2002:0a00:0005::]/secret",
+            "http://[2002:a9fe:a9fe::]/secret",
+            "http://[2001:0:1::1]/secret",
+            "http://224.0.0.1/secret"
+    })
+    void blocksNonPublicAddresses(String value) {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://8.8.8.8/img.png",
+            "https://93.184.216.34/img.png",
+            "http://[2606:4700:4700::1111]/img.png",
+            "http://[2002:0808:0808::]/img.png"
+    })
+    void allowsPublicAddresses(String value) {
+        assertTrue(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ftp://8.8.8.8/img.png", "file:///etc/passwd", "jar:http://8.8.8.8/a.jar!/img.png"})
+    void blocksForeignSchemes(String value) {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
+    }
+
+    @Test
+    void blocksUnresolvableHost() {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url("http://unresolvable-host.invalid/img.png")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://[2002:ac10:0005::]/secret",  // 6to4 of 172.16.0.5
+            "http://[2002:c0a8:0105::]/secret",  // 6to4 of 192.168.1.5
+            "http://[2002:e000:0001::]/secret",  // 6to4 of 224.0.0.1
+            "http://[2002:6440:0001::]/secret",  // 6to4 of 100.64.0.1
+            "http://[2002:c000:0001::]/secret",  // 6to4 of 192.0.0.1
+            "http://[2002:c612:0001::]/secret",  // 6to4 of 198.18.0.1
+            "http://[2002:c613:0001::]/secret",  // 6to4 of 198.19.0.1
+            "http://[2002:0000:0001::]/secret",  // 6to4 of 0.0.0.1
+            "http://[2002:f000:0001::]/secret",  // 6to4 of 240.0.0.1
+            "http://[64:ff9b::a9fe:a9fe]/secret", // NAT64 well known prefix carrying 169.254.169.254
+            "http://[64:ff9b:1::1]/secret"       // NAT64 local use prefix, the address can sit anywhere in it
+    })
+    void blocksNonPublicAddressesEmbeddedInIpv6(String value) {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://[2002:ac0f:0001::]/img.png",  // 6to4 of 172.15.0.1, just below the private range
+            "http://[2002:ac20:0001::]/img.png",  // 6to4 of 172.32.0.1, just above it
+            "http://[2002:a9fd:0001::]/img.png",  // 6to4 of 169.253.0.1, not link local
+            "http://[2002:643f:0001::]/img.png",  // 6to4 of 100.63.0.1, below the shared range
+            "http://[2002:6480:0001::]/img.png",  // 6to4 of 100.128.0.1, above it
+            "http://[2002:c000:0101::]/img.png",  // 6to4 of 192.0.1.1, outside 192.0.0.0/24
+            "http://[2002:c001:0001::]/img.png",  // 6to4 of 192.1.0.1
+            "http://[2002:c611:0001::]/img.png",  // 6to4 of 198.17.0.1, below the benchmark range
+            "http://[2002:c614:0001::]/img.png",  // 6to4 of 198.20.0.1, above it
+            "http://[2001:0100::1]/img.png",      // not Teredo, the third byte is set
+            "http://[2001:0001::1]/img.png",      // not Teredo, the fourth byte is set
+            "http://[2003::1]/img.png",           // not Teredo, the second byte differs
+            "http://[64:ff9b::808:808]/img.png",  // NAT64 well known prefix carrying 8.8.8.8
+            "http://[64:ff9c::1]/img.png"         // next to the NAT64 prefix, not in it
+    })
+    void allowsPublicAddressesNextToTheBlockedRanges(String value) {
+        assertTrue(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url(value)));
+    }
+
+    @Test
+    @SneakyThrows
+    void classifiesIpv4EmbeddedInIpv6() {
+        assertFalse(ResourceUrlPolicy.isPublicAddress(ipv6(compatible(10, 0, 0, 5))));
+        assertTrue(ResourceUrlPolicy.isPublicAddress(ipv6(compatible(8, 8, 8, 8))));
+        assertFalse(ResourceUrlPolicy.isPublicAddress(ipv6(mapped(127, 0, 0, 1))));
+        assertTrue(ResourceUrlPolicy.isPublicAddress(ipv6(mapped(8, 8, 8, 8))));
+        // the tenth byte is set, so nothing is embedded and the address stays a plain public IPv6 one
+        byte[] notEmbedded = compatible(10, 0, 0, 5);
+        notEmbedded[9] = 1;
+        assertTrue(ResourceUrlPolicy.isPublicAddress(ipv6(notEmbedded)));
+
+        // only 0x0000 and 0xFFFF in the eleventh and twelfth byte mark an embedded IPv4 address
+        byte[] halfZero = compatible(10, 0, 0, 5);
+        halfZero[11] = 5;
+        assertTrue(ResourceUrlPolicy.isPublicAddress(ipv6(halfZero)));
+        byte[] halfMapped = mapped(10, 0, 0, 5);
+        halfMapped[11] = 0;
+        assertTrue(ResourceUrlPolicy.isPublicAddress(ipv6(halfMapped)));
+    }
+
+    @SneakyThrows
+    private static InetAddress ipv6(byte[] address) {
+        return Inet6Address.getByAddress(null, address, 0);
+    }
+
+    private static byte[] compatible(int a, int b, int c, int d) {
+        return new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) a, (byte) b, (byte) c, (byte) d};
+    }
+
+    private static byte[] mapped(int a, int b, int c, int d) {
+        return new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xFF, (byte) 0xFF, (byte) a, (byte) b, (byte) c, (byte) d};
+    }
+
+    @Test
+    void blocksUrlWithoutHost() {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowed(url("http:///img.png")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"   ", "not-a-url", "http://[unterminated"})
+    void survivesAnUnusableBaseUrlValue(String baseUrl) {
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, Arrays.asList("8.8.4.4", null), baseUrl, 16);
+        assertTrue(policy.isAllowed(url("https://8.8.4.4/img.png")));
+        assertFalse(policy.isAllowed(url("http://10.0.0.5/img.png")));
+    }
+
+    @Test
+    void allowsPolarionBaseUrlItself() {
+        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of());
+        assertTrue(policy.isAllowed(url("http://localhost/polarion/some-resource.png")));
+        assertTrue(policy.isAllowed(url("http://LOCALHOST:80/polarion/some-resource.png")));
+        assertFalse(policy.isAllowed(url("http://localhost:8080/polarion/some-resource.png")));
+    }
+
+    @Test
+    void tellsWhichUrlsTheConfigurationTrustsAsSuch() {
+        ResourceUrlPolicy policy = policy(Mode.BLOCK_INTERNAL, List.of("8.8.4.4"));
+        assertTrue(policy.isExplicitlyTrusted(url("https://8.8.4.4/img.png")));
+        assertTrue(policy.isExplicitlyTrusted(url("http://localhost/polarion/img.png")));
+        assertFalse(policy.isExplicitlyTrusted(url("https://8.8.8.8/img.png")));
+        assertFalse(policy.isExplicitlyTrusted(url("http:///img.png")));
+        assertTrue(policy(Mode.ALLOW_ALL, List.of()).isExplicitlyTrusted(url("https://8.8.8.8/img.png")));
+    }
+
+    @Test
+    void readsTheSchemeOfTheBaseUrl() {
+        assertEquals("http", policy(Mode.BLOCK_INTERNAL, List.of()).getBaseUrlScheme());
+        assertEquals("https", new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), "https://polarion.example", 16).getBaseUrlScheme());
+        assertEquals("http", new ResourceUrlPolicy(Mode.BLOCK_INTERNAL, List.of(), null, 16).getBaseUrlScheme());
+    }
+
+    @Test
+    void allowsExplicitlyListedOrigins() {
+        // an allowed origin still has to resolve, so the test uses addresses instead of invented names
+        ResourceUrlPolicy policy = policy(Mode.BLOCK_INTERNAL, List.of(" 10.0.0.5 ", "127.0.0.1:8443", ""));
+        assertTrue(policy.isAllowed(url("http://10.0.0.5/img.png")));
+        assertTrue(policy.isAllowed(url("https://127.0.0.1:8443/img.png")));
+        assertFalse(policy.isAllowed(url("https://127.0.0.1/img.png")));
+        assertFalse(policy.isAllowed(url("http://10.0.0.6/img.png")));
+    }
+
+    @Test
+    void allowsAnOriginUnderTheSchemeItNames() {
+        // what an entry leaves out is not compared, and a scheme names the port it implies
+        ResourceUrlPolicy policy = policy(Mode.BLOCK_INTERNAL, List.of("https://10.0.0.5", "http://10.0.0.6:8080"));
+
+        assertTrue(policy.isAllowed(url("https://10.0.0.5/img.png")));
+        assertFalse(policy.isAllowed(url("http://10.0.0.5/img.png")));
+        assertFalse(policy.isAllowed(url("https://10.0.0.5:8443/img.png")));
+        assertTrue(policy.isAllowed(url("http://10.0.0.6:8080/img.png")));
+        assertFalse(policy.isAllowed(url("https://10.0.0.6:8080/img.png")));
+        assertFalse(policy.isAllowed(url("http://10.0.0.6/img.png")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ftp://10.0.0.5",            // only http and https can be requested
+            "https://10.0.0.5:99999",    // no port
+            "https://10.0.0.5/secured/", // an origin names no path
+            "https://10.0.0.5?q=1",
+            "http://",
+            "://10.0.0.5"
+    })
+    void ignoresAnEntryWhichNamesNoOrigin(String entry) {
+        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of(entry));
+
+        assertFalse(policy.isAllowed(url("https://10.0.0.5/img.png")));
+        assertFalse(policy.isAllowed(url("http://10.0.0.5/img.png")));
+    }
+
+    @Test
+    void allowlistOnlyRejectsEverythingElse() {
+        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of("8.8.4.4"));
+        assertTrue(policy.isAllowed(url("https://8.8.4.4/img.png")));
+        assertFalse(policy.isAllowed(url("https://8.8.8.8/img.png")));
+    }
+
+    @Test
+    void tellsWhetherARefusalTurnedOnTheScheme() {
+        // an entry naming a scheme allows that spelling of the host and no other
+        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of("https://cdn.example.com", "https://other.example.com:8443"));
+
+        assertTrue(policy.isRefusalSchemeSpecific(url("http://cdn.example.com/logo.png")));
+        assertFalse(policy.isRefusalSchemeSpecific(url("https://cdn.example.com/logo.png")));
+        // a written port keeps the question open, the entry may name the other scheme on that port
+        assertTrue(policy.isRefusalSchemeSpecific(url("http://other.example.com:8443/logo.png")));
+        assertFalse(policy.isRefusalSchemeSpecific(url("http://unlisted.example.com/logo.png")));
+    }
+
+    @Test
+    void tellsNothingTurnsOnTheSchemeWhereTheEntryNamesNone() {
+        ResourceUrlPolicy policy = policy(Mode.ALLOWLIST_ONLY, List.of("cdn.example.com"));
+
+        assertFalse(policy.isRefusalSchemeSpecific(url("http://cdn.example.com/logo.png")));
+        assertFalse(policy.isRefusalSchemeSpecific(url("https://cdn.example.com/logo.png")));
+    }
+
+    @Test
+    void allowAllRejectsNothingButForeignSchemes() {
+        ResourceUrlPolicy policy = policy(Mode.ALLOW_ALL, List.of());
+        assertTrue(policy.isAllowed(url("http://127.0.0.1:8080/secret")));
+        assertTrue(policy.isAllowed(url("http://169.254.169.254/latest/meta-data/")));
+        assertFalse(policy.isAllowed(url("ftp://127.0.0.1/secret")));
+    }
+
+    @Test
+    @SneakyThrows
+    void handlesUnusableBaseUrl() {
+        ResourceUrlPolicy policy = new ResourceUrlPolicy(Mode.ALLOWLIST_ONLY, null, null, 16);
+        assertFalse(policy.isAllowed(url("http://localhost/polarion/some-resource.png")));
+        assertTrue(ResourceUrlPolicy.isPublicAddress(InetAddress.getByName("8.8.8.8")));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "BLOCK_INTERNAL,BLOCK_INTERNAL",
+            " ALLOWLIST_ONLY ,ALLOWLIST_ONLY",
+            "ALLOW_ALL,ALLOW_ALL",
+            // one of the three names, written exactly so, and anything else is the safe mode
+            "blockInternal,BLOCK_INTERNAL",
+            "block_internal,BLOCK_INTERNAL",
+            "allow_all,BLOCK_INTERNAL",
+            "ALLOW-ALL,BLOCK_INTERNAL",
+            "nonsense,BLOCK_INTERNAL",
+            "'',BLOCK_INTERNAL"
+    })
+    void parsesMode(String value, Mode expected) {
+        assertEquals(expected, Mode.parse(value));
+    }
+
+    @Test
+    void parsesMissingMode() {
+        assertEquals(Mode.BLOCK_INTERNAL, Mode.parse(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"image/png", "IMAGE/SVG+XML", "image/jpeg; charset=binary", "font/woff2",
+            "application/font-woff", "application/x-font-ttf", "text/css", "application/octet-stream", "  "})
+    void allowsResourceContentTypes(String contentType) {
+        assertTrue(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowedContentType(contentType));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"application/json", "text/html", "text/plain", "application/xml"})
+    void rejectsForeignContentTypes(String contentType) {
+        assertFalse(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowedContentType(contentType));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            // the sender named a kind and the content is one: believed
+            "image/png,image/png,false",
+            "font/woff2,font/woff2,false",
+            "image/svg+xml,image/svg+xml,false",
+            // a stylesheet and an svg read as text, and the sender named one of those two
+            "text/css,text/plain,false",
+            "text/css; charset=utf-8,text/plain,false",
+            "image/svg+xml,text/plain,false",
+            "image/svg+xml,application/xml,false",
+            // the sender named a shape the content does not have
+            "image/png,text/plain,true",
+            "image/png,application/octet-stream,true",
+            "font/woff2,application/octet-stream,true",
+            "image/png,text/html,true",
+            "font/woff2,application/json,true",
+            "text/css,text/html,true",
+            // the sender named nothing usable, so the content alone answers
+            "'',image/png,false",
+            "application/octet-stream,image/png,false",
+            "application/octet-stream,text/plain,true",
+            "'',text/plain,true",
+            "'',application/xml,true"
+    })
+    void judgesTheContentAgainstWhatItsSenderCalledIt(String declared, String sniffed, boolean rejected) {
+        assertEquals(rejected, policy(Mode.BLOCK_INTERNAL, List.of()).isRejectedContent(declared, sniffed));
+    }
+
+    @Test
+    void believesASenderWhichNamedAKindWhenNothingCouldBeDetected() {
+        ResourceUrlPolicy policy = policy(Mode.BLOCK_INTERNAL, List.of());
+
+        assertFalse(policy.isRejectedContent("image/png", null));
+        assertTrue(policy.isRejectedContent(null, null));
+        assertTrue(policy.isRejectedContent("application/octet-stream", null));
+    }
+
+    @Test
+    void acceptsMissingContentType() {
+        assertTrue(policy(Mode.BLOCK_INTERNAL, List.of()).isAllowedContentType(null));
+    }
+
+    @Test
+    void readsItsConfiguration() {
+        PdfExporterExtensionConfiguration configuration = mock(PdfExporterExtensionConfiguration.class);
+        when(configuration.getExternalResourcesPolicy()).thenReturn("ALLOWLIST_ONLY");
+        when(configuration.getExternalResourcesAllowedOrigins()).thenReturn("8.8.4.4, https://10.0.0.5");
+        when(configuration.getExternalResourcesMaxSizeMB()).thenReturn(4);
+
+        try (MockedStatic<PdfExporterExtensionConfiguration> mocked = mockStatic(PdfExporterExtensionConfiguration.class)) {
+            mocked.when(PdfExporterExtensionConfiguration::getInstance).thenReturn(configuration);
+
+            ResourceUrlPolicy policy = ResourceUrlPolicy.getInstance();
+            assertEquals(4L * 1024 * 1024, policy.getMaxResourceBytes());
+            assertTrue(policy.isAllowed(url("https://8.8.4.4/img.png")));
+            // the entry of that one names https, so the http spelling of it is no allowed origin
+            assertTrue(policy.isAllowed(url("https://10.0.0.5/img.png")));
+            assertFalse(policy.isAllowed(url("http://10.0.0.5/img.png")));
+            assertFalse(policy.isAllowed(url("https://8.8.8.8/img.png")));
+        }
+    }
+
+    @Test
+    void fallsBackWhenTheConfigurationIsEmpty() {
+        PdfExporterExtensionConfiguration configuration = mock(PdfExporterExtensionConfiguration.class);
+
+        try (MockedStatic<PdfExporterExtensionConfiguration> mocked = mockStatic(PdfExporterExtensionConfiguration.class)) {
+            mocked.when(PdfExporterExtensionConfiguration::getInstance).thenReturn(configuration);
+
+            ResourceUrlPolicy policy = ResourceUrlPolicy.getInstance();
+            assertEquals(16L * 1024 * 1024, policy.getMaxResourceBytes());
+            assertFalse(policy.isAllowed(url("http://127.0.0.1/secret")));
+        }
+    }
+
+    @Test
+    void convertsSizeLimitToBytes() {
+        assertEquals(16L * 1024 * 1024, policy(Mode.BLOCK_INTERNAL, List.of()).getMaxResourceBytes());
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/TikaMimeTypeResolverTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/TikaMimeTypeResolverTest.java
@@ -98,35 +98,35 @@ class TikaMimeTypeResolverTest {
     }
 
     @Test
-    void testRunWithUnknownFileNameReturnsEmptyOptional() {
+    void testRunWithUnknownFileNameReportsUnknownBytes() {
         Map<String, Object> input = Map.of(TikaMimeTypeResolver.PARAM_VALUE, "unknown_file");
         Map<String, Object> result = resolver.run(input);
 
         assertThat(result).containsKey(TikaMimeTypeResolver.PARAM_RESULT);
         Optional<String> mimeType = (Optional<String>) result.get(TikaMimeTypeResolver.PARAM_RESULT);
-        assertThat(mimeType).isEmpty();
+        assertThat(mimeType).contains("application/octet-stream");
     }
 
     @Test
-    void testRunWithEmptyByteArrayReturnsEmptyOptional() {
+    void testRunWithEmptyByteArrayReportsUnknownBytes() {
         byte[] emptyContent = new byte[0];
         Map<String, Object> input = Map.of(TikaMimeTypeResolver.PARAM_VALUE, emptyContent);
         Map<String, Object> result = resolver.run(input);
 
         assertThat(result).containsKey(TikaMimeTypeResolver.PARAM_RESULT);
         Optional<String> mimeType = (Optional<String>) result.get(TikaMimeTypeResolver.PARAM_RESULT);
-        assertThat(mimeType).isEmpty();
+        assertThat(mimeType).contains("application/octet-stream");
     }
 
     @Test
-    void testRunWithRandomByteArrayReturnsEmptyOptional() {
+    void testRunWithRandomByteArrayReportsUnknownBytes() {
         byte[] randomContent = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
         Map<String, Object> input = Map.of(TikaMimeTypeResolver.PARAM_VALUE, randomContent);
         Map<String, Object> result = resolver.run(input);
 
         assertThat(result).containsKey(TikaMimeTypeResolver.PARAM_RESULT);
         Optional<String> mimeType = (Optional<String>) result.get(TikaMimeTypeResolver.PARAM_RESULT);
-        assertThat(mimeType).isEmpty();
+        assertThat(mimeType).contains("application/octet-stream");
     }
 
 

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizerTest.java
@@ -108,4 +108,34 @@ class ExternalCssInternalizerTest {
         Optional<String> result = cssLinkInliner.inline(Map.of("rel", rel, "href", "my-href-location"));
 
         assertThat(result).isEmpty();
-    }}
+    }
+    @Test
+    void shouldKeepAValueOfTheDocumentInsideItsAttribute() {
+        // the value is written back as markup, so a quote in it may not end the attribute it sits in
+        when(fileResourceProvider.getResourceAsBytes("my-href-location")).thenReturn("body{color:red}".getBytes());
+
+        Optional<String> result = cssLinkInliner.inline(Map.of(
+                "rel", "stylesheet",
+                "href", "my-href-location",
+                "data-precedence", "x\"><img src=http://169.254.169.254/x>"));
+
+        assertThat(result).isPresent();
+        assertThat(result.get())
+                .doesNotContain("<img src=http://169.254.169.254/x>")
+                .contains("&quot;&gt;&lt;img");
+    }
+
+    @Test
+    void shouldKeepAStylesheetInsideItsStyleElement() {
+        // a style element ends at the first closing tag written in it, and a stylesheet may carry one
+        when(fileResourceProvider.getResourceAsBytes("my-href-location"))
+                .thenReturn("a::after{content:\"</style><img src=http://169.254.169.254/x>\"}".getBytes());
+
+        Optional<String> result = cssLinkInliner.inline(Map.of("rel", "stylesheet", "href", "my-href-location"));
+
+        assertThat(result).isPresent();
+        assertThat(result.get())
+                .doesNotContain("</style><img")
+                .endsWith("</style>");
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizerTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/html/ExternalCssInternalizerTest.java
@@ -3,6 +3,8 @@ package ch.sbb.polarion.extension.pdf_exporter.util.html;
 import ch.sbb.polarion.extension.pdf_exporter.configuration.PdfExporterExtensionConfigurationExtension;
 import ch.sbb.polarion.extension.pdf_exporter.util.FileResourceProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -86,4 +88,24 @@ class ExternalCssInternalizerTest {
                 "src: url('/non-relative/fonts/some-font3.woff')"
         );
     }
-}
+    @ParameterizedTest
+    @ValueSource(strings = {"stylesheet", "Stylesheet", "STYLESHEET", "stylesheet ", " stylesheet"})
+    void internalizesEverySpellingOfTheRelAStylesheetHas(String rel) {
+        // a renderer reads rel as a list of tokens, each case insensitive, and loads all of these
+        when(fileResourceProvider.getResourceAsBytes("my-href-location")).thenReturn("test-stylesheet".getBytes());
+
+        Optional<String> result = cssLinkInliner.inline(Map.of("rel", rel, "href", "my-href-location"));
+
+        assertThat(result).contains("<style>test-stylesheet</style>");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"icon", "preload", "stylesheets", "nostylesheet",
+            // an alternative style sheet is skipped by a renderer until someone selects it, and nothing
+            // selects one in an export: measured, weasyprint-service does not ask for such a link
+            "alternate stylesheet", "stylesheet alternate", "Alternate Stylesheet"})
+    void keepsALinkWhichNamesNoStylesheet(String rel) {
+        Optional<String> result = cssLinkInliner.inline(Map.of("rel", rel, "href", "my-href-location"));
+
+        assertThat(result).isEmpty();
+    }}

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/html/HtmlLinksHelperTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/html/HtmlLinksHelperTest.java
@@ -3,6 +3,8 @@ package ch.sbb.polarion.extension.pdf_exporter.util.html;
 import ch.sbb.polarion.extension.pdf_exporter.configuration.PdfExporterExtensionConfigurationExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -50,5 +52,33 @@ class HtmlLinksHelperTest {
         ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
         verify(linkInternalizer1).inline(captor.capture());
         assertThat(captor.getValue()).containsExactly(Map.entry("attr1", "value1"), Map.entry("attr2", "value2")); // also it must lowercase attributes
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // a renderer reads each of these as one link, so each of them reaches an inliner here
+            "<link rel=stylesheet href=http://169.254.169.254/x.css>",
+            "<link rel='stylesheet' href=http://169.254.169.254/x.css>",
+            "<link rel=\"stylesheet\" href=\"http://169.254.169.254/x.css?a=>b\">",
+            "<link REL=Stylesheet HREF='http://169.254.169.254/x.css'>",
+            "<link\n   rel = 'stylesheet'\n   href = 'http://169.254.169.254/x.css'>"
+    })
+    void shouldReadALinkWhateverItsAttributesLookLike(String linkTag) {
+        when(linkInternalizer1.inline(anyMap())).thenReturn(Optional.of("<style>replacement</style>"));
+
+        String resultHtml = htmlLinksHelper.internalizeLinks("<html lang='en'><head>" + linkTag + "</head>");
+
+        assertThat(resultHtml)
+                .isEqualTo("<html lang='en'><head><style>replacement</style></head>")
+                .doesNotContain("169.254.169.254");
+    }
+
+    @Test
+    void shouldReadTheAddressOfALinkWithoutQuotes() {
+        Map<String, String> attributes = HtmlLinksHelper.parseLinkTagAttributes(
+                "<link rel=stylesheet href=http://169.254.169.254/x.css>");
+
+        assertThat(attributes).containsExactly(
+                Map.entry("rel", "stylesheet"), Map.entry("href", "http://169.254.169.254/x.css"));
     }
 }


### PR DESCRIPTION
## What

An authenticated document editor could make the Polarion server fetch an arbitrary HTTP(S) address and receive the whole answer inside the exported file. Any image, font or stylesheet url in a Live Document, in a cover page or in a header or footer was loaded by the server and embedded. That reaches whatever the server reaches: an internal service, an admin interface, the cloud metadata endpoint `169.254.169.254`.

This restricts what may be loaded, and binds each request to what was checked.

## How

**The address, not just the name.** `ResourceUrlPolicy` resolves the host and approves the addresses; `CustomResourceUrlResolver` builds a client whose `DnsResolver` answers with exactly those for that host and delegates every other name. A second lookup therefore cannot return an address the policy never saw. Loopback, private, link local, CGNAT and their IPv6 spellings are refused, 6to4, Teredo, IPv4-mapped and both NAT64 prefixes included.

**Every hop.** Automatic redirects are off. Each hop is vetted again, at most five of them.

**What comes back.** The header must name an image, a font or a stylesheet, and the content has to agree: an image and a font have a shape, while a stylesheet and an SVG read as text and are believed only where the sender named one of those two. A content nothing was recognized in is refused whatever the header claimed. The body is capped by `Content-Length` and again while streaming, 16 MB by default.

**Proxies.** The proxy setup is read once per request and that answer both decides and routes, so nothing can be routed past the decision. A proxy resolves the host name itself, so a proxied request is made only for a host the configuration trusts, and never when the route could not be named. Such a request does not resolve the host here either: a server whose egress is the proxy usually cannot. A SOCKS proxy is applied by the JVM under the connection, which keeps the address binding: the socket carries the vetted address, never the name.

**The markup.** The html and the css are read by parsers - jsoup with position tracking, ph-css at the positions it reports - and every url is rewritten where it stands, so no pattern runs over editor-controlled text and the formatting of the document survives. An attribute is read as the html parser read it, entities resolved, and written back escaped. What a conversion service would read from somewhere of its own is replaced by a 1x1 transparent png: an address in any scheme, and a path from the root of the file system where the document carries no base to resolve it against. An `@import` of such an address is removed, since an at-rule cannot be embedded and the service would fetch it itself. A stylesheet naming an address that nothing accounted for is dropped whole, which is the fail-closed backstop for anything the parser did not read.

## Measured, not assumed

Which constructs are covered was decided by running the two conversion services against a listener and against files placed inside their containers:

| Construct | pandoc-service | weasyprint-service |
| --- | --- | --- |
| `img[src]` | fetched | fetched |
| `iframe[src]` | fetched | no |
| `object[data]`, `embed[src]` | no | fetched |
| `url()` in `<style>` and in a `style` attribute | no | fetched |
| `<link rel="stylesheet">`, `rel="Stylesheet"`, `rel="stylesheet "` | - | fetched |
| `<link rel="alternate stylesheet">`, `rel="preload"`, `rel="icon"` | - | no |
| `file:///…` as an image | embedded it | no |
| `file:///…` through an `@import` | - | read it |
| a path from the root, no base in the document | embedded `/etc/hostname` into the export | no |
| a path from the root, with `<base href>` | fetched it from the base | - |
| `<svg><image href>`, `xlink:href`, `<use href>`, `srcset`, `poster`, `input[type=image]`, `table[background]` | no | no |

Everything a service reads is covered. The inline-svg image reference is rewritten too, a data url being valid there; the rest is left alone, since rewriting an attribute nothing reads only risks breaking a document.

Two parser details were measured the same way, because every position in this change rests on them: ph-css ends a line on a lone carriage return, and counts a tab as eight columns unless told otherwise. Both are now read the way the parser reads them.

## Configuration

```properties
# BLOCK_INTERNAL (default) - public addresses, the Polarion server and the allowed origins
# ALLOWLIST_ONLY           - only the Polarion server and the allowed origins
# ALLOW_ALL                - no restriction, this exposes the server's network to document editors
ch.sbb.polarion.extension.pdf-exporter.externalResources.policy=BLOCK_INTERNAL
ch.sbb.polarion.extension.pdf-exporter.externalResources.allowedOrigins=cdn.intranet,https://images.intranet:8443
ch.sbb.polarion.extension.pdf-exporter.externalResources.maxSizeMB=16
```

The policy is one of the three names, written exactly so: a setting which is nearly right is a setting whose author expects something else to happen.

An allowed origin is written `[scheme://]host[:port]`, and what it leaves out is not compared:

| Entry | What it allows |
| --- | --- |
| `cdn.intranet` | that host under either scheme, on any port |
| `cdn.intranet:8443` | that host on port 8443, under either scheme |
| `https://cdn.intranet` | that host under https, on port 443 |
| `https://cdn.intranet:8443` | that host under https, on port 8443 |

The README section "External resources" describes the modes, the origins, what a generic content type means, the removal of `@import` and the proxy behaviour.

## What stays as it was

A url written `/some/path` is resolved against `base.url` as before, and the origin of the Polarion server itself is exempt in every mode. A relative url is never rewritten. A document which loads nothing external is unaffected.

## Tests

`ResourceUrlPolicyTest` (address classification, modes, origins, the header against the content, sizes), `CustomResourceUrlResolverTest` (an embedded HTTP server: pinning, redirects, caps, unknown bytes, proxy classification and routing, a proxied fetch of a host with no address, SOCKS down to the bytes it sends), `HtmlProcessorTest` and `MediaUtilsTest` (url and import syntaxes, css escapes, html entities, line breaks, tabs, every attribute a converter reads, the drop guard), `ExternalCssInternalizerTest` (every spelling of `rel`), provider, resolver and configuration coverage.

## Compatibility

Uses the Apache HttpClient 4.5.14 bundle Polarion ships, declared `provided` with a matching `Require-Bundle`. A document which loads an internal resource loses it unless its origin is listed, and the log says which resource was skipped and why.
