### PR TITLE
build: switch to @sbb-polarion/react-sbb-polarion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **`ch.sbb.polarion.extension.generic`** is the parent project providing reusable infrastructure for all Polarion plugins in this org (settings framework, REST base classes, OSGi helpers, etc.). Before implementing anything cross-cutting, check if it already exists there.
 - **All administration pages are React now.** They were converted to
-  [react-sbb-polarion](https://github.com/grigoriev/react-sbb-polarion) one at a time, and
+  [react-sbb-polarion](https://github.com/SchweizerischeBundesbahnen/react-sbb-polarion) one at a time, and
   `pdf-exporter-app` (the Vite bundle in `ui/`, see [`ui/README.md`](ui/README.md)) serves every one of
   them. `hivemodule.xml` carries a `pageUrl` per menu entry; the ids there must match
   `ui/src/features.tsx` - a mismatch is a blank page and no test catches it. The legacy

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,6 +1,6 @@
 # PDF Exporter UI
 
-A React + Vite single-page app on [react-sbb-polarion](https://github.com/grigoriev/react-sbb-polarion)
+A React + Vite single-page app on [react-sbb-polarion](https://github.com/SchweizerischeBundesbahnen/react-sbb-polarion)
 (RSP), served from the `pdf-exporter-app` webapp.
 
 It replaced the JSP administration UI **page by page**, and every administration entry of the extension

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,7 +7,7 @@
     <!-- Baseline Polarion look. Served by Polarion in production; 404s harmlessly during `vite dev`. -->
     <link rel="stylesheet" href="/polarion/wiki/skins/sidecar/presentation.css" />
     <!-- Control tokens + searchable-dropdown / inputs / buttons / alerts CSS ship bundled in
-         @grigoriev/react-sbb-polarion (imported in main.tsx), not linked from generic. -->
+         @sbb-polarion/react-sbb-polarion (imported in main.tsx), not linked from generic. -->
     <!-- Markdown styling for the About page README help article (served by GenericUiServlet). -->
     <link rel="stylesheet" href="/polarion/pdf-exporter-app/ui/generic/css/github-markdown-light.css" />
   </head>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pdf-exporter-app",
       "version": "1.0.0",
       "dependencies": {
-        "@grigoriev/react-sbb-polarion": "^0.2.0",
+        "@sbb-polarion/react-sbb-polarion": "^1.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "sonner": "^2.0.7"
@@ -658,24 +658,6 @@
         }
       }
     },
-    "node_modules/@grigoriev/react-sbb-polarion": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.2.0.tgz",
-      "integrity": "sha512-Yiuy22TWG5qWVJLYQx/b0FrMip/FJmfiGp6vUPcXN2JYILTmvuXTPK7vBTWbVOc8cobtnyPRtIx7h+IFn0JzmQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "refractor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=24.0.0",
-        "npm": ">=11"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "sonner": "^2.0.7"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1081,6 +1063,24 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sbb-polarion/react-sbb-polarion": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sbb-polarion/react-sbb-polarion/-/react-sbb-polarion-1.0.0.tgz",
+      "integrity": "sha512-hTk4oewJvkUL02blEktAJXMc4IiyftaG6fH4+viNP5wdH12mJxKMfHZAmB4xA50vnvFrfdZDhLrxPP/+fC6VwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "refractor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=11"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "sonner": "^2.0.7"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@grigoriev/react-sbb-polarion": "^0.2.0",
+    "@sbb-polarion/react-sbb-polarion": "^1.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sonner": "^2.0.7"

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -103,7 +103,7 @@
 }
 
 /* The About page (and its .markdown-body README article headings) is the shared
-   @grigoriev/react-sbb-polarion component; its styles ship in the lib's bundled style.css. */
+   @sbb-polarion/react-sbb-polarion component; its styles ship in the lib's bundled style.css. */
 
 /* The editor fills the page below the tab bar: the stylesheets these pages hold are long, and the
    legacy page gave them the same full-height box. RSP's CodeEditor fills whatever it is given. */

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { Toaster } from '@grigoriev/react-sbb-polarion';
+import { Toaster } from '@sbb-polarion/react-sbb-polarion';
 import { findFeature } from './features';
 import Landing from './pages/Landing';
 

--- a/ui/src/components/CustomTemplatesPage.tsx
+++ b/ui/src/components/CustomTemplatesPage.tsx
@@ -9,7 +9,7 @@ import {
   RevisionsTable,
   Tabs,
   useConfirm,
-} from '@grigoriev/react-sbb-polarion';
+} from '@sbb-polarion/react-sbb-polarion';
 import { toast } from 'sonner';
 import { getScope } from '../services/scope';
 import useNamedSettings from '../services/settings';

--- a/ui/src/components/DocumentPicker.tsx
+++ b/ui/src/components/DocumentPicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import { getCookie, setCookie } from '../services/cookies';
 import { MAX_PAGES, documentPath, fetchDocuments } from '../services/documents';
 import type { ProjectDocument } from '../services/documents';

--- a/ui/src/export/exportData.ts
+++ b/ui/src/export/exportData.ts
@@ -1,4 +1,4 @@
-import type { SelectOption, SendRequest, SettingName } from '@grigoriev/react-sbb-polarion';
+import type { SelectOption, SendRequest, SettingName } from '@sbb-polarion/react-sbb-polarion';
 import type { DocumentIdentity } from '../services/exportContext';
 import { CHILD_SETTINGS, type ChildNames, NO_CHILD_NAMES, type StylePackageSettings } from '../services/stylePackage';
 import type { DocumentType, ExportType } from './documentType';

--- a/ui/src/export/exportForm.ts
+++ b/ui/src/export/exportForm.ts
@@ -1,4 +1,4 @@
-import type { SelectOption } from '@grigoriev/react-sbb-polarion';
+import type { SelectOption } from '@sbb-polarion/react-sbb-polarion';
 import {
   DEFAULT_HEADERS_COLOR,
   DEFAULT_IMAGE_DENSITY,

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { configureGenericModules } from '@grigoriev/react-sbb-polarion';
-import '@grigoriev/react-sbb-polarion/style.css';
+import { configureGenericModules } from '@sbb-polarion/react-sbb-polarion';
+import '@sbb-polarion/react-sbb-polarion/style.css';
 import App from './App';
 import './App.css';
 

--- a/ui/src/pages/About.tsx
+++ b/ui/src/pages/About.tsx
@@ -1,4 +1,4 @@
-import { About } from '@grigoriev/react-sbb-polarion';
+import { About } from '@sbb-polarion/react-sbb-polarion';
 import appIcon from '../assets/app-icon.svg';
 import useRemote from '../services/useRemote';
 

--- a/ui/src/pages/Authorization.tsx
+++ b/ui/src/pages/Authorization.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { AuthorizationSettings, createAuthorizationService } from '@grigoriev/react-sbb-polarion';
+import { AuthorizationSettings, createAuthorizationService } from '@sbb-polarion/react-sbb-polarion';
 import useRemote from '../services/useRemote';
 
 /** The named-settings feature the export permissions are stored under. */

--- a/ui/src/pages/CoverPage.tsx
+++ b/ui/src/pages/CoverPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import { toast } from 'sonner';
 import CustomTemplatesPage from '../components/CustomTemplatesPage';
 import { getScope } from '../services/scope';

--- a/ui/src/pages/Css.tsx
+++ b/ui/src/pages/Css.tsx
@@ -8,7 +8,7 @@ import {
   RevisionsTable,
   Tabs,
   useConfirm,
-} from '@grigoriev/react-sbb-polarion';
+} from '@sbb-polarion/react-sbb-polarion';
 import { toast } from 'sonner';
 import { getScope } from '../services/scope';
 import useNamedSettings from '../services/settings';

--- a/ui/src/pages/Disclaimer.tsx
+++ b/ui/src/pages/Disclaimer.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useState } from 'react';
-import { PageLayout } from '@grigoriev/react-sbb-polarion';
+import { PageLayout } from '@sbb-polarion/react-sbb-polarion';
 import useRemote from '../services/useRemote';
 
 /** Where this extension's sources live; used when the build-generated article is missing. */

--- a/ui/src/pages/ExportPopupPreview.tsx
+++ b/ui/src/pages/ExportPopupPreview.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { PageLayout, SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { PageLayout, SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import DocumentPicker from '../components/DocumentPicker';
 import type { DocumentType, ExportType } from '../export/documentType';
 import { documentEditorHash } from '../services/documents';

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import { FEATURES } from '../features';
 import { getCookie, setCookie } from '../services/cookies';
 import { fetchProjects } from '../services/projects';

--- a/ui/src/pages/Localization.tsx
+++ b/ui/src/pages/Localization.tsx
@@ -6,7 +6,7 @@ import {
   PageLayout,
   RevisionsTable,
   useConfirm,
-} from '@grigoriev/react-sbb-polarion';
+} from '@sbb-polarion/react-sbb-polarion';
 import { toast } from 'sonner';
 import useLocalizationFiles, { type TranslationsMap, saveBlob } from '../services/localization';
 import { getScope } from '../services/scope';

--- a/ui/src/pages/SidePanelPreview.tsx
+++ b/ui/src/pages/SidePanelPreview.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { PageLayout } from '@grigoriev/react-sbb-polarion';
+import { PageLayout } from '@sbb-polarion/react-sbb-polarion';
 import DocumentPicker from '../components/DocumentPicker';
 import { documentEditorHash } from '../services/documents';
 import type { ProjectDocument } from '../services/documents';

--- a/ui/src/pages/StylePackageWeights.tsx
+++ b/ui/src/pages/StylePackageWeights.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { StylePackageWeights, createStylePackageWeightsService } from '@grigoriev/react-sbb-polarion';
+import { StylePackageWeights, createStylePackageWeightsService } from '@sbb-polarion/react-sbb-polarion';
 import useRemote from '../services/useRemote';
 
 /**

--- a/ui/src/pages/StylePackages.tsx
+++ b/ui/src/pages/StylePackages.tsx
@@ -9,7 +9,7 @@ import {
   type SelectOption,
   type SettingName,
   useConfirm,
-} from '@grigoriev/react-sbb-polarion';
+} from '@sbb-polarion/react-sbb-polarion';
 import { toast } from 'sonner';
 import { getScope } from '../services/scope';
 import useNamedSettings from '../services/settings';

--- a/ui/src/pages/UserGuide.tsx
+++ b/ui/src/pages/UserGuide.tsx
@@ -1,4 +1,4 @@
-import { UserGuide } from '@grigoriev/react-sbb-polarion';
+import { UserGuide } from '@sbb-polarion/react-sbb-polarion';
 import useRemote from '../services/useRemote';
 
 /**

--- a/ui/src/pages/Webhooks.tsx
+++ b/ui/src/pages/Webhooks.tsx
@@ -7,7 +7,7 @@ import {
   RevisionsTable,
   SearchableSelect,
   useConfirm,
-} from '@grigoriev/react-sbb-polarion';
+} from '@sbb-polarion/react-sbb-polarion';
 import { toast } from 'sonner';
 import { getScope } from '../services/scope';
 import useNamedSettings from '../services/settings';

--- a/ui/src/pages/WidgetPreview.tsx
+++ b/ui/src/pages/WidgetPreview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { PageLayout } from '@grigoriev/react-sbb-polarion';
+import { PageLayout } from '@sbb-polarion/react-sbb-polarion';
 import {
   SAMPLE_ITEMS,
   SAMPLE_ITEMS_EMPTY,

--- a/ui/src/popup/ExportPopupModal.tsx
+++ b/ui/src/popup/ExportPopupModal.tsx
@@ -1,6 +1,6 @@
 import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Modal, SearchableSelect } from '@grigoriev/react-sbb-polarion';
-import type { SelectOption } from '@grigoriev/react-sbb-polarion';
+import { Modal, SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
+import type { SelectOption } from '@sbb-polarion/react-sbb-polarion';
 import validateIcon from '../assets/validate.svg';
 import type { DocumentType, ExportFieldName, ExportType } from '../export/documentType';
 import {

--- a/ui/src/services/conversion.ts
+++ b/ui/src/services/conversion.ts
@@ -10,7 +10,7 @@
  * lets the three surfaces await an export instead of threading success and error callbacks. The requests,
  * the headers read off them and the messages built from those headers are unchanged.
  */
-import type { SendRequest } from '@grigoriev/react-sbb-polarion';
+import type { SendRequest } from '@sbb-polarion/react-sbb-polarion';
 
 /** The two request flavors a conversion needs: the REST base, and a URL the server handed out. */
 export interface Remote {

--- a/ui/src/services/settings.ts
+++ b/ui/src/services/settings.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import type { Revision, SettingName } from '@grigoriev/react-sbb-polarion';
+import type { Revision, SettingName } from '@sbb-polarion/react-sbb-polarion';
 import useRemote from './useRemote';
 
 /** Extracts a readable message from a failed response, the way the legacy ExtensionContext did. */

--- a/ui/src/services/shadowMount.ts
+++ b/ui/src/services/shadowMount.ts
@@ -1,4 +1,4 @@
-import styleText from '@grigoriev/react-sbb-polarion/style.css?inline';
+import styleText from '@sbb-polarion/react-sbb-polarion/style.css?inline';
 
 interface ShadowMountOptions {
   /** Classes for the inner container React mounts into (token scope + any wrapper classes the

--- a/ui/src/services/stylePackage.ts
+++ b/ui/src/services/stylePackage.ts
@@ -1,4 +1,4 @@
-import type { SelectOption } from '@grigoriev/react-sbb-polarion';
+import type { SelectOption } from '@sbb-polarion/react-sbb-polarion';
 
 /**
  * The style package: what one named `style-package` configuration holds, and the fixed option lists its

--- a/ui/src/sidepanel/SidePanel.tsx
+++ b/ui/src/sidepanel/SidePanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
-import type { SelectOption } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
+import type { SelectOption } from '@sbb-polarion/react-sbb-polarion';
 import validateIcon from '../assets/validate.svg';
 import type { PanelData } from '../export/exportData';
 import { loadPanelData, loadStylePackage } from '../export/exportData';

--- a/ui/src/widget/BulkExportProgressModal.tsx
+++ b/ui/src/widget/BulkExportProgressModal.tsx
@@ -1,4 +1,4 @@
-import { Modal } from '@grigoriev/react-sbb-polarion';
+import { Modal } from '@sbb-polarion/react-sbb-polarion';
 import type { BulkExportState } from './useBulkExport';
 import { itemName, itemTypeLabel } from './useBulkExport';
 

--- a/ui/src/widget/main.tsx
+++ b/ui/src/widget/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import rspStyles from '@grigoriev/react-sbb-polarion/style.css?inline';
+import rspStyles from '@sbb-polarion/react-sbb-polarion/style.css?inline';
 import popupStyles from '../popup/export-popup.css?inline';
 import BulkExportWidget from './BulkExportWidget';
 import type { WidgetDependencies } from './BulkExportWidget';

--- a/ui/test/exportData.test.ts
+++ b/ui/test/exportData.test.ts
@@ -1,4 +1,4 @@
-import type { SendRequest } from '@grigoriev/react-sbb-polarion';
+import type { SendRequest } from '@sbb-polarion/react-sbb-polarion';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { loadDocumentLanguage, loadPanelData, loadPopupData, loadStylePackage } from '../src/export/exportData';
 import type { PopupDataRequest } from '../src/export/exportData';

--- a/ui/test/exportPopupSamples.ts
+++ b/ui/test/exportPopupSamples.ts
@@ -1,4 +1,4 @@
-import type { SelectOption } from '@grigoriev/react-sbb-polarion';
+import type { SelectOption } from '@sbb-polarion/react-sbb-polarion';
 import type { PopupData } from '../src/export/exportData';
 import type { ExportPopupDependencies } from '../src/popup/ExportPopupModal';
 import type { ConversionResult } from '../src/services/conversion';

--- a/ui/test/setup.ts
+++ b/ui/test/setup.ts
@@ -9,6 +9,6 @@
 // The Polarion-served stylesheets linked in index.html (presentation.css, github-markdown-light.css)
 // are not bundled and are not loaded here; they are baseline chrome / help-article styling. Also
 // registers the jest-dom matchers.
-import '@grigoriev/react-sbb-polarion/style.css';
+import '@sbb-polarion/react-sbb-polarion/style.css';
 import '@testing-library/jest-dom/vitest';
 import '../src/App.css';

--- a/ui/test/sidePanelSamples.ts
+++ b/ui/test/sidePanelSamples.ts
@@ -1,4 +1,4 @@
-import type { SelectOption } from '@grigoriev/react-sbb-polarion';
+import type { SelectOption } from '@sbb-polarion/react-sbb-polarion';
 import type { PanelData } from '../src/export/exportData';
 import type { ConversionResult } from '../src/services/conversion';
 import type { DocumentIdentity } from '../src/services/exportContext';

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const polarionUrl = env.VITE_BASE_URL || 'http://localhost';
 
-  // Dedupe so the app and @grigoriev/react-sbb-polarion resolve to this app's single instance of
+  // Dedupe so the app and @sbb-polarion/react-sbb-polarion resolve to this app's single instance of
   // each: React (two copies mean "invalid hook call") and sonner (the RSP `Toaster` host and the
   // toasts RSP components fire must share one instance, or the toasts never reach the host).
   const resolve = { dedupe: ['react', 'react-dom', 'sonner'] };

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -58,7 +58,7 @@ export default defineConfig({
       'react/jsx-dev-runtime',
       'vitest-browser-react',
       'sonner',
-      '@grigoriev/react-sbb-polarion',
+      '@sbb-polarion/react-sbb-polarion',
     ],
   },
   test: {


### PR DESCRIPTION
The shared React library moved from a personal npm scope to the SBB organization and released 1.0.0:
`@grigoriev/react-sbb-polarion` is now
[`@sbb-polarion/react-sbb-polarion`](https://www.npmjs.com/package/@sbb-polarion/react-sbb-polarion).

Only the package name changes. 1.0.0 is 0.2.1 with a different name - the major is there because the
rename itself is the breaking change, not because the API moved. So this is the dependency, its version
range and every import, nothing else.

The stale `github.com/grigoriev/react-sbb-polarion` links follow the repository to
`SchweizerischeBundesbahnen`. `io.github.grigoriev` in `pom.xml` and `grigoriev/pre-commit-*` in
`.pre-commit-config.yaml` are unrelated projects and are left alone.
