### PR TITLE
fix: hold tika-core on 3.x to keep Polarion startable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 ## Gotchas
 
+- **A dependency can block Polarion startup through its manifest alone.** Polarion 2606 scans every
+  nested jar and rejects both a class that references a forbidden package and a `META-INF/MANIFEST.MF`
+  whose attribute value *contains* one, so an OSGi `uses:="javax.annotation.processing,..."` counts as
+  `javax.annotation` and the whole extension is reported as "not Jakarta compatible" - no CI job sees
+  this, only a local deploy.
+  That is why `tika.version` stays on 3.x (`renovate.json` holds it there); tika-core 4.0.0 trips it.
+  Check a bump with a real deploy, or `unzip -p <nested>.jar META-INF/MANIFEST.MF | grep javax`.
 - **`ch.sbb.polarion.extension.generic`** is the parent project providing reusable infrastructure for all Polarion plugins in this org (settings framework, REST base classes, OSGi helpers, etc.). Before implementing anything cross-cutting, check if it already exists there.
 - **All administration pages are React now.** They were converted to
   [react-sbb-polarion](https://github.com/SchweizerischeBundesbahnen/react-sbb-polarion) one at a time, and

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,14 @@
         <testcontainers.version>2.0.5</testcontainers.version>
 
         <awaitility.version>4.3.0</awaitility.version>
-        <tika.version>4.0.0</tika.version>
+        <!-- Hold at 3.x: tika-core 4.0.0 ships the compile-time processor
+             org/apache/tika/annotation/TikaComponentProcessor.class and an OSGi manifest exporting
+             org.apache.tika.annotation with uses:="javax.annotation.processing,...". Polarion 2606's
+             JakartaCompatibilityChecker rejects both a class referencing and a manifest value
+             containing a forbidden package prefix, and "javax.annotation.processing" contains
+             "javax.annotation" - so the extension jar counts as one incompatible file and Polarion
+             refuses to start. See renovate.json. -->
+        <tika.version>3.3.2</tika.version>
         <ph-css.version>8.2.1</ph-css.version>
         <commons-text.version>1.15.0</commons-text.version>
         <verapdf.version>1.30.2</verapdf.version>

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SchweizerischeBundesbahnen/casc-renovate-preset-polarion-java"
+  ],
+  "packageRules": [
+    {
+      "description": "tika-core stays on 3.x. Its 4.0.0 jar carries the compile-time TikaComponentProcessor class and an OSGi manifest with uses:=\"javax.annotation.processing,...\", and Polarion 2606's JakartaCompatibilityChecker rejects a class reference or a manifest value that merely contains a forbidden package prefix - javax.annotation.processing contains javax.annotation. The extension then counts as one incompatible file and Polarion refuses to start, which no CI job can see.",
+      "matchPackageNames": ["org.apache.tika:tika-core"],
+      "allowedVersions": "<4"
+    }
   ]
 }


### PR DESCRIPTION
### Proposed changes

`tika-core` 4.0.0 makes the extension undeployable on Polarion 2606: the platform refuses to start with

```
Extension: ch.sbb.polarion.extension.pdf-exporter (1 incompatible files)
```

`JakartaCompatibilityChecker` flags a nested jar on two independent rules, and 4.0.0 trips both:

- `org/apache/tika/annotation/TikaComponentProcessor.class` references `javax.annotation.processing`;
- the OSGi manifest exports `org.apache.tika.annotation` with `uses:="javax.annotation.processing,..."`
  and imports the same package.

The match is `contains`, so `javax.annotation.processing` counts as the forbidden `javax.annotation` -
even though it is JDK compiler API (`java.compiler`), not Jakarta EE. There is no jakarta-flavoured
tika-core and there never will be for these packages; 3.3.2's manifest carries only
`javax.crypto` / `javax.xml.*`, none of which is on the forbidden list.

So the version goes back to 3.3.2 and a renovate rule holds it there. `Tika.detect` - the only API this
extension uses - is unchanged between the two.

Verified on a local Polarion 2606: with 4.0.0 startup is blocked; removing only the class or only the
manifest entry still blocks; with 3.3.2 (and with a hand-patched 4.0.0 missing both) Polarion starts.
No CI job can see this, which is why the trap is written down in `CLAUDE.md`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation

### Tests

`mvn clean install -P install-to-local-polarion` green, then deployed into the local Polarion 2606
container: `Polarion started`, no extension errors in `log4j-errors`.
