### PR TITLE
chore: opt into the polarion compatibility check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@
   the three injector scripts, the empty `css/starter.css` trigger and the three HTML templates the Java
   renderer reads server-side (`sidePanelContent.html`, `pdfTemplate.html`, `headerAndFooter.html`).
 - **The UI build comes from the generic parent**, activated by the presence of `ui/package.json` (its
-  `vite-ui` profile): `npm ci` + `npm run build`, the bundle copied into `webapp/pdf-exporter-app/`, and
+  `ui-build-react-app` profile): `npm ci` + `npm run build`, the bundle copied into `webapp/pdf-exporter-app/`, and
   the JS suite in the Maven `test` phase. This pom adds nothing for it beyond pinning
   `frontend-maven-plugin.version`, which the parent's profile reads. Note it also redirects
   markdown2html's output (`about.html`, `user-guide.html`, `disclaimer.html`) into
@@ -78,7 +78,7 @@
 - **Package naming**: Use `ch.sbb.polarion.extension.pdf_exporter` (underscore). Pre-v7.0.0 code used `pdf.exporter` (dot) — don't follow old patterns still present in the codebase.
 - **Maven Settings**: Builds require `.mvn/settings.xml` (JFrog, GitHub Packages, Sonatype credentials via env vars). CI passes it with `-s .mvn/settings.xml`.
 - **Polarion Dependencies**: You must extract dependencies from the Polarion installer using [polarion-artifacts-deployer](https://github.com/SchweizerischeBundesbahnen/polarion-artifacts-deployer) before the Maven build will work.
-- **Local Polarion Installation**: Requires `POLARION_HOME` environment variable. Use the `install-to-local-polarion` Maven profile: `mvn clean install -P install-to-local-polarion`
+- **Local Polarion Installation**: Requires `POLARION_HOME` environment variable. Use the `local-install-into-polarion` Maven profile: `mvn clean install -P local-install-into-polarion`
 - **After any code change**: Delete `<POLARION_HOME>/data/workspace/.config` before restarting Polarion or changes won't be picked up.
 - **Remote Debugging**: Add to Polarion's `config.sh`: `JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"`
 - **Logging**: Polarion logs: `<POLARION_HOME>/polarion/logs/main/*.log`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,11 @@
 - **A dependency can block Polarion startup through its manifest alone.** Polarion 2606 scans every
   nested jar and rejects both a class that references a forbidden package and a `META-INF/MANIFEST.MF`
   whose attribute value *contains* one, so an OSGi `uses:="javax.annotation.processing,..."` counts as
-  `javax.annotation` and the whole extension is reported as "not Jakarta compatible" - no CI job sees
-  this, only a local deploy.
-  That is why `tika.version` stays on 3.x (`renovate.json` holds it there); tika-core 4.0.0 trips it.
-  Check a bump with a real deploy, or `unzip -p <nested>.jar META-INF/MANIFEST.MF | grep javax`.
+  `javax.annotation` and the whole extension is reported as "not Jakarta compatible".
+  `polarion-compatibility-maven-plugin` fails the build on this at `verify`, so a green build means a
+  server which boots. That is why `tika.version` stays on 3.x (`renovate.json` holds it there);
+  tika-core 4.0.0 trips it. Keep the pin: the check turns a startup refusal into a red build, it does
+  not make tika 4 usable.
 - **`ch.sbb.polarion.extension.generic`** is the parent project providing reusable infrastructure for all Polarion plugins in this org (settings framework, REST base classes, OSGi helpers, etc.). Before implementing anything cross-cutting, check if it already exists there.
 - **All administration pages are React now.** They were converted to
   [react-sbb-polarion](https://github.com/SchweizerischeBundesbahnen/react-sbb-polarion) one at a time, and

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,7 +79,7 @@ mvn clean package
 ### Install to Local Polarion
 
 ```bash
-mvn clean install -P install-to-local-polarion
+mvn clean install -P local-install-into-polarion
 ```
 
 Note: This requires `POLARION_HOME` environment variable to be set correctly.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install the extension to Polarion `ch.sbb.polarion.extension.pdf-exporter-<ve
 should be copied to `<polarion_home>/polarion/extensions/ch.sbb.polarion.extension.pdf-exporter/eclipse/plugins`
 It can be done manually or automated using maven build:
 ```bash
-mvn clean install -P install-to-local-polarion
+mvn clean install -P local-install-into-polarion
 ```
 For automated installation with maven env variable `POLARION_HOME` should be defined and point to folder where Polarion is installed.
 

--- a/pom.xml
+++ b/pom.xml
@@ -407,6 +407,12 @@
                 <groupId>io.github.grigoriev</groupId>
                 <artifactId>pre-commit-run-maven-plugin</artifactId>
             </plugin>
+            <!-- Opts in to the compatibility check the generic parent pom declares. -->
+            <plugin>
+                <groupId>com.intechcore</groupId>
+                <artifactId>polarion-compatibility-maven-plugin</artifactId>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "packageRules": [
     {
-      "description": "tika-core stays on 3.x. Its 4.0.0 jar carries the compile-time TikaComponentProcessor class and an OSGi manifest with uses:=\"javax.annotation.processing,...\", and Polarion 2606's JakartaCompatibilityChecker rejects a class reference or a manifest value that merely contains a forbidden package prefix - javax.annotation.processing contains javax.annotation. The extension then counts as one incompatible file and Polarion refuses to start, which no CI job can see.",
+      "description": "tika-core stays on 3.x. Its 4.0.0 jar carries the compile-time TikaComponentProcessor class and an OSGi manifest with uses:=\"javax.annotation.processing,...\", and Polarion 2606's JakartaCompatibilityChecker rejects a class reference or a manifest value that merely contains a forbidden package prefix - javax.annotation.processing contains javax.annotation. The extension then counts as one incompatible file and Polarion refuses to start. polarion-compatibility-maven-plugin fails the build on it, so this pin is what keeps a tika-4 bump from becoming a red build.",
       "matchPackageNames": ["org.apache.tika:tika-core"],
       "allowedVersions": "<4"
     }

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/GeneratedHelpArticlesTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/GeneratedHelpArticlesTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * <p>
  * The three of them are written by markdown2html into the directory
  * {@code markdown2html-maven-plugin.extensionContextAdminHtml} points at - a property whose name
- * predates the React apps: as soon as {@code ui/} exists, the generic parent's {@code vite-ui} profile
+ * predates the React apps: as soon as {@code ui/} exists, the generic parent's {@code ui-build-react-app} profile
  * redefines it to the <em>app</em> webapp. Two things then depend on that, silently:
  * <ul>
  *   <li>generic's {@code /readme}, {@code /user-guide} and {@code /disclaimer} endpoints read their

--- a/ui/README.md
+++ b/ui/README.md
@@ -378,7 +378,7 @@ the same command.
 ## Production build
 
 `npm run build` emits all four entries to `ui/dist/app` with base path
-`/polarion/pdf-exporter-app/ui/app/`. The Maven build (the parent's `vite-ui` profile:
+`/polarion/pdf-exporter-app/ui/app/`. The Maven build (the parent's `ui-build-react-app` profile:
 frontend-maven-plugin + maven-resources-plugin) runs this automatically and copies the bundle into
 `src/main/resources/webapp/pdf-exporter-app/app`, where `PdfExporterAppServlet` serves it at
 `/polarion/pdf-exporter-app/ui/app/index.html`.

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -74,7 +74,7 @@ export default defineConfig(({ command, mode }) => {
     // Never let a developer's personal access token reach a shipped bundle. VITE_BEARER_TOKEN is a
     // `vite dev` convenience (it switches useRemote to the token-authenticated /api endpoints); Vite
     // inlines import.meta.env.VITE_* at build time, so a local .env.local would otherwise be baked
-    // into the bundle that `mvn -P install-to-local-polarion` deploys, readable by everyone the SPA is
+    // into the bundle that `mvn -P local-install-into-polarion` deploys, readable by everyone the SPA is
     // served to. Forcing it undefined here keeps production on the session-authenticated /internal
     // endpoints, which is what Polarion provides anyway.
     define: { 'import.meta.env.VITE_BEARER_TOKEN': 'undefined' },


### PR DESCRIPTION
Declares `com.intechcore:polarion-compatibility-maven-plugin`, which the `generic` parent pom manages in `pluginManagement`.

The goal binds to `verify`. It scans the assembled bundle and every jar nested inside it, and fails the build when a class, an OSGi manifest header or a deployment descriptor names a `javax` package Polarion 2606 rejects.

Extension sources are safe already, because they compile against the Jakarta API. Bundled dependencies are not: a dependency bump can reintroduce such a package with no source change, and the failure then surfaces on the server after deployment.


## Verification

Clean local build, `mvn clean install -P local-install-into-polarion -DskipJsTests`:

```
Scanned ch.sbb.polarion.extension.pdf-exporter-13.7.1-SNAPSHOT.jar: 12830 classes in 57 nested jar(s), 1971 ms
No forbidden packages found
```

Surefire was skipped for that local run. `ExternalCssInternalizerTest` has two errors on Windows (`NTFS ADS separator (':') in file name is forbidden`) which also occur on unmodified `main`, so they are unrelated to this change. CI runs the suite on Linux.

## Profile names

A second commit follows the profile renames that generic 16.1.0 carried in `refactor: rename maven profiles to one naming scheme` (`1e2972d`): `install-to-local-polarion` becomes `local-install-into-polarion`, and `vite-ui` becomes `ui-build-react-app`.

Maven only warns on an unknown `-P`, so the command this repository documented produced a green build that never installed into `$POLARION_HOME`. Touched here: `CLAUDE.md DEVELOPMENT.md README.md src/test/java/ch/sbb/polarion/extension/pdf_exporter/GeneratedHelpArticlesTest.java ui/README.md ui/vite.config.js `. Documentation, prose and comments only, no profile is defined locally under either id.

Refs: SchweizerischeBundesbahnen/ch.sbb.polarion.extension.generic/issues/689
