### PR TITLE
fix: read a url extension without a file name utility

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
+++ b/src/main/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtils.java
@@ -41,7 +41,6 @@ import com.polarion.subterra.base.location.ILocation;
 import com.polarion.subterra.base.location.Location;
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.io.RandomAccessReadBuffer;
@@ -939,15 +938,29 @@ public class MediaUtils {
     /**
      * Extracts the lowercase file extension from a URL, ignoring any query string or fragment.
      * Returns an empty string when the URL has no extension.
+     * <p>
+     * The extension is read here rather than by {@code FilenameUtils.getExtension}. That method reads
+     * the string as a path of the host: on Windows it refuses a ':' standing after the last separator,
+     * which names an NTFS alternate data stream there and means nothing in a url. A url may carry one
+     * wherever it likes, and the refusal aborts the export instead of judging that url.
+     * </p>
+     * <p>
+     * Reported upstream as <a href="https://issues.apache.org/jira/browse/IO-783">IO-783</a>, which is
+     * open, and commons-io 2.22.0 still throws. Once it is fixed this method may go back to the
+     * utility: it counts the same separators and returns the same extension.
+     * </p>
      */
     @VisibleForTesting
     static String getResourceExtension(@Nullable String url) {
         if (url == null) {
             return "";
         }
-        // strip the query string and fragment, then let Commons IO extract the extension
+        // strip the query string and fragment, then read the extension of the last segment. Both slashes
+        // separate one, the way a file name utility counts them on every platform
         String path = url.split("[?#]", 2)[0];
-        return FilenameUtils.getExtension(path).toLowerCase(Locale.ROOT);
+        int lastSeparator = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+        int lastDot = path.lastIndexOf('.');
+        return lastDot > lastSeparator ? path.substring(lastDot + 1).toLowerCase(Locale.ROOT) : "";
     }
 
     /**

--- a/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/pdf_exporter/util/MediaUtilsTest.java
@@ -228,6 +228,18 @@ class MediaUtilsTest {
         assertEquals("", MediaUtils.getResourceExtension("/path/file."));
         assertEquals("", MediaUtils.getResourceExtension(null));
         assertEquals("", MediaUtils.getResourceExtension(""));
+        // A colon may stand after the last separator of a url. A file name utility reads that as an NTFS
+        // alternate data stream and refuses it on Windows, which would abort the export on that host.
+        // What such a segment names is no renderable extension, and that is all the callers ask
+        assertEquals("png:2", MediaUtils.getResourceExtension("/path/file.png:2"));
+        assertEquals("png) } c { color: red",
+                MediaUtils.getResourceExtension("/path/x.png) } b { url(http://host/y.png) } c { color: red"));
+        assertEquals("", MediaUtils.getResourceExtension("http://localhost:8080/imgs"));
+        assertEquals("png", MediaUtils.getResourceExtension("http://localhost:8080/img.png"));
+        // both slashes separate a segment, so a dot before either of them names no extension
+        assertEquals("", MediaUtils.getResourceExtension("/path.d/file"));
+        assertEquals("", MediaUtils.getResourceExtension("C:\\path.d\\file"));
+        assertEquals("png", MediaUtils.getResourceExtension("C:\\path\\img.PNG"));
     }
 
     private void fillImageWithColor(BufferedImage image, Color color) {


### PR DESCRIPTION
## What

`MediaUtils.getResourceExtension` no longer calls `FilenameUtils.getExtension`. It reads the extension of the last URL segment directly.

## Why

`FilenameUtils` reads its argument as a path of the host. On Windows it refuses a `:` standing after the last separator, because there it names an NTFS alternate data stream:

```
java.lang.IllegalArgumentException: NTFS ADS separator (':') in file name is forbidden.
	at org.apache.commons.io.FilenameUtils.indexOfExtension(FilenameUtils.java:975)
	at ...MediaUtils.getResourceExtension(MediaUtils.java:950)
	at ...MediaUtils.isRenderableImageUrl(MediaUtils.java:936)
	at ...MediaUtils.replacementFor(MediaUtils.java:379)
	at ...MediaUtils.inlineCssResources(MediaUtils.java:428)
	at ...ExternalCssInternalizer.inline(ExternalCssInternalizer.java:53)
```

A colon in a URL is legal and says nothing about NTFS. `isRenderableImageUrl` does not catch the throw, so it escaped through `inlineCssResources` and aborted the whole export instead of judging that one URL.

Upstream ticket [IO-783](https://issues.apache.org/jira/browse/IO-783) is open and unresolved, and commons-io 2.22.0, the version this project resolves, still throws. Waiting for it is not the fix: a URL is not a host path, so the utility is the wrong tool either way. The javadoc carries the link so the choice can be revisited.

## Behavior

Unchanged on Linux. `FilenameUtils.indexOfLastSeparator` counts both `/` and `\` on every platform, and the replacement counts the same two, so it returns the same extension for every input that did not throw.

A URL whose last segment carries a colon now yields an extension that is simply not a renderable one, which is all the two callers (`isRenderableImageUrl` and `getMimeTypeUsingCustomMap`) ask of it.

## Tests

Two existing tests covered exactly such a URL and errored on Windows, while passing on Linux where the guard never runs:

- `ExternalCssInternalizerTest.shouldKeepAResolvedUrlInsideItsTerm`
- `ExternalCssInternalizerTest.shouldEscapeAResolvedUrlWhichStaysInTheStylesheet`

Both pass now. `MediaUtilsTest.getResourceExtensionTest` gains the ADS-shaped input, the CSS value from those two tests, a colon in an authority, and backslash-separator cases that pin the cross-platform behavior.

Full suite on Windows: `Tests run: 1201, Failures: 0, Errors: 0, Skipped: 44`.

Refs: #1039
